### PR TITLE
Fix serialization for redis >=5.X

### DIFF
--- a/lib/familia/redisobject.rb
+++ b/lib/familia/redisobject.rb
@@ -258,6 +258,10 @@ module Familia
     end
 
     def to_redis v
+      if v.class == TrueClass || v.class == FalseClass || v.class == NilClass
+        return v.send Familia.dump_method
+      end
+
       return v unless @opts[:class]
       ret = case @opts[:class]
       when ::Symbol, ::String, ::Integer, ::Float, Gibbler::Digest

--- a/try/26_redis_bool_try.rb
+++ b/try/26_redis_bool_try.rb
@@ -1,0 +1,23 @@
+require 'familia'
+require 'familia/test_helpers'
+
+
+@hashkey = Familia::HashKey.new 'key'
+
+@hashkey["test"]="true"
+#=> "true"
+
+@hashkey["test"]
+#=> "true"
+
+@hashkey["test"]=true
+#=> true
+
+@hashkey["test"]
+#=> "true"
+
+@hashkey["test"]=nil
+#=> nil
+
+@hashkey["test"]
+#=> "null"


### PR DESCRIPTION
Related to onetimesecret/onetimesecret#238

I chose this over `return MultiJson.encode(v)` , let me know if you prefer one

Add a test to ensure it's not crashing after the patch