### PR TITLE
Raise an exception for boolean and nil values

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -68,4 +68,4 @@ jobs:
       run: bundle install
 
     - name: Run the tryouts
-      run: bundle exec try -v
+      run: bundle exec try -v try/*_try.rb

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -7,6 +7,8 @@ on:
 
   pull_request:
 
+  workflow_dispatch:
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -49,7 +49,7 @@ jobs:
           - 6379:6379
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Familia - 0.10.0
+# Familia - 0.10.1
 
 **Organize and store ruby objects in Redis. A Ruby ORM for Redis.**
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,14 @@
-# Familia - 0.9 (2024-04-04)
+# Familia - 0.10.0
 
-**Organize and store ruby objects in Redis**
+**Organize and store ruby objects in Redis. A Ruby ORM for Redis.**
 
+## Installation
+
+Get it in one of the following ways:
+
+* In your Gemfile: `gem 'familia', '>= 0.10.0'`
+* Install it by hand: `gem install familia`
+* Or for development: `git clone git@github.com:delano/familia.git`
 
 ## Basic Example
 
@@ -21,4 +28,5 @@
 
 ## More Information
 
-* [Codes](https://github.com/delano/familia)
+* [Github](https://github.com/delano/familia)
+* [Rubygems](https://rubygems.org/gems/familia)

--- a/VERSION.yml
+++ b/VERSION.yml
@@ -1,4 +1,4 @@
 ---
 :MAJOR: 0
 :MINOR: 10
-:PATCH: 0
+:PATCH: 1

--- a/familia.gemspec
+++ b/familia.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = "familia"
-  s.version     = "0.10.0"
+  s.version     = "0.10.1"
   s.summary     = "Organize and store ruby objects in Redis"
   s.description = "Familia: #{s.summary}"
   s.authors     = ["Delano Mandelbaum"]

--- a/lib/familia.rb
+++ b/lib/familia.rb
@@ -32,6 +32,7 @@ module Familia
   @debug = false
   @dump_method = :to_json
   @load_method = :from_json
+
   class << self
     attr_reader :clients, :uri, :logger
     attr_accessor :debug, :secret, :delim, :dump_method, :load_method
@@ -50,7 +51,7 @@ module Familia
     end
     def trace label, redis_instance, ident, context=nil
       return unless Familia.debug?
-      info "[%s] %s/%s" % [label, redis_instance.id, ident]
+      info "[%s] %s %s" % [label, redis_instance.id, ident]
       if context
         context = [context].flatten
         context.reject! { |line| line =~ /lib\/familia/ }
@@ -89,7 +90,7 @@ module Familia
       uri ||= Familia.uri
       conf = uri.conf
       redis = Redis.new conf
-      Familia.trace :CONNECT, redis, conf.inspect, caller[0..3] if Familia.debug
+      Familia.trace(:CONNECT, redis, conf.inspect, caller[0..3])
       @clients[uri.serverid] = redis
     end
     def reconnect_all!

--- a/lib/familia.rb
+++ b/lib/familia.rb
@@ -36,6 +36,8 @@ module Familia
     attr_reader :clients, :uri, :logger
     attr_accessor :debug, :secret, :delim, :dump_method, :load_method
     attr_writer :apiversion
+
+    alias_method :url, :uri
     def debug?() @debug == true end
     def info *msg
       STDERR.puts *msg

--- a/lib/familia/redisobject.rb
+++ b/lib/familia/redisobject.rb
@@ -818,6 +818,11 @@ module Familia
       ret = redis.hset rediskey, n, to_redis(v)
       update_expiration
       ret
+    rescue TypeError => e
+      echo :hset, caller[0] if Familia.debug
+      klass = v.class
+      msg = "Cannot store #{n} => #{v.inspect} (#{klass}) in #{rediskey}"
+      raise e.class, msg
     end
     alias_method :put, :[]=
     alias_method :store, :[]=

--- a/lib/familia/redisobject.rb
+++ b/lib/familia/redisobject.rb
@@ -46,7 +46,7 @@ module Familia
       end
     end
 
-    attr_reader :name, :parent, :opts
+    attr_reader :name, :parent
     attr_writer :redis
 
       # RedisObject instances are frozen. `cache` is a hash

--- a/try/00_familia.rb
+++ b/try/00_familia.rb
@@ -1,8 +1,0 @@
-require 'familia'
-require 'familia/test_helpers'
-Familia.apiversion = 'v1'
-
-
-## .
-Bone.redis_objects
-#=> true

--- a/try/00_familia_try.rb
+++ b/try/00_familia_try.rb
@@ -1,0 +1,21 @@
+require 'familia'
+require 'familia/test_helpers'
+
+Familia.apiversion = 'v1'
+
+
+## Check for help class
+Bone.redis_objects.keys # consistent b/c hashes are ordered
+#=> [:owners, :tags, :metrics, :props, :value]
+
+## Familia has a uri
+Familia.uri.class
+#=> URI::Redis
+
+## Familia has a uri as a string
+Familia.uri.to_s
+#=> 'redis://127.0.0.1'
+
+## Familia has a url, an alias to uri
+Familia.url.eql?(Familia.uri)
+#=> true

--- a/try/20_redis_object_try.rb
+++ b/try/20_redis_object_try.rb
@@ -7,13 +7,12 @@ Familia.apiversion = 'v1'
 ## Redis Objects are unique per instance of a Familia class
 @a = Bone.new 'atoken', :name1
 @b = Bone.new 'atoken', :name2
-@a.owners.rediskey == @b.owners.rediskey
+@a.owners.rediskey.eql?(@b.owners.rediskey)
 #=> false
 
-## Redis Objects are frozen 
+## Redis Objects are frozen
 @a.owners.frozen?
 #=> true
-
 
 ## Limiter#qstamp
 @limiter = Limiter.new :requests

--- a/try/26_redis_bool_try.rb
+++ b/try/26_redis_bool_try.rb
@@ -1,0 +1,39 @@
+require 'familia'
+require 'familia/test_helpers'
+
+Familia.debug = true
+
+@hashkey = Familia::HashKey.new 'key'
+
+
+## Boolean values are returned as strings, on assignment as string
+@hashkey["test"] = "true"
+#=> "true"
+
+## Boolean values are returned as strings
+@hashkey["test"]
+#=> "true"
+
+## Trying to store a boolean value to a hash key raises an exception
+begin
+  @hashkey["test"] = true
+rescue TypeError => e
+  e.message
+end
+#=> "Cannot store test => true (TrueClass) in key"
+
+## Boolean values are returned as strings
+@hashkey["test"]
+#=> "true"
+
+## Trying to store a nil value to a hash key raises an exception
+begin
+  @hashkey["test"] = nil
+rescue TypeError => e
+  e.message
+end
+#=> "Cannot store test => nil (NilClass) in key"
+
+## The exceptions prevented the hash from being updated
+@hashkey["test"]
+#=> "true"


### PR DESCRIPTION
Paired w/ @sebastien-coavoux
See #5 and discussion on onetimesecret/onetimesecret#238.

Familia now raises an exception when setting a hash key with a boolean or nil value. 

HashKey objects are stored as hashes in redis. When setting a hash key,
we choose to raise an exception if the value is a boolean or nil.

e.g. `hashkey["test"] = true`

This is a conservative approach to avoid unexpected behavior when
reading the value back. Unlike object serialization with JSON or YAML,
redis hash key values are always strings. Without a more nuanced way to
configure types, there's no way for Famila to tell the difference
between "true" as in true and "true" as in the literal string "true". We
may revisit in future versions.@sebastien-coavoux