### PR TITLE
Fix for TypeError: Unsupported command argument type: NilClass

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,14 +1,8 @@
 source 'https://rubygems.org'
 
-ruby '>= 2.7.8'
-
-gem 'redis', '>= 4.8.1', '< 6.0'
-gem 'uri-redis', '>= 1.3.0'
-gem 'gibbler', '~> 1.0.0'
-gem 'storable', '~> 0.10.0'
-gem 'multi_json', '~> 1.15'
+gemspec
 
 group :development, :test do
   gem 'pry-byebug', '~> 3.10.1', require: false
-  gem 'tryouts', '~> 2.2', require: false
+  gem 'tryouts', '~> 2.3', require: false
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,13 @@
+PATH
+  remote: .
+  specs:
+    familia (0.10.1)
+      gibbler (~> 1.0.0)
+      multi_json (~> 1.15)
+      redis (>= 4.8.1, < 6.0)
+      storable (~> 0.10.0)
+      uri-redis (>= 1.3.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -6,7 +16,6 @@ GEM
     byebug (11.1.3)
     coderay (1.1.3)
     connection_pool (2.4.1)
-    drydock (0.6.9)
     gibbler (1.0.0)
       attic (~> 1.0)
       rake (~> 13.0)
@@ -24,28 +33,18 @@ GEM
     redis-client (0.22.2)
       connection_pool
     storable (0.10.0)
-    sysinfo (0.10.0)
-      drydock (< 1.0)
-      storable (~> 0.10)
-    tryouts (2.2.0)
-      sysinfo (~> 0.10)
+    tryouts (2.3.1)
     uri-redis (1.3.0)
 
 PLATFORMS
+  arm64-darwin-23
   arm64-darwin-24
   ruby
 
 DEPENDENCIES
-  gibbler (~> 1.0.0)
-  multi_json (~> 1.15)
+  familia!
   pry-byebug (~> 3.10.1)
-  redis (>= 4.8.1, < 6.0)
-  storable (~> 0.10.0)
-  tryouts (~> 2.2)
-  uri-redis (>= 1.3.0)
-
-RUBY VERSION
-   ruby 3.2.4p170
+  tryouts (~> 2.3)
 
 BUNDLED WITH
-   2.5.9
+   2.5.14

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    familia (0.10.1)
+    familia (0.10.2)
       gibbler (~> 1.0.0)
       multi_json (~> 1.15)
       redis (>= 4.8.1, < 6.0)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Familia - 0.10.1
+# Familia - 0.10.2
 
 **Organize and store ruby objects in Redis. A Ruby ORM for Redis.**
 
@@ -6,7 +6,7 @@
 
 Get it in one of the following ways:
 
-* In your Gemfile: `gem 'familia', '>= 0.10.0'`
+* In your Gemfile: `gem 'familia', '>= 0.10.2'`
 * Install it by hand: `gem install familia`
 * Or for development: `git clone git@github.com:delano/familia.git`
 

--- a/VERSION.yml
+++ b/VERSION.yml
@@ -1,4 +1,4 @@
 ---
 :MAJOR: 0
 :MINOR: 10
-:PATCH: 1
+:PATCH: 2

--- a/familia.gemspec
+++ b/familia.gemspec
@@ -1,8 +1,8 @@
 Gem::Specification.new do |spec|
   spec.name        = "familia"
-  spec.version     = "0.10.1"
-  spec.summary     = "Organize and store ruby objects in Redis"
-  spec.description = "Familia: #{spec.summary}"
+  spec.version     = "0.10.2"
+  spec.summary     = "An ORM for Redis in Ruby."
+  spec.description = "Familia: #{spec.summary}. Organize and store ruby objects in Redis"
   spec.authors     = ["Delano Mandelbaum"]
   spec.email       = "gems@solutious.com"
   spec.homepage    = "https://github.com/delano/familia"

--- a/familia.gemspec
+++ b/familia.gemspec
@@ -1,17 +1,23 @@
-Gem::Specification.new do |s|
-  s.name        = "familia"
-  s.version     = "0.10.1"
-  s.summary     = "Organize and store ruby objects in Redis"
-  s.description = "Familia: #{s.summary}"
-  s.authors     = ["Delano Mandelbaum"]
-  s.email       = "gems@solutious.com"
-  s.homepage    = "https://github.com/delano/familia"
-  s.license     = "MIT"
+Gem::Specification.new do |spec|
+  spec.name        = "familia"
+  spec.version     = "0.10.1"
+  spec.summary     = "Organize and store ruby objects in Redis"
+  spec.description = "Familia: #{spec.summary}"
+  spec.authors     = ["Delano Mandelbaum"]
+  spec.email       = "gems@solutious.com"
+  spec.homepage    = "https://github.com/delano/familia"
+  spec.license     = "MIT"
 
-  s.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
-  s.bindir        = "exe"
-  s.executables   = s.files.grep(%r{^exe/}) { |f| File.basename(f) }
-  s.require_paths = ["lib"]
+  spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
+  spec.bindir        = "exe"
+  spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
+  spec.require_paths = ["lib"]
 
-  s.required_ruby_version = Gem::Requirement.new(">= 2.7.8")
+  spec.required_ruby_version = Gem::Requirement.new(">= 2.7.8")
+
+  spec.add_dependency 'redis', '>= 4.8.1', '< 6.0'
+  spec.add_dependency 'uri-redis', '>= 1.3.0'
+  spec.add_dependency 'gibbler', '~> 1.0.0'
+  spec.add_dependency 'storable', '~> 0.10.0'
+  spec.add_dependency 'multi_json', '~> 1.15'
 end

--- a/lib/familia.rb
+++ b/lib/familia.rb
@@ -51,12 +51,12 @@ module Familia
     end
     def trace label, redis_instance, ident, context=nil
       return unless Familia.debug?
-      info "[%s] %s %s" % [label, redis_instance.id, ident]
-      if context
+      codeline = if context
         context = [context].flatten
         context.reject! { |line| line =~ /lib\/familia/ }
-        info "   %s" % context[0..6].join("\n   ")
+        context.first
       end
+      info "[%s] -> %s <- %s %s" % [label, codeline, redis_instance.id, ident]
     end
     def uri= v
       v = URI.parse v unless URI === v

--- a/lib/familia/redisobject.rb
+++ b/lib/familia/redisobject.rb
@@ -262,6 +262,8 @@ module Familia
       ret = case @opts[:class]
       when ::Symbol, ::String, ::Integer, ::Float, Gibbler::Digest
         v
+      when ::NilClass
+        ""
       else
         if ::String === v
           v

--- a/try/20_redis_object_try.rb
+++ b/try/20_redis_object_try.rb
@@ -30,13 +30,13 @@ Familia.apiversion = 'v1'
 
 ## Check ttl
 @limiter.counter.ttl
-#=> 3600
+#=> 3600.0
 
 ## Check ttl for a different instance
 ## (this exists to make sure options are cloned for each instance)
 @limiter2 = Limiter.new :requests
 @limiter2.counter.ttl
-#=> 3600
+#=> 3600.0
 
 ## Check realttl
 sleep 1

--- a/try/21_redis_object_zset_try.rb
+++ b/try/21_redis_object_zset_try.rb
@@ -47,7 +47,7 @@ require 'familia/test_helpers'
 
 ## Familia::SortedSet#score
 @a.metrics.score 'metric4'
-#=> 54
+#=> 54.0
 
 ## Familia::SortedSet#remrangebyscore
 @a.metrics.remrangebyscore 3, 100


### PR DESCRIPTION
### **User description**
Fixes #8 and https://github.com/onetimesecret/onetimesecret/issues/441


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Updated gemspec to version 0.10.2 and added necessary dependencies.
- Enhanced debug trace output to include context.
- Fixed handling of `NilClass` in `to_redis` method.
- Updated test cases to expect float values for TTL and scores.
- Moved non-development dependencies back to gemspec and updated `tryouts` gem version.
- Updated version number in README and version configuration file.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Dependencies
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>familia.gemspec</strong><dd><code>Update gemspec version and dependencies.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
familia.gemspec

<li>Updated gemspec version to 0.10.2.<br> <li> Added dependencies for <code>redis</code>, <code>uri-redis</code>, <code>gibbler</code>, <code>storable</code>, and <br><code>multi_json</code>.<br> <li> Changed variable name from <code>s</code> to <code>spec</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/delano/familia/pull/9/files#diff-a36758066a82d2e932e8d590e9f7ee06b3d166bc81948c995fcea95316cc050b">+20/-14</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>Gemfile</strong><dd><code>Move dependencies to gemspec and update `tryouts`.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
Gemfile

<li>Moved non-development dependencies back to gemspec.<br> <li> Updated <code>tryouts</code> gem version.<br>


</details>
    

  </td>
  <td><a href="https://github.com/delano/familia/pull/9/files#diff-d09ea66f8227784ff4393d88a19836f321c915ae10031d16c93d67e6283ab55f">+2/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>familia.rb</strong><dd><code>Enhance debug trace output with context.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
lib/familia.rb

- Improved debug trace output to include context.



</details>
    

  </td>
  <td><a href="https://github.com/delano/familia/pull/9/files#diff-2fcd125226b496da9c2e5992551dbd71828ea361f198c898bec403034fd97cf3">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>redisobject.rb</strong><dd><code>Handle `NilClass` in `to_redis` method.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
lib/familia/redisobject.rb

- Added handling for `NilClass` in `to_redis` method.



</details>
    

  </td>
  <td><a href="https://github.com/delano/familia/pull/9/files#diff-cc7b1df34a934fc2e7d0b8e16d01a19ba9faa5bac2281b0f72dcaf2f67eb07bc">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Tests
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>20_redis_object_try.rb</strong><dd><code>Update TTL values to float in tests.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
try/20_redis_object_try.rb

- Updated expected TTL values to be floats.



</details>
    

  </td>
  <td><a href="https://github.com/delano/familia/pull/9/files#diff-2e2f73d75c7b44032798a4d2a8185233d6bdb3f3e380699f5431a37cbd63ce48">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>21_redis_object_zset_try.rb</strong><dd><code>Update score values to float in tests.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
try/21_redis_object_zset_try.rb

- Updated expected score values to be floats.



</details>
    

  </td>
  <td><a href="https://github.com/delano/familia/pull/9/files#diff-a72836c6d446ed1ccebec0e4f9fa835ac9a5aa55f319160c5e8dddacc2232e89">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Documentation
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Update version number in README.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
README.md

- Updated version number to 0.10.2.



</details>
    

  </td>
  <td><a href="https://github.com/delano/familia/pull/9/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Configuration changes
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>VERSION.yml</strong><dd><code>Bump version to 0.10.2.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
VERSION.yml

- Updated patch version to 0.10.2.



</details>
    

  </td>
  <td><a href="https://github.com/delano/familia/pull/9/files#diff-a00cc85abbd4e325c816b6553dae9c3748e3dcf2be640bdfd58c0e027ba04e2a">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

