### PR TITLE
Finalize persistence method return values (MultiResult)

### DIFF
--- a/lib/familia/features/expiration.rb
+++ b/lib/familia/features/expiration.rb
@@ -3,7 +3,7 @@
 
 
 module Familia::Features
-  #
+
   module Expiration
     @ttl = nil
 
@@ -57,7 +57,7 @@ module Familia::Features
     # @raise [Familia::Problem] If you try to feed it non-numbers or time-travel
     #   (negative numbers). It's strict, but fair!
     #
-    def update_expiration(ttl = nil)
+  def update_expiration(ttl = nil)
       ttl ||= self.ttl
       # It's important to raise exceptions here and not just log warnings. We
       # don't want to silently fail at setting expirations and cause data
@@ -67,14 +67,14 @@ module Familia::Features
       # good reason for the ttl to not be set in the first place. If the
       # class doesn't have a ttl, the default comes from Familia.ttl (which
       # is 0).
-      raise Familia::Problem, "TTL must be a number (#{ttl.class})" unless ttl.is_a?(Numeric)
+      raise Familia::Problem, "TTL must be a number (#{ttl.class} in #{self.class})" unless ttl.is_a?(Numeric)
       raise Familia::Problem, "TTL must be positive (#{ttl})" unless ttl.is_a?(Numeric)
 
       if ttl.zero?
         return Familia.ld "[update_expiration] No expiration for #{self.class} (#{rediskey})"
       end
 
-      Familia.info "[update_expiration] Expires #{rediskey} in #{ttl} seconds"
+      Familia.ld "[update_expiration] Expires #{rediskey} in #{ttl} seconds"
 
       # Redis' EXPIRE command returns 1 if the timeout was set, 0 if key does
       # not exist or the timeout could not be set. Via redis-rb here, it's

--- a/lib/familia/features/expiration.rb
+++ b/lib/familia/features/expiration.rb
@@ -67,8 +67,9 @@ module Familia::Features
       # good reason for the ttl to not be set in the first place. If the
       # class doesn't have a ttl, the default comes from Familia.ttl (which
       # is 0).
-      raise Familia::Problem, "TTL must be a number (#{ttl.class} in #{self.class})" unless ttl.is_a?(Numeric)
-      raise Familia::Problem, "TTL must be positive (#{ttl})" unless ttl.is_a?(Numeric)
+      unless ttl.is_a?(Numeric)
+        raise Familia::Problem, "TTL must be a number (#{ttl.class} in #{self.class})"
+      end
 
       if ttl.zero?
         return Familia.ld "[update_expiration] No expiration for #{self.class} (#{rediskey})"

--- a/lib/familia/horreum.rb
+++ b/lib/familia/horreum.rb
@@ -233,7 +233,7 @@ module Familia
                   end
 
       # If the unique_id is nil, raise an error
-      raise Problem, "Identifier is nil for #{self.class} #{custid}" if unique_id.nil?
+      raise Problem, "Identifier is nil for #{self.class} #{rediskey}" if unique_id.nil?
       raise Problem, 'Identifier is empty' if unique_id.empty?
 
       unique_id

--- a/lib/familia/horreum.rb
+++ b/lib/familia/horreum.rb
@@ -233,7 +233,7 @@ module Familia
                   end
 
       # If the unique_id is nil, raise an error
-      raise Problem, "Identifier is nil for #{self.class}" if unique_id.nil?
+      raise Problem, "Identifier is nil for #{self.class} #{custid}" if unique_id.nil?
       raise Problem, 'Identifier is empty' if unique_id.empty?
 
       unique_id

--- a/lib/familia/horreum/serialization.rb
+++ b/lib/familia/horreum/serialization.rb
@@ -418,9 +418,17 @@ module Familia
         @results = results
       end
 
-      # e.g. [true, ["OK", true, 1]]
+      # Returns a tuple representing the result of the transaction.
+      #
+      # @return [Array] A tuple containing the success status and the raw results.
+      #   The success status is a boolean indicating if all commands succeeded.
+      #   The raw results is an array of return values from the Redis commands.
+      #
+      # @example
+      #   [true, ["OK", true, 1]]
+      #
       def tuple
-        [success?, results]
+        [successful?, results]
       end
 
       # Convenient method to check if the commit was successful.

--- a/lib/familia/horreum/serialization.rb
+++ b/lib/familia/horreum/serialization.rb
@@ -6,6 +6,24 @@ module Familia
   # Familia::Horreum
   #
   class Horreum
+    # List of valid return values for Redis commands.
+    # This includes:
+    # - "OK": Indicates successful execution of a command.
+    # - true: Indicates a successful boolean response.
+    # - 1: Indicates success for commands that return a count of affected items.
+    # - 0: Indicates success for commands that return a count of affected items, but no items were affected.
+    # - nil: Indicates the absence of a value, which can be considered a valid outcome in some contexts.
+    #
+    # This list is used to validate the return values of multiple Redis commands executed within methods.
+    # Methods that run multiple Redis commands will check if all return values are included in this list
+    # to determine overall success. If any return value is not in this list, it is considered unexpected
+    # and may be logged or handled accordingly.
+    @valid_command_return_values = ["OK", true, 1, 0, nil]
+
+    class << self
+      attr_accessor :valid_command_return_values
+    end
+
     # Serialization: Where Objects Go to Become Strings (and Vice Versa)!
     #
     # This module is chock-full of methods that'll make your head spin (in a
@@ -108,12 +126,12 @@ module Familia
         self.created ||= Familia.now.to_i
 
         # Commit our tale to the Redis chronicles
-        ret = commit_fields # e.g. ["OK"]
+        ret = commit_fields # e.g. MultiResult.new(true, ["OK", "OK"])
 
         Familia.ld "[save] #{self.class} #{rediskey} #{ret}"
 
         # Did Redis accept our offering?
-        ret.uniq.all? { |value| ["OK", true].include?(value) }
+        ret.successful?
       end
 
       # Apply a smattering of fields to this object like fairy dust.
@@ -126,10 +144,10 @@ module Familia
       #   fresh attributes.
       #
       # @example Giving your object a makeover
-      #   dragon.apply_fields(name: "Puff", breathes: "fire", loves: "little boys
+      #   dragon.apply_fields(name: "Puff", breathes: "fire", loves: "Toys
       #   named Jackie")
       #   # => #<Dragon:0x007f8a1c8b0a28 @name="Puff", @breathes="fire",
-      #   @loves="little boys named Jackie">
+      #   @loves="Toys named Jackie">
       #
       def apply_fields(**fields)
         fields.each do |field, value|
@@ -143,23 +161,48 @@ module Familia
       #
       # This method performs a sacred ritual, sending our cherished attributes
       # on a journey through the ethernet to find their resting place in Redis.
+      # It executes a transaction that includes setting field values and,
+      # if applicable, updating the expiration time.
       #
-      # @return [Array<String>] A mystical array of strings, cryptic messages
-      #   from the Redis gods.
+      # @return [MultiResult] A mystical object containing:
+      #   - success: A boolean indicating if all Redis commands succeeded
+      #   - results: An array of strings, cryptic messages from the Redis gods
+      #
+      # The MultiResult object responds to:
+      #   - successful?: Returns the boolean success value
+      #   - results: Returns the array of command return values
       #
       # @note Be warned, young programmer! This method dabbles in the arcane
       #   art of transactions. Side effects may include data persistence and a
-      #   slight tingling sensation.
+      #   slight tingling sensation. The method does not raise exceptions for
+      #   unexpected Redis responses, but logs warnings and returns a failure status.
       #
       # @example Offering your changes to the Redis deities
       #   unicorn.name = "Charlie"
       #   unicorn.horn_length = "magnificent"
-      #   unicorn.commit_fields
-      #   # => ["OK", "OK"] (The Redis gods are pleased with your offering)
+      #   result = unicorn.commit_fields
+      #   if result.successful?
+      #     puts "The Redis gods are pleased with your offering"
+      #     p result.results  # => ["OK", "OK"]
+      #   else
+      #     puts "The Redis gods frown upon your offering"
+      #     p result.results  # Examine the unexpected values
+      #   end
+      #
+      # @see Familia::Horreum.valid_command_return_values for the list of
+      #   acceptable Redis command return values.
+      #
+      # @note This method performs logging at various levels:
+      #   - Debug: Logs the object's class, Redis key, and current state before committing
+      #   - Warn: Logs any unexpected return values from Redis commands
+      #   - Debug: Logs the final result, including success status and all return values
+      #
+      # @note The expiration update is only performed for classes that have
+      #   the expiration feature enabled. For others, it's a no-op.
       #
       def commit_fields
         Familia.ld "[commit_fields] #{self.class} #{rediskey} #{to_h}"
-        transaction do |conn|
+        command_return_values = transaction do |conn|
           hmset
 
           # Only classes that have the expiration ferature enabled will
@@ -167,6 +210,26 @@ module Familia
           # this will be a no-op.
           update_expiration
         end
+
+        # The acceptable redis command return values are defined in the
+        # Horreum class. This is to ensure that all commands return values
+        # are validated against a consistent set of values.
+        acceptable_values = Familia::Horreum.valid_command_return_values
+
+        # Check if all return values are valid
+        summary_boolean = command_return_values.uniq.all? { |value|
+          acceptable_values.include?(value)
+        }
+
+        # Log the unexpected
+        unless summary_boolean
+          unexpected_values = command_return_values.reject { |value| acceptable_values.include?(value) }
+          Familia.warn "[commit_fields] Unexpected return values: #{unexpected_values}"
+        end
+
+        Familia.ld "[commit_fields] #{self.class} #{rediskey} #{summary_boolean}: #{command_return_values}"
+
+        MultiResult.new(summary_boolean, command_return_values)
       end
 
       # Dramatically vanquish this object from the face of Redis! (ed: delete it)
@@ -312,6 +375,63 @@ module Familia
 
     end
     # End of Serialization module
+
+    # Represents the result of a multiple Redis commands.
+    #
+    # This class encapsulates the outcome of a Redis "transaction",
+    # providing both a success indicator and the raw results from
+    # the Redis commands executed during the transaction ("MULTI").
+    #
+    # @attr_reader success [Boolean] Indicates whether all Redis commands
+    #   in the transaction were successful.
+    # @attr_reader results [Array<String>] An array of return values from
+    #   the Redis commands executed in the transaction.
+    #
+    # @example Creating a MultiResult
+    #   result = MultiResult.new(true, ["OK", "OK"])
+    #
+    # @example Checking the success of a commit
+    #   if result.successful?
+    #     puts "All commands succeeded"
+    #   else
+    #     puts "Some commands failed"
+    #   end
+    #
+    # @example Accessing raw results
+    #   result.results.each_with_index do |value, index|
+    #     puts "Command #{index + 1} returned: #{value}"
+    #   end
+    class MultiResult
+      # @return [Boolean] true if all commands in the transaction succeeded,
+      #   false otherwise
+      attr_reader :success
+
+      # @return [Array<String>] The raw return values from the Redis commands
+      attr_reader :results
+
+      # Creates a new MultiResult instance.
+      #
+      # @param success [Boolean] Whether all commands succeeded
+      # @param results [Array<String>] The raw results from Redis commands
+      def initialize(success, results)
+        @success = success
+        @results = results
+      end
+
+      # e.g. [true, ["OK", true, 1]]
+      def tuple
+        [success?, results]
+      end
+
+      # Convenient method to check if the commit was successful.
+      #
+      # @return [Boolean] true if all commands succeeded, false otherwise
+      def successful?
+        @success
+      end
+      alias success? successful?
+    end
+    # End of MultiResult class
 
     include Serialization # these become Horreum instance methods
   end

--- a/lib/familia/redistype.rb
+++ b/lib/familia/redistype.rb
@@ -102,7 +102,12 @@ module Familia
 
       # Apply the options to instance method setters of the same name
       @opts.each do |k, v|
-        Familia.ld " [setting] #{k} #{v}"
+        # Bewarde logging :parent instance here implicitly calls #to_s which for
+        # some classes could include the identifier which could still be nil at
+        # this point. This would result in a Familia::Problem being raised. So
+        # to be on the safe-side here until we have a better understanding of
+        # the issue, we'll just log the class name for each key-value pair.
+        Familia.ld " [setting] #{k} #{v.class}"
         send(:"#{k}=", v) if respond_to? :"#{k}="
       end
 

--- a/lib/familia/utils.rb
+++ b/lib/familia/utils.rb
@@ -38,7 +38,7 @@ module Familia
   #   # => "193tosc85k3u513do2mtmibchpd2ruh5l3nsp6dnl0ov1i91h7m7"
   #
   def generate_id(length: 32, encoding: 36)
-    raise ArgumentError, "Encoding must be between 2 and 32" unless (1..32).include?(encoding)
+    raise ArgumentError, "Encoding must be between 2 and 36" unless (1..36).include?(encoding)
 
     input = SecureRandom.hex(length)
     Digest::SHA256.hexdigest(input).to_i(16).to_s(encoding)


### PR DESCRIPTION
### **User description**
This pull request addresses issue #32 and includes the following commits:

- Introduces MultiResult class to encapsulate Redis transaction outcomes

- Enhances commit_fields method to provide more detailed success/failure info

- Maintains simple, boolean return value from save

- Updates error messages with more context in various modules

- Improves logging to avoid potential nil identifier issues

The changes in this pull request clarify the return values of the `save` method, document the behavior and return value of the `transaction` method, and explain the return value of the `commit_fields` method. Additionally, an example is added to demonstrate the full save process and its return values. The class/module documentation is also reviewed and updated to improve code understanding and maintainability.


___

### **PR Type**
enhancement, documentation


___

### **Description**
- Introduced the `MultiResult` class to encapsulate Redis transaction outcomes, providing a structured way to handle success and results.
- Enhanced the `commit_fields` method to utilize the `MultiResult` class, improving the handling and logging of Redis command results.
- Improved error messages and logging to provide more context, particularly for TTL validation and nil identifier issues.
- Corrected the encoding range validation in the `generate_id` method to allow values between 2 and 36.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>expiration.rb</strong><dd><code>Enhance TTL validation and logging in Expiration module</code>&nbsp; &nbsp; </dd></summary>
<hr>

lib/familia/features/expiration.rb

<li>Improved error message for TTL validation.<br> <li> Adjusted logging level for expiration updates.<br>


</details>


  </td>
  <td><a href="https://github.com/delano/familia/pull/33/files#diff-aa070db77634f7507e28accf52e270a5968d96df438f9ca84ea1d42d8da61bef">+6/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>horreum.rb</strong><dd><code>Improve error message for nil identifier in Horreum</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/familia/horreum.rb

- Enhanced error message for nil identifier.



</details>


  </td>
  <td><a href="https://github.com/delano/familia/pull/33/files#diff-c42ea61e6354fd846082c12370a61f8e7771e39f1779388fad96d72658207300">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>serialization.rb</strong><dd><code>Introduce MultiResult class and enhance commit_fields method</code></dd></summary>
<hr>

lib/familia/horreum/serialization.rb

<li>Introduced <code>MultiResult</code> class for transaction outcomes.<br> <li> Updated <code>commit_fields</code> method to use <code>MultiResult</code>.<br> <li> Added documentation for valid Redis command return values.<br>


</details>


  </td>
  <td><a href="https://github.com/delano/familia/pull/33/files#diff-e132748c31a61268f19736f1fd44db42ff4c3e3e8c811f36643c86e8ab7a4226">+138/-10</a></td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>redistype.rb</strong><dd><code>Enhance logging to prevent nil identifier issues</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/familia/redistype.rb

- Improved logging to avoid nil identifier issues.



</details>


  </td>
  <td><a href="https://github.com/delano/familia/pull/33/files#diff-1a8bd2caf123345e69520ebc2eb87e3da26e5f63eb35ffcae4c35a5252a025b1">+6/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>utils.rb</strong><dd><code>Fix encoding range validation in generate_id method</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/familia/utils.rb

- Corrected encoding range validation in `generate_id`.



</details>


  </td>
  <td><a href="https://github.com/delano/familia/pull/33/files#diff-c0dff2491f5f69a56bfb313f500f326639dc868f6a9ed0f271667ef04edb6e73">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

