### PR TITLE
Enhancements for Redis access and instance relations

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    familia (1.0.0.pre.rc6)
+    familia (1.0.0.pre.rc7)
       redis (>= 4.8.1, < 6.0)
       uri-redis (~> 1.3)
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Familia - 1.0.0-rc6 (August 2024)
+# Familia - 1.0.0-rc7 (August 2024)
 
 **Organize and store Ruby objects in Redis. A powerful Ruby ORM (of sorts) for Redis.**
 

--- a/VERSION.yml
+++ b/VERSION.yml
@@ -2,4 +2,4 @@
 :MAJOR: 1
 :MINOR: 0
 :PATCH: 0
-:PRE: rc6
+:PRE: rc7

--- a/lib/familia/horreum.rb
+++ b/lib/familia/horreum.rb
@@ -142,9 +142,11 @@ module Familia
         #
         opts[:parent] = self # unless opts.key(:parent)
 
+        suffix_override = opts.fetch(:suffix, name)
+
         # Instantiate the RedisType object and below we store it in
         # an instance variable.
-        redis_type = klass.new name, opts
+        redis_type = klass.new suffix_override, opts
 
         # Freezes the redis_type, making it immutable.
         # This ensures the object's state remains consistent and prevents any modifications,

--- a/lib/familia/redistype.rb
+++ b/lib/familia/redistype.rb
@@ -16,7 +16,7 @@ module Familia
     extend Familia::Features
 
     @registered_types = {}
-    @valid_options = %i[class parent ttl default db key redis]
+    @valid_options = %i[class parent ttl default db key redis suffix]
     @db = nil
 
     feature :expiration

--- a/try/27_redis_horreum_try.rb
+++ b/try/27_redis_horreum_try.rb
@@ -47,12 +47,12 @@ Familia.debug = false
 @customer.save
 #=> true
 
-## Horreum object fields have a fast writer method (1 of 2)
+## Horreum object fields have a fast attribute method (1 of 2)
 Familia.trace :LOAD, @customer.redis, @customer.redisuri, caller if Familia.debug?
 @customer.name! 'Jane Doe'
 #=> 0
 
-## Horreum object fields have a fast writer method (2 of 2)
+## Horreum object fields have a fast attribute method (2 of 2)
 @customer.refresh!
 @customer.name
 #=> "Jane Doe"


### PR DESCRIPTION
### **User description**
This pull request includes two commits that introduce enhancements for Redis access and instance relations.

The first commit, "Enhance fast writer to support both read and write", improves the `fast_writer` method by renaming it to `fast_attribute!` and expanding its functionality to support both reading and writing operations. This enhancement provides a more versatile and robust solution for accessing Redis hash fields quickly.

The second commit, "Allow suffix override for instance relations", introduces a new 'suffix' option for Redis types, enabling more flexible naming of instance relations. This enhancement allows for greater customization of Redis key names, which can be useful in scenarios where default naming conventions need to be adjusted for specific use cases or data structures.

These changes provide improved functionality and customization options for Redis access and instance relations.


___

### **PR Type**
Enhancement, Documentation


___

### **Description**
- Enhanced the `fast_writer` method by renaming it to `fast_attribute!` and expanding its functionality to support both reading and writing operations.
- Introduced a new 'suffix' option for Redis types, allowing more flexible naming of instance relations.
- Updated related test cases and documentation to reflect the new functionality.
- Bumped version from 1.0.0-rc6 to 1.0.0-rc7.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>horreum.rb</strong><dd><code>Add suffix override for RedisType instances</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/familia/horreum.rb

<li>Introduced a suffix override option for RedisType instances.<br> <li> Updated RedisType instantiation to use the suffix override.<br>


</details>


  </td>
  <td><a href="https://github.com/delano/familia/pull/37/files#diff-c42ea61e6354fd846082c12370a61f8e7771e39f1779388fad96d72658207300">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>class_methods.rb</strong><dd><code>Enhance fast attribute method for Redis access</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/familia/horreum/class_methods.rb

<li>Renamed <code>fast_writer!</code> to <code>fast_attribute!</code>.<br> <li> Enhanced method to support both reading and writing.<br> <li> Updated method documentation for clarity.<br>


</details>


  </td>
  <td><a href="https://github.com/delano/familia/pull/37/files#diff-bcc0002fe067d3d54b5fcfc3e29fed2652ba76ad6fe8a306106a128ac830fa8e">+68/-16</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>redistype.rb</strong><dd><code>Extend RedisType options with suffix</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/familia/redistype.rb

- Added `suffix` to valid options for RedisType.



</details>


  </td>
  <td><a href="https://github.com/delano/familia/pull/37/files#diff-1a8bd2caf123345e69520ebc2eb87e3da26e5f63eb35ffcae4c35a5252a025b1">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>27_redis_horreum_try.rb</strong><dd><code>Update comments for fast attribute method</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

try/27_redis_horreum_try.rb

<li>Updated comments to reflect the renaming of fast writer to fast <br>attribute.<br>


</details>


  </td>
  <td><a href="https://github.com/delano/familia/pull/37/files#diff-13e83d5ff51491b4303b50858e471aeff0677960188e44e5e1746d9221ceec90">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Update version number in README</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

README.md

- Updated version number to 1.0.0-rc7.



</details>


  </td>
  <td><a href="https://github.com/delano/familia/pull/37/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>VERSION.yml</strong><dd><code>Version bump to 1.0.0-rc7</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

VERSION.yml

- Bumped version from rc6 to rc7.



</details>


  </td>
  <td><a href="https://github.com/delano/familia/pull/37/files#diff-a00cc85abbd4e325c816b6553dae9c3748e3dcf2be640bdfd58c0e027ba04e2a">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

