### PR TITLE
Improve Horreum object usability and JSON serialization control

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 *.env
 *.log
 *.md
+!README.md
 *.txt
 !LICENSE.txt
 .ruby-version

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -64,6 +64,6 @@ repos:
         stages: [prepare-commit-msg]
         name: Link commit to Github issue
         args:
-          - "--default=[NOJIRA]"
+          - "--default="
           - "--pattern=[a-zA-Z0-9]{0,10}-?[0-9]{1,5}"
           - "--template=[#{}]"

--- a/lib/familia.rb
+++ b/lib/familia.rb
@@ -1,6 +1,7 @@
 # rubocop:disable all
 # frozen_string_literal: true
 
+require 'json'
 require 'redis'
 require 'uri/redis'
 

--- a/lib/familia/horreum.rb
+++ b/lib/familia/horreum.rb
@@ -208,7 +208,6 @@ module Familia
     end
     private :initialize_with_positional_args
 
-
     # Initializes the object with keyword arguments.
     # Assigns values to fields based on the provided hash of field names and values.
     # Handles both symbol and string keys to accommodate different sources of data.
@@ -280,6 +279,19 @@ module Familia
       raise Problem, 'Identifier is empty' if unique_id.empty?
 
       unique_id
+    end
+
+    # The principle is: **If Familia objects have `to_s`, then they should work
+    # everywhere strings are expected**, including as Redis hash field names.
+    def to_s
+      # Enable polymorphic string usage for Familia objects
+      # This allows passing Familia objects directly where strings are expected
+      # without requiring explicit .identifier calls
+      identifier.to_s
+    rescue => e
+      # Fallback for cases where identifier might fail
+      Familia.ld "[#{self.class}#to_s] Failed to get identifier: #{e.message}"
+      "#<#{self.class}:0x#{object_id.to_s(16)}>"
     end
   end
 end

--- a/lib/familia/horreum.rb
+++ b/lib/familia/horreum.rb
@@ -81,7 +81,7 @@ module Familia
       # that every object horreum class has a unique identifier field. Ideally
       # this logic would live somewhere else b/c we only need to call it once
       # per class definition. Here it gets called every time an instance is
-      # instantiated/
+      # instantiated.
       unless self.class.fields.include?(:key)
         # Define the 'key' field for this class
         # This approach allows flexibility in how identifiers are generated
@@ -181,6 +181,7 @@ module Familia
     end
     private :initialize_with_positional_args
 
+
     # Initializes the object with keyword arguments.
     # Assigns values to fields based on the provided hash of field names and values.
     # Handles both symbol and string keys to accommodate different sources of data.
@@ -203,6 +204,12 @@ module Familia
     end
     private :initialize_with_keyword_args
 
+    def initialize_with_keyword_args_from_redis(**fields)
+      # Deserialize Redis string values back to their original types
+      deserialized_fields = fields.transform_values { |value| deserialize_value(value) }
+      initialize_with_keyword_args(**deserialized_fields)
+    end
+
     # A thin wrapper around the private initialize method that accepts a field
     # hash and refreshes the existing object.
     #
@@ -218,7 +225,7 @@ module Familia
     # @return [Array] The list of field names that were updated.
     def optimistic_refresh(**fields)
       Familia.ld "[optimistic_refresh] #{self.class} #{rediskey} #{fields.keys}"
-      initialize_with_keyword_args(**fields)
+      initialize_with_keyword_args_from_redis(**fields)
     end
 
     # Determines the unique identifier for the instance

--- a/lib/familia/horreum/serialization.rb
+++ b/lib/familia/horreum/serialization.rb
@@ -121,8 +121,9 @@ module Familia
       def save update_expiration: true
         Familia.trace :SAVE, redis, redisuri, caller(1..1) if Familia.debug?
 
-        # Update our object's life story
-        self.key ||= self.identifier
+        # Update our object's life story, keeping the mandatory built-in
+        # key field in sync with the field that is the chosen identifier.
+        self.key = self.identifier
         self.created ||= Familia.now.to_i if respond_to?(:created)
         self.updated = Familia.now.to_i if respond_to?(:updated)
 

--- a/lib/familia/redistype/types/sorted_set.rb
+++ b/lib/familia/redistype/types/sorted_set.rb
@@ -2,7 +2,6 @@
 
 module Familia
   class SortedSet < RedisType
-
     # Returns the number of elements in the sorted set
     # @return [Integer] number of elements
     def element_count

--- a/try/28_redis_horreum_serialization_try.rb
+++ b/try/28_redis_horreum_serialization_try.rb
@@ -1,0 +1,159 @@
+require_relative '../lib/familia'
+require_relative './test_helpers'
+
+Familia.debug = false
+
+@identifier = 'tryouts-28@onetimesecret.com'
+@customer = Customer.new @identifier
+
+## Basic save functionality works
+@customer.name = 'John Doe'
+@customer.save
+#=> true
+
+## to_h returns field hash with all Customer fields
+@customer.to_h.class
+#=> Hash
+
+## to_h includes the fields we set (using symbol keys)
+@customer.to_h[:name]
+#=> "John Doe"
+
+## to_h includes the key field (using symbol keys)
+@customer.to_h[:key]
+#=> "tryouts-28@onetimesecret.com"
+
+## to_a returns field array in definition order
+@customer.to_a.class
+#=> Array
+
+## to_a includes values in field order (name should be at index 5)
+@customer.to_a[5]
+#=> "John Doe"
+
+## batch_update can update multiple fields atomically, to_h
+@result = @customer.batch_update(name: 'Jane Smith', email: 'jane@example.com')
+@result.to_h
+#=> {:success=>true, :results=>[0, 0]}
+
+## batch_update returns successful result, successful?
+@result.successful?
+#=> true
+
+## batch_update returns successful result, tuple
+@result.tuple
+#=> [true, [0, 0]]
+
+## batch_update returns successful result, to_a
+@result.to_a
+#=> [true, [0, 0]]
+
+## batch_update updates object fields in memory, confirm fields changed
+[@customer.name, @customer.email]
+#=> ["Jane Smith", "jane@example.com"]
+
+## batch_update persists to Redis
+@customer.refresh!
+[@customer.name, @customer.email]
+#=> ["Jane Smith", "jane@example.com"]
+
+## batch_update with update_expiration: false works
+@customer.batch_update(name: 'Bob Jones', update_expiration: false)
+@customer.refresh!
+@customer.name
+#=> "Bob Jones"
+
+## apply_fields updates object in memory only (1 of 2)
+@customer.apply_fields(name: 'Memory Only', email: 'memory@test.com')
+[@customer.name, @customer.email]
+#=> ["Memory Only", "memory@test.com"]
+
+## apply_fields doesn't persist to Redis (2 of 2)
+@customer.refresh!
+[@customer.name, @customer.email]
+#=> ["Bob Jones", "jane@example.com"]
+
+## serialize_value handles strings
+@customer.serialize_value("test string")
+#=> "test string"
+
+## serialize_value handles numbers
+@customer.serialize_value(42)
+#=> "42"
+
+## serialize_value handles hashes as JSON
+@customer.serialize_value({key: 'value', num: 123})
+#=> "{\"key\":\"value\",\"num\":123}"
+
+## serialize_value handles arrays as JSON
+@customer.serialize_value([1, 2, 'three'])
+#=> "[1,2,\"three\"]"
+
+## deserialize_value handles JSON strings back to objects
+@customer.deserialize_value('{"key":"value","num":123}')
+#=> {:key=>"value", :num=>123}
+
+## deserialize_value handles JSON arrays
+@customer.deserialize_value('[1,2,"three"]')
+#=> [1, 2, "three"]
+
+## deserialize_value handles plain strings
+@customer.deserialize_value('plain string')
+#=> "plain string"
+
+## transaction method works with block
+result = @customer.transaction do |conn|
+  conn.hset @customer.rediskey, 'temp_field', 'temp_value'
+  conn.hset @customer.rediskey, 'another_field', 'another_value'
+end
+result.size
+#=> 2
+
+## refresh! reloads from Redis
+@customer.refresh!
+@customer.hget('temp_field')
+#=> "temp_value"
+
+## Empty batch_update still works
+result = @customer.batch_update()
+result.successful?
+#=> true
+
+## destroy! removes object from Redis (1 of 2)
+@customer.destroy!
+#=> true
+
+## After destroy!, Redis key no longer exists (2 of 2)
+@customer.exists?
+#=> false
+
+## destroy! removes object from Redis, not the in-memory object (2 of 2)
+@customer.refresh!
+@customer.name
+#=> "Bob Jones"
+
+## clear_fields! removes the in-memory object fields
+@customer.clear_fields!
+@customer.name
+#=> nil
+
+## Fresh customer for testing new field creation
+@fresh_customer = Customer.new 'fresh-customer@test.com'
+@fresh_customer.class
+#=> Customer
+
+## batch_update with new fields returns [1, 1] for new field creation
+@fresh_customer.remove_field('role')
+@fresh_customer.remove_field('planid')
+@fresh_result = @fresh_customer.batch_update(role: 'admin', planid: 'premium')
+@fresh_result.to_h
+#=> {:success=>true, :results=>[1, 1]}
+
+## Fresh customer fields are set correctly
+[@fresh_customer.role, @fresh_customer.planid]
+#=> ["admin", "premium"]
+
+## Fresh customer changes persist to Redis
+@fresh_customer.refresh!
+[@fresh_customer.role, @fresh_customer.planid]
+#=> ["admin", "premium"]

--- a/try/29_redis_horreum_initialization_try.rb
+++ b/try/29_redis_horreum_initialization_try.rb
@@ -1,0 +1,113 @@
+require_relative '../lib/familia'
+require_relative './test_helpers'
+
+Familia.debug = false
+
+## Existing positional argument initialization still works
+@customer1 = Customer.new 'tryouts-29@test.com', '', '', '', '', 'John Doe'
+[@customer1.custid, @customer1.name]
+#=> ["tryouts-29@test.com", "John Doe"]
+
+## Keyword argument initialization works (order independent)
+@customer2 = Customer.new(name: 'Jane Smith', custid: 'jane@test.com', email: 'jane@example.com')
+[@customer2.custid, @customer2.name, @customer2.email]
+#=> ["jane@test.com", "Jane Smith", "jane@example.com"]
+
+## Keyword arguments are order independent (different order, same result)
+@customer3 = Customer.new(email: 'bob@example.com', custid: 'bob@test.com', name: 'Bob Jones')
+[@customer3.custid, @customer3.name, @customer3.email]
+#=> ["bob@test.com", "Bob Jones", "bob@example.com"]
+
+## Legacy hash support (single hash argument)
+@customer4 = Customer.new({custid: 'legacy@test.com', name: 'Legacy User', role: 'admin'})
+[@customer4.custid, @customer4.name, @customer4.role]
+#=> ["legacy@test.com", "Legacy User", "admin"]
+
+## Empty initialization works
+@customer5 = Customer.new
+@customer5.class
+#=> Customer
+
+## Keyword args with save and retrieval
+@customer6 = Customer.new(custid: 'save-test@test.com', name: 'Save Test', email: 'save@example.com')
+@customer6.save
+#=> true
+
+## Saved customer can be retrieved with correct values
+@customer6.refresh!
+[@customer6.custid, @customer6.name, @customer6.email]
+#=> ["save-test@test.com", "Save Test", "save@example.com"]
+
+## Keyword initialization sets key field correctly
+@customer6.key
+#=> "save-test@test.com"
+
+## Mixed valid and nil values in keyword args (nil values stay nil)
+@customer7 = Customer.new(custid: 'mixed@test.com', name: 'Mixed Test', email: nil, role: 'user')
+[@customer7.custid, @customer7.name, @customer7.email, @customer7.role]
+#=> ["mixed@test.com", "Mixed Test", nil, "user"]
+
+## to_h works correctly with keyword-initialized objects
+@customer2.to_h[:name]
+#=> "Jane Smith"
+
+## to_a works correctly with keyword-initialized objects
+@customer2.to_a[5]  # name field should be at index 5
+#=> "Jane Smith"
+
+## Session has limited fields (only sessid defined)
+@session1 = Session.new('sess123')
+@session1.sessid
+#=> "sess123"
+
+## Session with keyword args works
+@session2 = Session.new(sessid: 'keyword-sess')
+@session2.sessid
+#=> "keyword-sess"
+
+## Session with legacy hash
+@session3 = Session.new({sessid: 'hash-sess'})
+@session3.sessid
+#=> "hash-sess"
+
+## CustomDomain with keyword initialization
+@domain1 = CustomDomain.new(display_domain: 'api.example.com', custid: 'domain-test@test.com')
+[@domain1.display_domain, @domain1.custid]
+#=> ["api.example.com", "domain-test@test.com"]
+
+## CustomDomain still works with positional args
+@domain2 = CustomDomain.new('web.example.com', 'positional@test.com')
+[@domain2.display_domain, @domain2.custid]
+#=> ["web.example.com", "positional@test.com"]
+
+## Keyword initialization can skip fields (they remain nil/empty)
+@partial = Customer.new(custid: 'partial@test.com', name: 'Partial User')
+[@partial.custid, @partial.name, @partial.email]
+#=> ["partial@test.com", "Partial User", nil]
+
+## Complex initialization with save/refresh cycle
+@complex = Customer.new(
+  custid: 'complex@test.com',
+  name: 'Complex User',
+  email: 'complex@example.com',
+  role: 'admin',
+  verified: true
+)
+@complex.save
+@complex.refresh!
+[@complex.custid, @complex.name, @complex.role, @complex.verified]
+#=> ["complex@test.com", "Complex User", "admin", "true"]
+
+## Clean up saved test objects
+[@customer6, @complex].map(&:delete!)
+#=> [true, true]
+
+## "Cleaning up" test objects that were never saved returns false.
+@customer1.save
+ret = [
+  @customer1, @customer2, @customer3, @customer4, @customer6, @customer7,
+  @session1, @session2, @session3,
+  @domain1, @domain2,
+  @partial, @complex
+].map(&:destroy!)
+#=> [true, false, false, false, false, false, false, false, false, false, false, false, false]

--- a/try/91_json_bug_try.rb
+++ b/try/91_json_bug_try.rb
@@ -1,0 +1,82 @@
+# try/91_json_bug_try.rb
+
+require_relative '../lib/familia'
+require_relative './test_helpers'
+
+Familia.debug = false
+
+# Define a simple model with fields that should handle JSON data
+class JsonTest < Familia::Horreum
+  identifier :id
+  field :id
+  field :config      # This should be able to store Hash objects
+  field :tags        # This should be able to store Array objects
+  field :simple      # This should store simple strings as-is
+end
+
+# Create an instance with JSON data
+@test_obj = JsonTest.new
+@test_obj.id = "json_test_1"
+
+## Test 1: Store a Hash - should serialize to JSON automatically
+@test_obj.config = { theme: "dark", notifications: true, settings: { volume: 80 } }
+@test_obj.config.class
+#=> Hash
+
+## Test 2: Store an Array - should serialize to JSON automatically
+@test_obj.tags = ["ruby", "redis", "json", "familia"]
+@test_obj.tags.class
+#=> Array
+
+## Test 3: Store a simple string - should remain as string
+@test_obj.simple = "just a string"
+@test_obj.simple.class
+#=> String
+
+## Save the object - this should call serialize_value and use to_json
+@test_obj.save
+#=> true
+
+## Verify what's actually stored in Redis (raw)
+raw_data = @test_obj.hgetall
+p [:plop, @test_obj]
+puts "Raw Redis data:"
+raw_data
+#=> {"id"=>"json_test_1", "config"=>"{\"theme\":\"dark\",\"notifications\":true,\"settings\":{\"volume\":80}}", "tags"=>"[\"ruby\",\"redis\",\"json\",\"familia\"]", "simple"=>"just a string"}
+
+## BUG: After refresh, JSON data comes back as strings instead of parsed objects
+@test_obj.refresh!
+
+## Test 4: Hash should be deserialized back to Hash, but it's a String!
+puts "Config after refresh:"
+puts @test_obj.config.inspect
+puts "Config class: "
+[@test_obj.config.class, @test_obj.config.inspect]
+#=> [String, "{\"theme\":\"dark\",\"notifications\":true,\"settings\":{\"volume\":80}}"]
+
+## Test 5: Array should be deserialized back to Array, but it's a String!
+puts "Tags after refresh:"
+puts @test_obj.tags.inspect
+puts "Tags class: #{@test_obj.tags.class}"
+#=> "[\"ruby\",\"redis\",\"json\",\"familia\"]"
+#=> String
+
+## Test 6: Simple string should remain a string (this works correctly)
+puts "Simple after refresh:"
+puts @test_obj.simple.inspect
+puts "Simple class: #{@test_obj.simple.class}"
+#=> "just a string"
+#=> String
+
+## Demonstrate the asymmetry:
+puts "\n=== ASYMMETRY DEMONSTRATION ==="
+puts "Before save: config is #{@test_obj.config.class}"
+@test_obj.config = { example: "data" }
+puts "After assignment: config is #{@test_obj.config.class}"
+@test_obj.save
+puts "After save: config is still #{@test_obj.config.class}"
+@test_obj.refresh!
+puts "After refresh: config is now #{@test_obj.config.class}!"
+
+## Clean up
+@test_obj.destroy!

--- a/try/91_json_bug_try.rb
+++ b/try/91_json_bug_try.rb
@@ -42,29 +42,33 @@ raw_data = @test_obj.hgetall
 p [:plop, @test_obj]
 puts "Raw Redis data:"
 raw_data
-#=> {"id"=>"json_test_1", "config"=>"{\"theme\":\"dark\",\"notifications\":true,\"settings\":{\"volume\":80}}", "tags"=>"[\"ruby\",\"redis\",\"json\",\"familia\"]", "simple"=>"just a string"}
+#=> {"id"=>"json_test_1", "config"=>"{\"theme\":\"dark\",\"notifications\":true,\"settings\":{\"volume\":80}}", "tags"=>"[\"ruby\",\"redis\",\"json\",\"familia\"]", "simple"=>"just a string", "key"=>"json_test_1"}
 
 ## BUG: After refresh, JSON data comes back as strings instead of parsed objects
 @test_obj.refresh!
 
-## Test 4: Hash should be deserialized back to Hash, but it's a String!
+## Test 4: Hash should be deserialized back to Hash
 puts "Config after refresh:"
 puts @test_obj.config.inspect
 puts "Config class: "
 [@test_obj.config.class, @test_obj.config.inspect]
-#=> [String, "{\"theme\":\"dark\",\"notifications\":true,\"settings\":{\"volume\":80}}"]
+#=> [Hash, "{:theme=>\"dark\", :notifications=>true, :settings=>{:volume=>80}}"]
 
-## Test 5: Array should be deserialized back to Array, but it's a String!
+## Test 5: Array should be deserialized back to Array
 puts "Tags after refresh:"
 puts @test_obj.tags.inspect
 puts "Tags class: #{@test_obj.tags.class}"
-#=> "[\"ruby\",\"redis\",\"json\",\"familia\"]"
-#=> String
+@test_obj.tags.inspect
+@test_obj.tags.class
+#=> ["ruby", "redis", "json", "familia"]
+#=> Array
 
 ## Test 6: Simple string should remain a string (this works correctly)
 puts "Simple after refresh:"
 puts @test_obj.simple.inspect
 puts "Simple class: #{@test_obj.simple.class}"
+@test_obj.simple.inspect
+@test_obj.simple.class
 #=> "just a string"
 #=> String
 

--- a/try/92_symbolize_try.rb
+++ b/try/92_symbolize_try.rb
@@ -1,0 +1,96 @@
+require_relative '../lib/familia'
+require_relative './test_helpers'
+
+Familia.debug = false
+
+# Test the updated deserialize_value method
+class SymbolizeTest < Familia::Horreum
+  identifier :id
+  field :id
+  field :config
+end
+
+@test_obj = SymbolizeTest.new
+@test_obj.id = "symbolize_test_1"
+
+## Test with a hash containing string keys
+@test_hash = { "name" => "John", "age" => 30, "nested" => { "theme" => "dark" } }
+@test_obj.config = @test_hash
+@test_obj.save
+
+## Original hash has string keys
+@test_hash.keys
+#=> ["name", "age", "nested"]
+
+## After save and refresh, default behavior uses symbol keys
+@test_obj.refresh!
+@test_obj.config.keys
+#=> [:name, :age, :nested]
+
+## Nested hash also has symbol keys
+@test_obj.config[:nested].keys
+#=> [:theme]
+
+## Get raw JSON from Redis
+@raw_json = @test_obj.hget('config')
+@raw_json.class
+#=> String
+
+## deserialize_value with default symbolize: true returns symbol keys
+@symbol_result = @test_obj.deserialize_value(@raw_json)
+@symbol_result.keys
+#=> [:name, :age, :nested]
+
+## Nested hash in symbol result also has symbol keys
+@symbol_result[:nested].keys
+#=> [:theme]
+
+## deserialize_value with symbolize: false returns string keys
+@string_result = @test_obj.deserialize_value(@raw_json, symbolize: false)
+@string_result.keys
+#=> ["name", "age", "nested"]
+
+## Nested hash in string result also has string keys
+@string_result["nested"].keys
+#=> ["theme"]
+
+## Values are preserved correctly in both cases
+@symbol_result[:name]
+#=> "John"
+
+@string_result["name"]
+#=> "John"
+
+## Arrays are handled correctly too
+@test_obj.config = [{ "item" => "value" }, "string", 123]
+@test_obj.save
+@array_json = @test_obj.hget('config')
+#=> "[{\"item\":\"value\"},\"string\",123]"
+
+## Array with symbolize: true converts hash keys to symbols
+@symbol_array = @test_obj.deserialize_value(@array_json)
+@symbol_array[0].keys
+#=> [:item]
+
+## Array with symbolize: false keeps hash keys as strings
+@string_array = @test_obj.deserialize_value(@array_json, symbolize: false)
+@string_array[0].keys
+#=> ["item"]
+
+## Non-hash/array values are returned as-is
+@test_obj.deserialize_value('"just a string"')
+#=> "\"just a string\""
+
+## Non-hash/array values are returned as-is
+@test_obj.deserialize_value('just a string')
+#=> "just a string"
+
+@test_obj.deserialize_value('42')
+#=> "42"
+
+## Invalid JSON returns original string
+@test_obj.deserialize_value('invalid json')
+#=> "invalid json"
+
+## Clean up
+@test_obj.destroy!

--- a/try/93_string_coercion_try.rb
+++ b/try/93_string_coercion_try.rb
@@ -1,0 +1,154 @@
+# try/93_string_coercion_try.rb
+
+require_relative '../lib/familia'
+require_relative './test_helpers'
+
+Familia.debug = false
+
+# Error handling: object without proper identifier setup
+class ::BadIdentifierTest < Familia::Horreum
+  # No identifier method defined - should cause issues
+end
+
+@bad_obj = ::BadIdentifierTest.new
+
+# Test polymorphic string usage for Familia objects
+@customer_id = 'customer-string-coercion-test'
+@customer = Customer.new(@customer_id)
+@customer.name = 'John Doe'
+@customer.planid = 'premium'
+@customer.save
+
+@session_id = 'session-string-coercion-test'
+@session = Session.new(@session_id)
+@session.custid = @customer_id
+@session.useragent = 'Test Browser'
+@session.save
+
+## Complex identifier test with array-based identifier
+@bone = Bone.new
+@bone.token = 'test_token'
+@bone.name = 'test_name'
+
+
+## Basic to_s functionality returns identifier
+@customer.to_s
+#=> @customer_id
+
+## String interpolation works seamlessly
+"Customer: #{@customer}"
+#=> "Customer: #{@customer_id}"
+
+## Explicit identifier call returns same value
+@customer.to_s == @customer.identifier
+#=> true
+
+## Session to_s works with generated identifier
+@session.to_s
+#=> @session_id
+
+## Method accepting string parameter works with Familia object
+def lookup_by_id(id_string)
+  id_string.to_s.upcase
+end
+
+lookup_by_id(@customer)
+#=> @customer_id.upcase
+
+## Hash key assignment using Familia object (implicit string conversion)
+@data = {}
+@data[@customer] = 'customer_data'
+@data[@customer]
+#=> 'customer_data'
+
+## Array operations work with mixed types
+@mixed_array = [@customer_id, @customer, @session]
+@mixed_array.map(&:to_s)
+#=> [@customer_id, @customer_id, @session_id]
+
+## String comparison works
+@customer.to_s == @customer_id
+#=> true
+
+## Join operations work seamlessly
+[@customer, 'separator', @session].join(':')
+#=> "#{@customer_id}:separator:#{@session_id}"
+
+## Case statement works with string matching
+def classify_id(obj)
+  case obj.to_s
+  when /customer/
+    'customer_type'
+  when /session/
+    'session_type'
+  else
+    'unknown_type'
+  end
+end
+
+classify_id(@customer)
+#=> 'customer_type'
+
+classify_id(@session)
+#=> 'session_type'
+
+## Polymorphic method accepting both strings and Familia objects
+def process_identifier(id_or_object)
+  # Can handle both string IDs and Familia objects uniformly
+  processed_id = id_or_object.to_s
+  "processed:#{processed_id}"
+end
+
+process_identifier(@customer_id)
+#=> "processed:#{@customer_id}"
+
+process_identifier(@customer)
+#=> "processed:#{@customer_id}"
+
+## Redis storage using object as string key
+@metadata = Familia::HashKey.new 'metadata'
+@metadata[@customer] = 'customer_metadata'
+@metadata[@customer.to_s] # Same key access
+#=> 'customer_metadata'
+
+## Cleanup after test
+@metadata.delete!
+#=> true
+
+@customer.delete!
+#=> true
+
+@session.delete!
+#=> true
+
+## to_s handles identifier errors gracefully
+@bad_obj.to_s.include?('BadIdentifierTest')
+#=> true
+
+## Array-based identifier works with to_s
+@bone.to_s
+#=> 'test_token:test_name'
+
+## String operations on complex identifier
+@bone.to_s.split(':')
+#=> ['test_token', 'test_name']
+
+## Cleanup a key that does not exist
+@bone.delete!
+#=> false
+
+## Cleanup a key that exists
+@bone.save
+@bone.delete!
+#=> true
+
+## Performance consideration: to_s caching behavior
+@customer2 = Customer.new('performance-test')
+@first_call = @customer2.to_s
+@second_call = @customer2.to_s
+@first_call == @second_call
+#=> true
+
+## Delete customer2
+[@customer2.exists?, @customer2.delete!]
+#=> [false, false]


### PR DESCRIPTION

This PR improves object handling and JSON serialization in Familia with several key enhancements:

### Key Changes

**Object Usability Improvements:**
- Add `Horreum#to_s` method to enable polymorphic usage, allowing Familia objects to be used directly as Redis hash field names without explicit `#identifier` calls
- Support keyword arguments in `Horreum#initialize` for more robust and self-documenting object creation while maintaining backward compatibility
- Add `#batch_update` for atomic multi-field updates within Redis transactions
- Add `#clear_fields!` to reset all in-memory object fields to nil

**JSON Serialization Control:**
- Add `symbolize` parameter to `deserialize_value` (defaults to `true`) to control JSON hash key symbolization
- Refine `serialize_value` to only attempt JSON serialization for Array/Hash types when the distinguisher returns nil

**Developer Experience:**
- Update Hashkey methods to explicitly call `#to_s` on field arguments for consistency
- Enhance MultiResult with `#to_h` and `#to_a` methods
- Add comprehensive test coverage via new try files

### Backward Compatibility
All existing initialization patterns and API usage are preserved. These changes are purely additive and enhance the library's flexibility without breaking existing code.

### Testing
- Added try files demonstrating new initialization patterns
- Added comprehensive coverage for serialization and transaction handling
- Verified polymorphic object usage scenarios