### PR TITLE
Resolve YARD documentation parameter warnings

### DIFF
--- a/lib/familia/features/expiration.rb
+++ b/lib/familia/features/expiration.rb
@@ -171,7 +171,7 @@ module Familia
       module ClassMethods
         # UnsortedSet the default expiration time for instances of this class
         #
-        # @param default_expiration [Numeric] Time in seconds (can be fractional)
+        # @param value [Numeric] Time in seconds (can be fractional)
         #
         attr_writer :default_expiration
 

--- a/lib/familia/features/transient_fields/transient_field_type.rb
+++ b/lib/familia/features/transient_fields/transient_field_type.rb
@@ -111,8 +111,8 @@ module Familia
     # This method should not be called since transient fields are not
     # persisted, but we provide it for completeness.
     #
-    # @param value [Object] The value to serialize
-    # @param record [Object] The record instance
+    # @param _value [Object] The value to serialize
+    # @param _record [Object] The record instance
     # @return [nil] Always nil since transient fields are not serialized
     #
     def serialize(_value, _record = nil)
@@ -126,8 +126,8 @@ module Familia
     # This method should not be called since transient fields are not
     # persisted, but we provide it for completeness.
     #
-    # @param value [Object] The value to deserialize
-    # @param record [Object] The record instance
+    # @param _value [Object] The value to deserialize
+    # @param _record [Object] The record instance
     # @return [nil] Always nil since transient fields are not stored
     #
     def deserialize(_value, _record = nil)

--- a/lib/familia/horreum/subclass/definition.rb
+++ b/lib/familia/horreum/subclass/definition.rb
@@ -317,7 +317,6 @@ end
       # Create and register a transient field type
       #
       # @param name [Symbol] The field name
-      # @param kwargs [Hash] Field options (passed as keyword arguments)
       #
       def transient_field(name, **)
         require_relative '../../features/transient_fields/transient_field_type'

--- a/lib/familia/horreum/subclass/management.rb
+++ b/lib/familia/horreum/subclass/management.rb
@@ -19,9 +19,9 @@ module Familia
 
       # Creates and persists a new instance of the class.
       #
-      # @param *args [Array] Variable number of positional arguments to be passed
+      # @param args [Array] Variable number of positional arguments to be passed
       #   to the constructor.
-      # @param **kwargs [Hash] Keyword arguments to be passed to the constructor.
+      # @param kwargs [Hash] Keyword arguments to be passed to the constructor.
       # @return [Object] The newly created and persisted instance.
       # @raise [Familia::Problem] If an instance with the same identifier already
       #   exists.
@@ -49,8 +49,6 @@ module Familia
       # @note The behavior of this method depends on the implementation of #new,
       #   #exists?, and #save in the class and its superclasses.
       #
-      # @param args [Array] Arguments passed to the constructor
-      # @param kwargs [Hash] Keyword arguments passed to the constructor
       # @see #new
       # @see #exists?
       # @see #save


### PR DESCRIPTION
Fixed all @param tag warnings in YARD documentation:
- Corrected parameter names in expiration.rb (default_expiration → value)
- Fixed parameter names in transient_field_type.rb (value → _value, record → _record)
- Removed duplicate @param declarations in management.rb
- Removed invalid @param for anonymous kwargs in definition.rb

YARD now generates documentation without warnings and exits cleanly (code 0).

🤖 Generated with [Claude Code](https://claude.ai/code)