### PR TITLE
Fix object identifier feature inheritance and initialization

### DIFF
--- a/lib/familia/features/encrypted_fields.rb
+++ b/lib/familia/features/encrypted_fields.rb
@@ -265,8 +265,6 @@ module Familia
         Familia.trace :LOADED, self, base if Familia.debug?
         base.extend ModelClassMethods
 
-        require_relative 'encrypted_fields/encrypted_field_type'
-
         # Initialize encrypted fields tracking
         base.instance_variable_set(:@encrypted_fields, []) unless base.instance_variable_defined?(:@encrypted_fields)
       end

--- a/lib/familia/features/transient_fields.rb
+++ b/lib/familia/features/transient_fields.rb
@@ -1,6 +1,7 @@
 # lib/familia/features/transient_fields.rb
 
 require_relative 'transient_fields/redacted_string'
+require_relative 'transient_fields/transient_field_type'
 
 module Familia
   module Features
@@ -109,8 +110,6 @@ module Familia
       def self.included(base)
         Familia.trace :LOADED, self, base if Familia.debug?
         base.extend ModelClassMethods
-
-        require_relative 'transient_fields/transient_field_type'
 
         # Initialize transient fields tracking
         base.instance_variable_set(:@transient_fields, []) unless base.instance_variable_defined?(:@transient_fields)

--- a/lib/familia/field_type.rb
+++ b/lib/familia/field_type.rb
@@ -117,25 +117,7 @@ module Familia
         klass.define_method :"#{method_name}=" do |value|
           instance_variable_set(:"@#{field_name}", value)
 
-          # If this field is the identifier and object_identifier feature is loaded,
-          # update objid_lookup mapping when identifier is set after objid generation
-          if respond_to?(:objid) &&
-             self.class.respond_to?(:identifier_field) &&
-             self.class.identifier_field == field_name &&
-             self.class.respond_to?(:objid_lookup)
-            current_objid = instance_variable_get(:@objid)
-            self.class.objid_lookup[current_objid] = value if current_objid && value
-          end
 
-          # If this field is the identifier and external_identifier feature is loaded,
-          # update extid_lookup mapping when identifier is set after extid generation
-          if respond_to?(:extid) &&
-             self.class.respond_to?(:identifier_field) &&
-             self.class.identifier_field == field_name &&
-             self.class.respond_to?(:extid_lookup)
-            current_extid = instance_variable_get(:@extid)
-            self.class.extid_lookup[current_extid] = value if current_extid && value
-          end
         end
       end
     end

--- a/lib/familia/horreum/definition.rb
+++ b/lib/familia/horreum/definition.rb
@@ -94,8 +94,11 @@ module Familia
 
         if block_given?
           @current_field_group = name.to_sym
-          instance_eval(&block)
-          @current_field_group = nil
+          begin
+            instance_eval(&block)
+          ensure
+            @current_field_group = nil
+          end
         else
           Familia.ld "[field_group] Created field group :#{name} but no block given" if Familia.debug?
         end

--- a/lib/familia/horreum/persistence.rb
+++ b/lib/familia/horreum/persistence.rb
@@ -76,8 +76,6 @@ module Familia
         if ret
           transaction do |conn|
             auto_update_class_indexes
-            # Update objid_lookup mapping if object_identifier feature is enabled
-            update_objid_lookup if respond_to?(:objid) && self.class.respond_to?(:objid_lookup)
             # Add to class-level instances collection after successful save
             self.class.instances.add(identifier, Familia.now) if self.class.respond_to?(:instances)
           end
@@ -155,8 +153,6 @@ module Familia
         if success
           transaction do |conn|
             auto_update_class_indexes
-            # Update objid_lookup mapping if object_identifier feature is enabled
-            update_objid_lookup if respond_to?(:objid) && self.class.respond_to?(:objid_lookup)
           end
         end
 
@@ -454,21 +450,6 @@ module Familia
         end
       end
 
-      # Updates the objid_lookup mapping for object_identifier feature
-      #
-      # Called automatically during save operations to maintain the mapping
-      # between objid and the model's primary identifier field.
-      #
-      # @private
-      #
-      def update_objid_lookup
-        return unless respond_to?(:objid) && respond_to?(:identifier)
-
-        current_objid = instance_variable_get(:@objid)
-        return if current_objid.nil? || identifier.nil?
-
-        self.class.objid_lookup[current_objid] = identifier
-      end
     end
   end
 end


### PR DESCRIPTION
### **User description**

This PR addresses architectural issues in how Familia features manage their lookup indices, specifically for `object_identifier` and `external_identifier` features. The changes prevent unwanted database writes during object initialization and ensure proper separation of concerns between feature modules and core Familia classes.

## The Problem

The previous implementation had a layering violation where `FieldType` (a low-level utility class) was directly aware of and managing high-level feature concerns (objid_lookup and extid_lookup indices). This caused several issues:

1. Database writes occurred when calling `.new()` on objects with these features
2. Feature logic was scattered across multiple files instead of being self-contained
3. The identifier field setter had complex conditional logic checking for feature availability
4. Field group blocks could leave `@current_field_group` in an inconsistent state if an exception occurred

## The Solution

See update https://github.com/delano/familia/pull/143#issuecomment-3367796683

**Moved lookup index management to feature modules** - Both `object_identifier` and `external_identifier` features now include a `ModelInstanceMethods` module that overrides `save()` to update their respective lookup indices. This ensures:
- Index updates only happen during explicit save operations
- Feature logic remains encapsulated in feature modules
- No database writes occur during object initialization

**Fixed field_group exception handling** - Added an ensure block to reset `@current_field_group` to nil even if an exception occurs during the field_group block evaluation. This prevents subsequent field definitions from incorrectly being assigned to the failed group.

**Relocated require statements** - Moved feature-specific requires to the top of their respective feature modules for clearer dependency management.

## Technical Details

The key architectural change is introducing a `save` override pattern in features that need post-save index updates. This follows the template:

```ruby
module ModelInstanceMethods
  def save(update_expiration: true)
    result = super
    
    # Update feature-specific indices after successful save
    if result && [conditions]
      # Update lookup mapping
    end
    
    result
  end
end
```

This pattern allows features to hook into the persistence lifecycle without the core framework needing to know about feature-specific requirements.

## Testing

- Added comprehensive test coverage for field_group exception handling
- Verified objid_lookup and extid_lookup indices are populated correctly during save
- Confirmed `.new()` no longer triggers database writes for these features

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Fix object identifier feature inheritance and initialization

- Move lookup index management to feature modules

- Add exception handling for field_group blocks

- Remove layering violations between core and features


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Core FieldType"] -- "removes" --> B["Feature-specific logic"]
  C["Feature Modules"] -- "adds" --> D["ModelInstanceMethods.save()"]
  D -- "updates" --> E["Lookup Indices"]
  F["field_group"] -- "ensures" --> G["Exception handling"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Formatting</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>encrypted_fields.rb</strong><dd><code>Relocate require statement for better organization</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/familia/features/encrypted_fields.rb

- Move require statement to top of file


</details>


  </td>
  <td><a href="https://github.com/delano/familia/pull/143/files#diff-efdfda22d12bc384dbf33527e9fef37ba7e3d353ffdcfa4db18fda6f71ecc1fd">+0/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>transient_fields.rb</strong><dd><code>Relocate require statement for better organization</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/familia/features/transient_fields.rb

- Move require statement to top of file


</details>


  </td>
  <td><a href="https://github.com/delano/familia/pull/143/files#diff-0ae4ca9f7b1deead120ca916fe46e92169d6bc4fda74c7b0d31620aa9217f3f8">+1/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>external_identifier.rb</strong><dd><code>Move extid lookup management to feature module</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/familia/features/external_identifier.rb

<ul><li>Add ModelInstanceMethods module with save override<br> <li> Remove auto-population logic from getter/setter methods<br> <li> Update extid_lookup mapping only during save operations</ul>


</details>


  </td>
  <td><a href="https://github.com/delano/familia/pull/143/files#diff-de59e5d5cf8bef0166d3c323924a5d633f285e0263c08301cbe5948bc4c1db6d">+27/-8</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>object_identifier.rb</strong><dd><code>Move objid lookup management to feature module</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/familia/features/object_identifier.rb

<ul><li>Add ModelInstanceMethods module with save override<br> <li> Update objid_lookup mapping only during save operations<br> <li> Prevent database writes during object initialization</ul>


</details>


  </td>
  <td><a href="https://github.com/delano/familia/pull/143/files#diff-fc43f3df50bd73bd18f0925cba3ec98838df3612f6a7315e68adc5c8913ebcdb">+27/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>field_type.rb</strong><dd><code>Remove feature-specific logic from core FieldType</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/familia/field_type.rb

<ul><li>Remove feature-specific lookup index update logic<br> <li> Simplify setter method to only set instance variables<br> <li> Eliminate layering violation between core and features</ul>


</details>


  </td>
  <td><a href="https://github.com/delano/familia/pull/143/files#diff-4f1159749e4341afced87c31eed520c0925a5e924d90857df3ff5829cc7f958b">+0/-18</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>definition.rb</strong><dd><code>Add exception handling for field_group blocks</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/familia/horreum/definition.rb

<ul><li>Add ensure block to reset <code>@current_field_group</code> after exceptions<br> <li> Prevent state leakage across field_group blocks</ul>


</details>


  </td>
  <td><a href="https://github.com/delano/familia/pull/143/files#diff-5d439fbd77f17e56a3c1ac01218164d4239a7a9f9b291cab396fceeb8e008174">+5/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>persistence.rb</strong><dd><code>Remove objid lookup management from core persistence</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/familia/horreum/persistence.rb

<ul><li>Remove <code>update_objid_lookup</code> method calls from save operations<br> <li> Remove <code>update_objid_lookup</code> method definition<br> <li> Delegate lookup management to feature modules</ul>


</details>


  </td>
  <td><a href="https://github.com/delano/familia/pull/143/files#diff-6e8aa91a474a9506b89e49a01bd5a0ca61383a0b45b319adc266a0008fb8d6d2">+0/-19</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>field_groups_try.rb</strong><dd><code>Add test coverage for field_group exception handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

try/features/field_groups_try.rb

<ul><li>Add comprehensive test cases for field_group exception handling<br> <li> Verify <code>@current_field_group</code> reset after exceptions<br> <li> Test field definition behavior after group errors</ul>


</details>


  </td>
  <td><a href="https://github.com/delano/familia/pull/143/files#diff-612e71c76008b8bab0aea79eda2c8eb561ad2f15331d191c2cbf49cef3c8237d">+35/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

