### PR TITLE
Addendum to #143

### DIFF
--- a/lib/familia/features/external_identifier.rb
+++ b/lib/familia/features/external_identifier.rb
@@ -168,7 +168,7 @@ module Familia
 
           # Update extid_lookup mapping after successful save
           if result && respond_to?(:extid) && respond_to?(:identifier)
-            current_extid = instance_variable_get(:@extid)
+            current_extid = extid  # Triggers lazy generation if needed
             if current_extid && identifier
               self.class.extid_lookup[current_extid] = identifier
             end

--- a/lib/familia/features/external_identifier.rb
+++ b/lib/familia/features/external_identifier.rb
@@ -176,6 +176,28 @@ module Familia
 
           result
         end
+
+        # Override save_if_not_exists to update extid_lookup mapping
+        #
+        # This ensures the extid_lookup index is populated during create operations
+        # which use save_if_not_exists instead of save.
+        #
+        # @param update_expiration [Boolean] Whether to update key expiration
+        # @return [Boolean] True if save was successful
+        #
+        def save_if_not_exists(update_expiration: true)
+          result = super
+
+          # Update extid_lookup mapping after successful save
+          if result && respond_to?(:extid) && respond_to?(:identifier)
+            current_extid = extid  # Triggers lazy generation if needed
+            if current_extid && identifier
+              self.class.extid_lookup[current_extid] = identifier
+            end
+          end
+
+          result
+        end
       end
 
       # Derives a deterministic, public-facing external identifier from the object's

--- a/lib/familia/features/object_identifier.rb
+++ b/lib/familia/features/object_identifier.rb
@@ -303,6 +303,28 @@ module Familia
 
           result
         end
+
+        # Override save_if_not_exists to update objid_lookup mapping
+        #
+        # This ensures the objid_lookup index is populated during create operations
+        # which use save_if_not_exists instead of save.
+        #
+        # @param update_expiration [Boolean] Whether to update key expiration
+        # @return [Boolean] True if save was successful
+        #
+        def save_if_not_exists(update_expiration: true)
+          result = super
+
+          # Update objid_lookup mapping after successful save
+          if result && respond_to?(:objid) && respond_to?(:identifier)
+            current_objid = objid  # Triggers lazy generation if needed
+            if current_objid && identifier
+              self.class.objid_lookup[current_objid] = identifier
+            end
+          end
+
+          result
+        end
       end
 
       # Instance method for generating object identifier using configured strategy

--- a/lib/familia/features/object_identifier.rb
+++ b/lib/familia/features/object_identifier.rb
@@ -295,7 +295,7 @@ module Familia
 
           # Update objid_lookup mapping after successful save
           if result && respond_to?(:objid) && respond_to?(:identifier)
-            current_objid = instance_variable_get(:@objid)
+            current_objid = objid  # Triggers lazy generation if needed
             if current_objid && identifier
               self.class.objid_lookup[current_objid] = identifier
             end


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Fix lazy generation in lookup index save overrides

- Add save_if_not_exists overrides for create operations

- Ensure proper index population during all save flows


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["save() method"] --> B["Trigger lazy generation"]
  C["save_if_not_exists() method"] --> B
  B --> D["Update lookup indexes"]
  D --> E["objid_lookup mapping"]
  D --> F["extid_lookup mapping"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>external_identifier.rb</strong><dd><code>Fix extid lookup index population</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/familia/features/external_identifier.rb

<ul><li>Replace <code>instance_variable_get(:@extid)</code> with <code>extid</code> method call<br> <li> Add <code>save_if_not_exists</code> override method<br> <li> Ensure extid_lookup index updates during create operations</ul>


</details>


  </td>
  <td><a href="https://github.com/delano/familia/pull/144/files#diff-de59e5d5cf8bef0166d3c323924a5d633f285e0263c08301cbe5948bc4c1db6d">+23/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>object_identifier.rb</strong><dd><code>Fix objid lookup index population</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/familia/features/object_identifier.rb

<ul><li>Replace <code>instance_variable_get(:@objid)</code> with <code>objid</code> method call<br> <li> Add <code>save_if_not_exists</code> override method<br> <li> Ensure objid_lookup index updates during create operations</ul>


</details>


  </td>
  <td><a href="https://github.com/delano/familia/pull/144/files#diff-fc43f3df50bd73bd18f0925cba3ec98838df3612f6a7315e68adc5c8913ebcdb">+23/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

