### PR TITLE
Add error handling for unresolved target classes in participates_in

### DIFF
--- a/lib/familia/features/relationships/participation.rb
+++ b/lib/familia/features/relationships/participation.rb
@@ -273,6 +273,23 @@ module Familia
             # Handle class target using Familia.resolve_class
             resolved_class = Familia.resolve_class(target_class)
 
+            # Raise helpful error if target class can't be resolved
+            if resolved_class.nil?
+              raise ArgumentError, <<~ERROR
+                Cannot resolve target class: #{target_class.inspect}
+
+                The target class '#{target_class}' could not be found in Familia.members.
+                This usually means:
+                1. The target class hasn't been loaded/required yet (load order issue)
+                2. The target class name is misspelled
+                3. The target class doesn't inherit from Familia::Horreum
+
+                Current registered classes: #{Familia.members.map(&:name).compact.sort.join(', ')}
+
+                Solution: Ensure #{target_class} is defined and loaded before #{self.name}
+              ERROR
+            end
+
             # Store metadata for this participation relationship
             participation_relationships << ParticipationRelationship.new(
               target_class: target_class, # as passed to `participates_in`

--- a/try/features/relationships/participation_unresolved_target_try.rb
+++ b/try/features/relationships/participation_unresolved_target_try.rb
@@ -1,0 +1,107 @@
+# try/features/relationships/participation_unresolved_target_try.rb
+#
+# Test for proper error handling when target class cannot be resolved
+#
+# This test verifies that participates_in raises a helpful error when
+# the target class hasn't been loaded yet or doesn't exist.
+
+require_relative '../../support/helpers/test_helpers'
+
+## Test error message when target class doesn't exist (Symbol)
+begin
+  class UnresolvedTargetTest1 < Familia::Horreum
+    feature :relationships
+    identifier_field :id
+    field :id
+
+    participates_in :NonExistentTargetClass, :items
+  end
+  @error_raised = false
+rescue ArgumentError => e
+  @error_raised = true
+  @error_message = e.message
+end
+@error_raised
+#=> true
+
+## Test error message includes the unresolved class name
+@error_message.include?('NonExistentTargetClass')
+#=> true
+
+## Test error message mentions load order issue
+@error_message.include?('load order')
+#=> true
+
+## Test error message mentions Familia.members
+@error_message.include?('Familia.members')
+#=> true
+
+## Test error message includes list of registered classes
+@error_message.include?('Current registered classes')
+#=> true
+
+## Test error when target class doesn't exist (String)
+begin
+  class UnresolvedTargetTest2 < Familia::Horreum
+    feature :relationships
+    identifier_field :id
+    field :id
+
+    participates_in 'AnotherNonExistentClass', :items
+  end
+  @string_error_raised = false
+rescue ArgumentError => e
+  @string_error_raised = true
+  @string_error_message = e.message
+end
+@string_error_raised
+#=> true
+
+## Test error message for String target includes class name
+@string_error_message.include?('AnotherNonExistentClass')
+#=> true
+
+## Test error provides solution hint
+@string_error_message.include?('Solution')
+#=> true
+
+## Test that Class objects don't trigger the error (they're already resolved)
+# This should work fine - no error expected
+class ExistingTargetClass < Familia::Horreum
+  feature :relationships
+  identifier_field :id
+  field :id
+end
+
+class WorkingParticipant < Familia::Horreum
+  feature :relationships
+  identifier_field :id
+  field :id
+
+  # This should work - ExistingTargetClass is already defined
+  participates_in ExistingTargetClass, :items
+end
+
+# Verify the class was created successfully
+WorkingParticipant.ancestors.include?(Familia::Horreum)
+#=> true
+
+## Test that resolved Symbol target works (no error)
+class PreDefinedTarget < Familia::Horreum
+  feature :relationships
+  identifier_field :id
+  field :id
+end
+
+class SymbolParticipant < Familia::Horreum
+  feature :relationships
+  identifier_field :id
+  field :id
+
+  # This should work - PreDefinedTarget is defined above
+  participates_in :PreDefinedTarget, :items
+end
+
+# Verify it worked
+SymbolParticipant.ancestors.include?(Familia::Horreum)
+#=> true


### PR DESCRIPTION
### **User description**
This commit fixes the a bug discovered after merging to main, where implementing projects with load order issues got confusing errors.

Problem:
- When participates_in references a target class that hasn't been loaded yet
- Familia.resolve_class returns nil
- The nil is passed to TargetMethods::Builder.build
- Results in: "undefined method 'method_defined?' for nil (NoMethodError)"
- Error location and message don't explain the actual problem

Example that triggers this:
```ruby
class Domain < Familia::Horreum
  # Customer class not loaded yet!
  participates_in :Customer, :domains
end
```

Root Cause:
- No validation that resolve_class returned a valid class
- nil propagates to method_defined? check in collection_operations.rb
- Error message is about nil, not about the unresolved class name

Solution:
- Added explicit nil check after Familia.resolve_class
- Raises ArgumentError with detailed, actionable error message
- Error message includes:
  * The unresolved target class name
  * Three most common causes (load order, typo, not inheriting)
  * List of all registered Familia classes for debugging
  * Clear solution guidance

Example of new error:
```
ArgumentError: Cannot resolve target class: :Customer

The target class 'Customer' could not be found in Familia.members.
This usually means:
1. The target class hasn't been loaded/required yet (load order issue)
2. The target class name is misspelled
3. The target class doesn't inherit from Familia::Horreum

Current registered classes: Domain, Product, Session, User

Solution: Ensure Customer is defined and loaded before Domain
```

Test Coverage:
- Added try/features/relationships/participation_unresolved_target_try.rb
- Tests error raised when target class doesn't exist (Symbol and String)
- Verifies error message includes helpful debugging information
- Tests that properly defined classes still work (no false positives)

Impact:
- Developers get clear, actionable error messages for load order issues
- Easier to diagnose typos in target class names
- Faster debugging when classes don't inherit from Horreum
- No impact on valid use cases - they continue to work as before

Changelog:
- Updated to document fourth bug and solution
- Added AI assistance notes about post-merge bug discovery


___

### **PR Type**
Bug fix


___

### **Description**
- Add error handling for unresolved target classes in `participates_in`

- Raise ArgumentError with detailed, actionable error message

- Include registered classes list and common causes in error

- Add comprehensive test coverage for unresolved target scenarios


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["participates_in called<br/>with unresolved target"] --> B["Familia.resolve_class<br/>returns nil"]
  B --> C["Check if resolved_class<br/>is nil"]
  C --> D["Raise ArgumentError<br/>with helpful message"]
  D --> E["Developer sees:<br/>class name, causes,<br/>registered classes"]
  E --> F["Fix load order<br/>or typo"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Error handling</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>participation.rb</strong><dd><code>Add nil check and detailed error for unresolved classes</code>&nbsp; &nbsp; </dd></summary>
<hr>

lib/familia/features/relationships/participation.rb

<ul><li>Added nil check after <code>Familia.resolve_class</code> call<br> <li> Raises <code>ArgumentError</code> with detailed error message when target class <br>cannot be resolved<br> <li> Error message includes unresolved class name, three common causes, <br>list of registered classes, and solution guidance<br> <li> Prevents confusing "undefined method 'method_defined?' for nil" error</ul>


</details>


  </td>
  <td><a href="https://github.com/delano/familia/pull/178/files#diff-03b4b8bf9ad7ad987fc724c51931e8b964dceeff437346fd41f164ba29d14d75">+17/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>participation_unresolved_target_try.rb</strong><dd><code>Add tests for unresolved target class error handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

try/features/relationships/participation_unresolved_target_try.rb

<ul><li>Tests error raised when target class doesn't exist (both Symbol and <br>String inputs)<br> <li> Verifies error message includes class name, load order mention, and <br>Familia.members reference<br> <li> Tests that properly defined classes still work without errors<br> <li> Covers both symbol and string target class resolution scenarios</ul>


</details>


  </td>
  <td><a href="https://github.com/delano/familia/pull/178/files#diff-dbd58451fecf0e14616d93621e2f41fa8379ea667f21c2f12cfc0a8007cf193a">+107/-0</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>20251107_fix_participates_in_symbol_resolution.rst</strong><dd><code>Document fourth bug fix in changelog</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

changelog.d/20251107_fix_participates_in_symbol_resolution.rst

<ul><li>Updated bug count from three to four in the summary<br> <li> Added detailed documentation of Bug 4 (confusing error when target <br>class not loaded)<br> <li> Documented root cause, solution, and impact of the fix<br> <li> Added note about fourth bug discovery after merging to main</ul>


</details>


  </td>
  <td><a href="https://github.com/delano/familia/pull/178/files#diff-c20746ac76e454641cd2651cfcfe4fc54724d880708ec36b27ab6c9c90a3cc4c">+17/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

