### PR TITLE
Fix RedisClient documentation inconsistencies

### DIFF
--- a/docs/guides/logging.md
+++ b/docs/guides/logging.md
@@ -101,10 +101,14 @@ Familia.error "Serialization failed", field: :email, error: e.message
 Familia includes `DatabaseLogger` middleware for Redis command logging:
 
 ```ruby
-# Enable command logging
-RedisClient.register(DatabaseLogger)
+# Enable command logging (uses redis-rb middleware internally)
+Familia.enable_database_logging = true
+
+# Optional: Configure logger (uses Familia.logger by default)
 DatabaseLogger.logger = Familia.logger
 ```
+
+**Note**: Familia automatically registers the middleware with redis-rb when enabled. You work with `Redis.new` connections - the underlying `RedisClient` middleware registration is handled internally.
 
 ### Output Formats
 

--- a/docs/reference/api-technical.md
+++ b/docs/reference/api-technical.md
@@ -622,9 +622,8 @@ end
 Monitor all Redis commands with DatabaseLogger middleware.
 
 ```ruby
-# Enable command logging
-RedisClient.register(DatabaseLogger)
-DatabaseLogger.logger = Familia.logger
+# Enable command logging (middleware registered automatically)
+Familia.enable_database_logging = true
 
 # Capture commands in tests
 commands = DatabaseLogger.capture_commands do

--- a/examples/sampling_demo.rb
+++ b/examples/sampling_demo.rb
@@ -8,8 +8,8 @@
 require_relative '../lib/familia'
 require 'logger'
 
-# Register DatabaseLogger middleware and enable logging
-RedisClient.register(DatabaseLogger)
+# Enable database command logging (middleware registered automatically)
+Familia.enable_database_logging = true
 DatabaseLogger.logger = Familia::FamiliaLogger.new($stdout)
 DatabaseLogger.logger.level = Familia::FamiliaLogger::TRACE
 

--- a/lib/middleware/database_command_counter.rb
+++ b/lib/middleware/database_command_counter.rb
@@ -2,11 +2,22 @@
 
 require 'concurrent-ruby'
 
-# DatabaseCommandCounter is RedisClient middleware for counting commands.
+# DatabaseCommandCounter is redis-rb middleware for counting commands.
 #
 # This middleware counts the number of Redis commands executed. It can be
 # useful for performance monitoring and debugging, allowing you to track
 # the volume of Redis operations in your application.
+#
+# Familia uses the redis-rb gem (v4.8.1 to <6.0), which internally uses
+# RedisClient infrastructure. Users work with Redis.new connections - the
+# RedisClient middleware registration is handled automatically by Familia.
+#
+# ## User-Facing API
+#
+# Enable via Familia configuration:
+#   Familia.enable_database_counter = true
+#
+# Familia automatically calls RedisClient.register(DatabaseCommandCounter) internally.
 #
 # ## Middleware Chaining
 #
@@ -14,14 +25,14 @@ require 'concurrent-ruby'
 # `super` to properly chain method calls. See {DatabaseLogger} for detailed
 # explanation of middleware chaining mechanics.
 #
-# @example Enable Redis command counting
+# @example Enable Redis command counting (recommended user-facing API)
 #   DatabaseCommandCounter.reset
-#   RedisClient.register(DatabaseCommandCounter)
+#   Familia.enable_database_counter = true
 #
 # @example Use with DatabaseLogger
-#   RedisClient.register(DatabaseLogger)
-#   RedisClient.register(DatabaseCommandCounter)
-#   # Both middlewares execute correctly in sequence
+#   Familia.enable_database_logging = true
+#   Familia.enable_database_counter = true
+#   # Both middlewares registered automatically and execute correctly in sequence
 #
 # @see https://github.com/redis-rb/redis-client?tab=readme-ov-file#instrumentation-and-middlewares
 # @see DatabaseLogger For middleware chain architecture details


### PR DESCRIPTION
### **User description**
The documentation incorrectly showed users calling RedisClient.register() directly, which is an internal implementation detail. Familia uses the redis-rb gem (v4.8.1 to <6.0), which internally uses RedisClient for middleware. Users work with Redis.new connections and should use Familia's configuration API instead.

Changes:
- docs/guides/logging.md: Replace RedisClient.register() examples with Familia.enable_database_logging = true
- docs/reference/api-technical.md: Update DatabaseLogger example to use Familia configuration API
- examples/sampling_demo.rb: Use Familia.enable_database_logging instead of direct RedisClient.register() call
- lib/middleware/database_logger.rb: Add user-facing API section and clarify that RedisClient is internal implementation
- lib/middleware/database_command_counter.rb: Add user-facing API section and update examples to use Familia configuration

All changes maintain backward compatibility - the internal implementation is unchanged, only documentation and examples are clarified.


___

### **PR Type**
Documentation, Enhancement


___

### **Description**
- Clarify user-facing API for database logging and command counting

- Replace internal RedisClient.register() calls with Familia configuration API

- Document that RedisClient is internal implementation detail of redis-rb

- Update examples and middleware documentation for consistency


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["User Code<br/>Redis.new"] -->|"uses"| B["Familia Configuration<br/>enable_database_logging"]
  B -->|"internally calls"| C["RedisClient.register<br/>Internal Implementation"]
  C -->|"registers"| D["DatabaseLogger<br/>Middleware"]
  E["Documentation<br/>Examples"] -->|"updated to show"| B
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>sampling_demo.rb</strong><dd><code>Update example to use Familia configuration API</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

examples/sampling_demo.rb

<ul><li>Replace <code>RedisClient.register(DatabaseLogger)</code> with <br><code>Familia.enable_database_logging = true</code><br> <li> Update comment to clarify middleware is registered automatically</ul>


</details>


  </td>
  <td><a href="https://github.com/delano/familia/pull/182/files#diff-a544deaecdbc9e6ca87076d891ac918ba8392d24105454293010b779f671b742">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>database_command_counter.rb</strong><dd><code>Document user-facing API and internal implementation details</code></dd></summary>
<hr>

lib/middleware/database_command_counter.rb

<ul><li>Add explanation that RedisClient is internal implementation of <br>redis-rb<br> <li> Add "User-Facing API" section documenting <br><code>Familia.enable_database_counter = true</code><br> <li> Update code examples to use Familia configuration instead of direct <br>RedisClient.register()<br> <li> Clarify that Familia automatically handles middleware registration</ul>


</details>


  </td>
  <td><a href="https://github.com/delano/familia/pull/182/files#diff-af3026fda3d1763267a5c93245fdc8a6600110d767e0ef259e8280f61d65b2ca">+17/-6</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>database_logger.rb</strong><dd><code>Document user-facing API and clarify internal implementation</code></dd></summary>
<hr>

lib/middleware/database_logger.rb

<ul><li>Add explanation that RedisClient is internal implementation of <br>redis-rb<br> <li> Add "User-Facing API" section documenting <br><code>Familia.enable_database_logging = true</code><br> <li> Mark RedisClient middleware architecture section as "Internal"<br> <li> Update all code examples to use Familia configuration API<br> <li> Clarify that users work with Redis.new connections, not RedisClient <br>directly</ul>


</details>


  </td>
  <td><a href="https://github.com/delano/familia/pull/182/files#diff-f03d37a9450eee7bffdd92769de8493c57eec4739b36640062e12c7a36805ed3">+20/-12</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>logging.md</strong><dd><code>Update logging guide to use Familia configuration API</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/guides/logging.md

<ul><li>Replace <code>RedisClient.register(DatabaseLogger)</code> with <br><code>Familia.enable_database_logging = true</code><br> <li> Add note explaining that Familia automatically registers middleware <br>internally<br> <li> Clarify that users work with Redis.new connections<br> <li> Update comment to indicate middleware registration is automatic</ul>


</details>


  </td>
  <td><a href="https://github.com/delano/familia/pull/182/files#diff-6cc2e307ea596019fb380287f91b40fb9ca8c5f7e00296003eab36b5dfced925">+6/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>api-technical.md</strong><dd><code>Update API reference to use Familia configuration API</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/reference/api-technical.md

<ul><li>Replace <code>RedisClient.register(DatabaseLogger)</code> with <br><code>Familia.enable_database_logging = true</code><br> <li> Remove redundant <code>DatabaseLogger.logger = Familia.logger</code> line<br> <li> Update comment to clarify middleware is registered automatically</ul>


</details>


  </td>
  <td><a href="https://github.com/delano/familia/pull/182/files#diff-23eddd0de0fc0fb9fc73e02c8f24919f7e20a0b50ab5c290168520f0dd2b0137">+2/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

