### PR TITLE
Reduce min Ruby version to 3.3.6

### DIFF
--- a/familia.gemspec
+++ b/familia.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.required_ruby_version = Gem::Requirement.new('>= 3.4')
+  spec.required_ruby_version = Gem::Requirement.new('>= 3.3.6')
 
   spec.add_dependency 'benchmark', '~> 0.4'
   spec.add_dependency 'concurrent-ruby', '~> 1.3'


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Reduces minimum Ruby version requirement from 3.4 to 3.3.6

- Expands compatibility with earlier Ruby 3.3 patch versions


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Ruby 3.4+"] -- "downgrade requirement" --> B["Ruby 3.3.6+"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>familia.gemspec</strong><dd><code>Lower minimum Ruby version requirement</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

familia.gemspec

<ul><li>Updated <code>spec.required_ruby_version</code> from <code>>= 3.4</code> to <code>>= 3.3.6</code><br> <li> Allows the gem to be installed on Ruby 3.3.6 and later versions</ul>


</details>


  </td>
  <td><a href="https://github.com/delano/familia/pull/189/files#diff-a36758066a82d2e932e8d590e9f7ee06b3d166bc81948c995fcea95316cc050b">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

