### PR TITLE
[#195] Fix typo in uri= setter and object mutation in redis()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 .history
 .devcontainer
 .vscode
+.serena
 *.env
 *.log
 *.md
@@ -19,3 +20,4 @@ tmp
 vendor
 *.gem
 .yardoc
+public

--- a/lib/familia/connection.rb
+++ b/lib/familia/connection.rb
@@ -68,7 +68,7 @@ module Familia
     #   Familia.redis('redis://localhost:6379')
     def redis(uri = nil)
       if uri.is_a?(Integer)
-        tmp = Familia.uri
+        tmp = Familia.uri.dup
         tmp.db = uri
         uri = tmp
       elsif uri.is_a?(String)
@@ -94,7 +94,7 @@ module Familia
     # @example
     #   Familia.uri = 'redis://localhost:6379'
     def uri=(val)
-      @uri = val.is_a?(URI) ? v : URI.parse(val)
+      @uri = val.is_a?(URI) ? val : URI.parse(val)
     end
 
     alias url uri

--- a/try/05_connection_try.rb
+++ b/try/05_connection_try.rb
@@ -1,0 +1,27 @@
+
+require_relative '../lib/familia'
+require_relative './test_helpers'
+
+## Bug 1: uri= setter correctly handles URI objects
+## Previously used undefined variable 'v' instead of 'val'
+original_uri = Familia.uri.dup
+test_uri = URI.parse('redis://testhost:6380/5')
+Familia.uri = test_uri
+result = Familia.uri.to_s
+Familia.uri = original_uri  # restore
+result
+#=> 'redis://testhost:6380/5'
+
+## Bug 1: uri= setter correctly handles string URIs
+original_uri = Familia.uri.dup
+Familia.uri = 'redis://stringhost:6381/7'
+result = Familia.uri.to_s
+Familia.uri = original_uri  # restore
+result
+#=> 'redis://stringhost:6381/7'
+
+## Bug 2: redis(db_index) does not mutate global Familia.uri
+## Previously tmp = Familia.uri (reference), now tmp = Familia.uri.dup (copy)
+Familia.redis(15)  # Request connection to DB 15
+Familia.uri.db  # Global URI should be unchanged (default is 0)
+#=> 0


### PR DESCRIPTION
### **User description**
## Summary

Fixes two bugs in `lib/familia/connection.rb` that were reported in #195.

## Bug 1: Typo in `uri=` setter

**Problem:** Used undefined variable `v` instead of `val` when assigning a URI object directly.

```ruby
# Before (broken)
def uri=(val)
  @uri = val.is_a?(URI) ? v : URI.parse(val)
end

# After (fixed)
def uri=(val)
  @uri = val.is_a?(URI) ? val : URI.parse(val)
end
```

## Bug 2: Object mutation in `redis(db_index)`

**Problem:** `tmp = Familia.uri` created a reference, not a copy. When `tmp.db = uri` was called, it mutated the global `Familia.uri` object.

```ruby
# Before (broken - mutates global URI)
if uri.is_a?(Integer)
  tmp = Familia.uri
  tmp.db = uri
  uri = tmp

# After (fixed - creates copy)
if uri.is_a?(Integer)
  tmp = Familia.uri.dup
  tmp.db = uri
  uri = tmp
```

## Bug 3: Documentation (out of scope)

The third bug in #195 relates to `uri-redis` gem documentation. Familia uses `uri-valkey`, so this is out of scope for this PR.

## Tests

Added `try/05_connection_try.rb` with 3 test cases covering both fixes.

Closes #195


___

### **PR Type**
Bug fix


___

### **Description**
- Fix typo in `uri=` setter using undefined variable `v` instead of `val`

- Fix object mutation in `redis()` by using `.dup` to copy global URI

- Add comprehensive test cases for both bug fixes


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["uri= setter bug"] -->|"typo: v instead of val"| B["Fixed typo"]
  C["redis db_index bug"] -->|"reference instead of copy"| D["Added .dup call"]
  B --> E["Tests added"]
  D --> E
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>connection.rb</strong><dd><code>Fix typo and object mutation bugs in connection methods</code>&nbsp; &nbsp; </dd></summary>
<hr>

lib/familia/connection.rb

<ul><li>Fixed typo in <code>uri=</code> setter: changed <code>v</code> to <code>val</code> on line 97<br> <li> Fixed object mutation in <code>redis()</code> method: added <code>.dup</code> to create copy of <br><code>Familia.uri</code> on line 72<br> <li> Both changes prevent unintended side effects when setting URIs or <br>requesting specific database indices</ul>


</details>


  </td>
  <td><a href="https://github.com/delano/familia/pull/196/files#diff-fb5b6dc9790fc38d1d8107d1ac43f0aa558f2d4b4532efeba9ba5dc2aeb7c773">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>05_connection_try.rb</strong><dd><code>Add tests for connection bug fixes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

try/05_connection_try.rb

<ul><li>Added test case for <code>uri=</code> setter with URI object assignment<br> <li> Added test case for <code>uri=</code> setter with string URI assignment<br> <li> Added test case for <code>redis(db_index)</code> to verify global URI is not <br>mutated<br> <li> All tests include setup/teardown to restore original state</ul>


</details>


  </td>
  <td><a href="https://github.com/delano/familia/pull/196/files#diff-f50629d936f63b11c21c51aba09fff29e2e5fc2c47aa3b9985a1fe7fcba6cfec">+27/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

