### PR TITLE
Rename bidirectional: to generate_participant_methods: parameter

### DIFF
--- a/docs/1106-participates_in-bidirectional-solution.md
+++ b/docs/1106-participates_in-bidirectional-solution.md
@@ -3,12 +3,14 @@
 > **Document Status**: Updated 2025-12 to reflect current implementation including
 > `:through` option and `config_name`-based method naming.
 
-## The Original Naming Problem
+## The Original Naming Problem (Now Resolved)
+
+The parameter was renamed from `bidirectional:` to `generate_participant_methods:`.
 
 `bidirectional: true` was misleading because:
 
 1. It's not truly bidirectional - It only helps you manage membership in specific instances, not query all memberships
-2. Better name would be: `generate_participant_methods: true`
+2. Better name: `generate_participant_methods: true` (**now implemented**)
 3. True bidirectionality would mean both sides can easily query their relationships
 
 ## What True Bidirectionality Should Look Like

--- a/lib/familia/features/relationships.rb
+++ b/lib/familia/features/relationships.rb
@@ -38,7 +38,7 @@ module Familia
     #
     #     # Participation with bidirectional control (no method collisions)
     #     participates_in Customer, :domains
-    #     participates_in Team, :domains, bidirectional: false
+    #     participates_in Team, :domains, generate_participant_methods: false
     #     participates_in Organization, :domains, type: :set
     #   end
     #

--- a/lib/familia/features/relationships/README.md
+++ b/lib/familia/features/relationships/README.md
@@ -12,7 +12,7 @@
 
 **participates_in** - Collection membership ("this object belongs in that collection")
 ```ruby
-participates_in Organization, :members, score: :joined_at, bidirectional: true
+participates_in Organization, :members, score: :joined_at, generate_participant_methods: true
 # Creates: org.members, org.add_member(), customer.add_to_organization_members()
 ```
 

--- a/lib/familia/features/relationships/participation.rb
+++ b/lib/familia/features/relationships/participation.rb
@@ -118,7 +118,7 @@ module Familia
           # - +ClassName.add_to_collection_name(instance)+ - Add instance to collection
           # - +ClassName.remove_from_collection_name(instance)+ - Remove instance from collection
           #
-          # ==== On Instances (Participant Methods, if bidirectional)
+          # ==== On Instances (Participant Methods, if generate_participant_methods)
           # - +instance.in_class_collection_name?+ - Check membership in class collection
           # - +instance.add_to_class_collection_name+ - Add self to class collection
           # - +instance.remove_from_class_collection_name+ - Remove self from class collection
@@ -135,7 +135,7 @@ module Familia
           #   - +:sorted_set+: Ordered by score (default)
           #   - +:set+: Unordered unique membership
           #   - +:list+: Ordered sequence allowing duplicates
-          # @param bidirectional [Boolean] Whether to generate convenience methods on instances (default: +true+)
+          # @param generate_participant_methods [Boolean] Whether to generate convenience methods on instances (default: +true+)
           # @param through [Class, Symbol, String, nil] Optional join model class for
           #        storing additional attributes. See +participates_in+ for details.
           #
@@ -163,7 +163,7 @@ module Familia
           # @see #participates_in for instance-level participation relationships
           # @since 1.0.0
           def class_participates_in(collection_name, score: nil,
-                                    type: :sorted_set, bidirectional: true, through: nil)
+                                    type: :sorted_set, generate_participant_methods: true, through: nil)
             # Store metadata for this participation relationship
             participation_relationships << ParticipationRelationship.new(
               _original_target: self,   # For class-level, original and resolved are the same
@@ -171,7 +171,7 @@ module Familia
               collection_name: collection_name,
               score: score,
               type: type,
-              bidirectional: bidirectional,
+              generate_participant_methods: generate_participant_methods,
               through: through,
             )
 
@@ -179,9 +179,9 @@ module Familia
             # e.g., User.all_users, User.add_to_all_users(user)
             TargetMethods::Builder.build_class_level(self, collection_name, type)
 
-            # STEP 2: Add participation methods to instances (if bidirectional)
+            # STEP 2: Add participation methods to instances (if generate_participant_methods)
             # e.g., user.in_class_all_users?, user.add_to_class_all_users
-            return unless bidirectional
+            return unless generate_participant_methods
 
             # Pass the string 'class' as target to distinguish class-level from instance-level
             # This prevents generating reverse collection methods (user can't have "all_users")
@@ -207,7 +207,7 @@ module Familia
           # - +target.remove_participant_class_name(participant)+ - Remove participant from collection
           # - +target.add_participant_class_names([participants])+ - Bulk add multiple participants
           #
-          # ==== On Participant Class (if bidirectional)
+          # ==== On Participant Class (if generate_participant_methods)
           # - +participant.in_target_collection_name?(target)+ - Check membership in target's collection
           # - +participant.add_to_target_collection_name(target)+ - Add self to target's collection
           # - +participant.remove_from_target_collection_name(target)+ - Remove self from target's collection
@@ -237,7 +237,7 @@ module Familia
           #        different scores (default)
           #   - +:set+: Unordered unique membership
           #   - +:list+: Ordered sequence, allows duplicates
-          # @param bidirectional [Boolean] Whether to generate reverse collection
+          # @param generate_participant_methods [Boolean] Whether to generate reverse collection
           #        methods on participant class. If true, methods are generated using the
           #        name of the target class. (default: +true+)
           # @param as [Symbol, nil] Custom name for reverse collection methods
@@ -294,7 +294,7 @@ module Familia
           # @see ModelInstanceMethods#current_participations for membership queries
           # @see ModelInstanceMethods#calculate_participation_score for scoring details
           #
-          def participates_in(target, collection_name, score: nil, type: :sorted_set, bidirectional: true, as: nil, through: nil)
+          def participates_in(target, collection_name, score: nil, type: :sorted_set, generate_participant_methods: true, as: nil, through: nil)
 
             # Normalize the target class parameter
             target_class = Familia.resolve_class(target)
@@ -334,7 +334,7 @@ module Familia
               collection_name: collection_name,
               score: score,
               type: type,
-              bidirectional: bidirectional,
+              generate_participant_methods: generate_participant_methods,
               through: through,
             )
 
@@ -347,8 +347,8 @@ module Familia
             TargetMethods::Builder.build(target_class, collection_name, type, through)
 
             # STEP 2: Add participation methods to PARTICIPANT class (Domain) - only if
-            # bidirectional. e.g. in_employee_domains?, add_to_employee_domains, etc.
-            if bidirectional
+            # generate_participant_methods. e.g. in_employee_domains?, add_to_employee_domains, etc.
+            if generate_participant_methods
               # `as` parameter allows custom naming for reverse collections
               # If not provided, we'll let the builder use the pluralized target class name
               ParticipantMethods::Builder.build(self, target_class, collection_name, type, as, through)

--- a/lib/familia/features/relationships/participation/participant_methods.rb
+++ b/lib/familia/features/relationships/participation/participant_methods.rb
@@ -89,7 +89,7 @@ module Familia
             end
           end
 
-          # Generate reverse collection methods on participant class for bidirectional access
+          # Generate reverse collection methods on participant class for symmetric access
           #
           # Creates methods like:
           # - user.team_instances (returns Array of Team instances)

--- a/lib/familia/features/relationships/participation_relationship.rb
+++ b/lib/familia/features/relationships/participation_relationship.rb
@@ -21,7 +21,7 @@ module Familia
         :collection_name,     # Symbol name of the collection (e.g., :members, :domains)
         :score,               # Proc/Symbol/nil - score calculator for sorted sets
         :type,                # Symbol - collection type (:sorted_set, :set, :list)
-        :bidirectional,       # Boolean/Symbol - whether to generate reverse methods
+        :generate_participant_methods,  # Boolean - whether to generate participant methods
         :through,             # Symbol/Class/nil - through model class for join table pattern
       ) do
         # Get a unique key for this participation relationship

--- a/try/features/relationships/participation_commands_verification_spec.rb
+++ b/try/features/relationships/participation_commands_verification_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe 'participation_commands_verification_try' do
       field :display_domain
       field :created_at
       participates_in ReverseIndexCustomer, :domains, score: :created_at
-      participates_in ReverseIndexCustomer, :preferred_domains, bidirectional: true
+      participates_in ReverseIndexCustomer, :preferred_domains, generate_participant_methods: true
       class_participates_in :all_domains, score: :created_at
     end
   end

--- a/try/features/relationships/participation_commands_verification_try.rb
+++ b/try/features/relationships/participation_commands_verification_try.rb
@@ -49,7 +49,7 @@ class ReverseIndexDomain < Familia::Horreum
   field :created_at
 
   participates_in ReverseIndexCustomer, :domains, score: :created_at
-  participates_in ReverseIndexCustomer, :preferred_domains, bidirectional: true
+  participates_in ReverseIndexCustomer, :preferred_domains, generate_participant_methods: true
   class_participates_in :all_domains, score: :created_at
 end
 

--- a/try/features/relationships/participation_reverse_index_try.rb
+++ b/try/features/relationships/participation_reverse_index_try.rb
@@ -28,7 +28,7 @@ class ReverseIndexDomain < Familia::Horreum
   field :created_at
 
   participates_in ReverseIndexCustomer, :domains, score: :created_at
-  participates_in ReverseIndexCustomer, :preferred_domains, bidirectional: true
+  participates_in ReverseIndexCustomer, :preferred_domains, generate_participant_methods: true
   class_participates_in :all_domains, score: :created_at
 end
 

--- a/try/features/relationships/participation_reverse_methods_try.rb
+++ b/try/features/relationships/participation_reverse_methods_try.rb
@@ -1,10 +1,10 @@
-# try/features/relationships/participation_bidirectional_try.rb
+# try/features/relationships/participation_reverse_methods_try.rb
 #
 # frozen_string_literal: true
 
 require_relative '../../../lib/familia'
 
-# Test demonstrating true bidirectional participation functionality
+# Test demonstrating reverse collection methods (generate_participant_methods: true)
 # This shows the improvement from asymmetric to symmetric relationship access
 
 # Setup test classes
@@ -51,8 +51,8 @@ class ::ProjectUser < Familia::Horreum
   field :name
   field :role
 
-  # Define bidirectional participation relationships
-  # These will auto-generate reverse collection methods with _instances suffix
+  # Define participation relationships with reverse collection methods
+  # These auto-generate methods like user.project_team_instances (when generate_participant_methods: true)
   participates_in ProjectTeam, :members          # Generates: user.project_team_instances
   participates_in ProjectTeam, :admins           # Also adds to user.project_team_instances (union)
   participates_in ProjectOrganization, :employees # Generates: user.project_organization_instances
@@ -197,13 +197,13 @@ contracting_orgs_instances.map(&:name)
 @team1.admins.to_a
 #=> [@user1.identifier]
 
-## Test bidirectional consistency - forward direction
+## Test symmetric consistency - forward direction
 team1_member_ids = @team1.members.to_a
 team1_members = ProjectUser.load_multi(team1_member_ids).compact
 team1_members.map(&:name)
 #=> ["Alice"]
 
-## Test bidirectional consistency - reverse direction
+## Test symmetric consistency - reverse direction
 user1_teams = @user1.project_team_instances
 user1_team_ids = user1_teams.map(&:identifier)
 user1_team_ids.include?(@team1.identifier)


### PR DESCRIPTION
### **User description**
## Summary

Renames the misleading `bidirectional:` parameter to `generate_participant_methods:` across participates_in and class_participates_in methods.

### Why the rename?

The old `bidirectional: true` suggested symmetric query capability, but what it actually does is control whether participant convenience methods (`add_to_*`, `in_*?`, `*_instances`, etc.) are generated. The new name explicitly describes the behavior.

### Changes

- Parameter rename in `participates_in` and `class_participates_in` method signatures
- Updated `ParticipationRelationship` Data.define attribute
- Updated all test files using the parameter
- Renamed `participation_bidirectional_try.rb` → `participation_reverse_methods_try.rb`
- Updated documentation

### Migration

```ruby
# Before
participates_in Team, :members, bidirectional: true

# After  
participates_in Team, :members, generate_participant_methods: true
```

### Test Results

All 3,068 tests pass. This is a naming-only change with no logic modifications.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Enhancement


___

### **Description**
- Rename `bidirectional:` parameter to `generate_participant_methods:` for clarity

- Update all method signatures, documentation, and test files with new parameter name

- Rename test file from `participation_bidirectional_try.rb` to `participation_reverse_methods_try.rb`

- Refresh design documentation with implementation details and through model support


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["bidirectional: parameter"] -->|"rename"| B["generate_participant_methods: parameter"]
  B -->|"controls"| C["Participant method generation"]
  C -->|"generates"| D["instance.in_target_collection?"]
  C -->|"generates"| E["instance.add_to_target_collection"]
  C -->|"generates"| F["instance.target_instances"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td><strong>relationships.rb</strong><dd><code>Update example documentation with new parameter name</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/delano/familia/pull/199/files#diff-864c2017decfc6772ec5f33dd9aeb19d9ac3da10c3301ad50e82ed1bd800b874">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>participant_methods.rb</strong><dd><code>Update comment terminology from bidirectional to symmetric</code></dd></td>
  <td><a href="https://github.com/delano/familia/pull/199/files#diff-6cfbd021acc91fc8b747d9a3563d7bbf7b14bb16f38acc60d3d89059a1baf972">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>1106-participates_in-bidirectional-solution.md</strong><dd><code>Comprehensive documentation refresh with implementation details</code></dd></td>
  <td><a href="https://github.com/delano/familia/pull/199/files#diff-df8b820d267dabc7a1f9c020089da79b977bd9b43190748cc04371bdaa138c4a">+172/-58</a></td>

</tr>

<tr>
  <td><strong>README.md</strong><dd><code>Update example to use new generate_participant_methods parameter</code></dd></td>
  <td><a href="https://github.com/delano/familia/pull/199/files#diff-04ae65e49dd349848e0a9c0276e02f504f33f1ed6d1d3253002bfe2446d3903a">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Enhancement</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>participation.rb</strong><dd><code>Rename bidirectional parameter to generate_participant_methods</code></dd></td>
  <td><a href="https://github.com/delano/familia/pull/199/files#diff-03b4b8bf9ad7ad987fc724c51931e8b964dceeff437346fd41f164ba29d14d75">+12/-12</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>participation_relationship.rb</strong><dd><code>Rename Data.define attribute from bidirectional to </code><br><code>generate_participant_methods</code></dd></td>
  <td><a href="https://github.com/delano/familia/pull/199/files#diff-9b4769f711f87ea113f56a380f6ccb76220c143567e46cd4bc1d807e69f88dc3">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td><strong>participation_commands_verification_spec.rb</strong><dd><code>Update test to use new generate_participant_methods parameter</code></dd></td>
  <td><a href="https://github.com/delano/familia/pull/199/files#diff-cea2070b0e6d6514ca65a0073939b7f103da7e5657ada7b9e38db48579b2f105">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>participation_commands_verification_try.rb</strong><dd><code>Update test to use new generate_participant_methods parameter</code></dd></td>
  <td><a href="https://github.com/delano/familia/pull/199/files#diff-e718a5b5fdc5aad1096f40ca3302cca1ec7c0dca97ffbaf13938f28f60e78660">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>participation_reverse_index_try.rb</strong><dd><code>Update test to use new generate_participant_methods parameter</code></dd></td>
  <td><a href="https://github.com/delano/familia/pull/199/files#diff-583543abefff17947218f6061d996a79e292337a5ba645011829a23a4ac01fc6">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>participation_reverse_methods_try.rb</strong><dd><code>Rename file and update comments for clarity on reverse methods</code></dd></td>
  <td><a href="https://github.com/delano/familia/pull/199/files#diff-588fc1a1224427752e579a39cb678dd37e4c6b5f4438533b271c5d4235164bc0">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tbody></table>

</details>

___

