### PR TITLE
Expand Redis 7 command coverage across all DataType classes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -62,8 +62,6 @@ repos:
     rev: v1.32.2
     hooks:
       - id: talisman-commit
-        env:
-          TALISMAN_SCAN_MODE: CI
 
   # Commit message issue tracking integration
   - repo: https://github.com/delano/add-msg-issue-prefix-hook

--- a/changelog.d/20260120_003058_delano_bit_part.rst
+++ b/changelog.d/20260120_003058_delano_bit_part.rst
@@ -1,0 +1,40 @@
+Added
+-----
+
+- Expanded Redis 7 command coverage across all DataType classes:
+
+  - **StringKey**: ``incrbyfloat``, ``getex``, ``getdel``, ``setex``, ``psetex``,
+    ``bitcount``, ``bitpos``, ``bitfield``, plus class methods ``mget``, ``mset``,
+    ``msetnx``, ``bitop`` for multi-key and bitwise operations.
+
+  - **List**: ``trim``/``ltrim``, ``set``/``lset``, ``insert``/``linsert``,
+    ``move``/``lmove``, ``pushx``/``rpushx``, ``unshiftx``/``lpushx``.
+    Updated ``pop`` and ``shift`` to support optional count parameter for batch operations.
+
+  - **UnsortedSet**: ``intersection``/``inter``, ``union``, ``difference``/``diff``,
+    ``member_any?``/``members?``, ``scan``, ``intercard``/``intersection_cardinality``,
+    ``interstore``/``intersection_store``, ``unionstore``/``union_store``,
+    ``diffstore``/``difference_store``.
+
+  - **SortedSet**: ``popmin``, ``popmax``, ``score_count``/``zcount``, ``mscore``,
+    ``union``, ``inter``, ``rangebylex``, ``revrangebylex``, ``remrangebylex``,
+    ``lexcount``, ``randmember``, ``scan``, ``unionstore``, ``interstore``,
+    ``diff``, ``diffstore``.
+
+  - **HashKey**: ``scan``/``hscan``, ``incrbyfloat``/``incrfloat``,
+    ``strlen``/``hstrlen``, ``randfield``/``hrandfield``, plus field-level TTL
+    commands (Redis 7.4+): ``expire_fields``, ``pexpire_fields``, ``expireat_fields``,
+    ``pexpireat_fields``, ``ttl_fields``, ``pttl_fields``, ``persist_fields``,
+    ``expiretime_fields``, ``pexpiretime_fields``.
+
+- Added 156 new tests across 5 test files covering all new methods.
+
+AI Assistance
+-------------
+
+- Claude Opus 4.5 analyzed Redis 7 command documentation and compared coverage
+  against existing Familia DataType implementations using parallel Explore agents.
+- Implementation performed by 5 parallel backend-dev agents, one per DataType.
+- Test coverage written by 5 parallel qa-automation-engineer agents focusing on
+  Familia-specific behavior (serialization, deserialization, aliases) rather than
+  re-testing redis-rb gem functionality.

--- a/changelog.d/20260120_003058_delano_bit_part.rst
+++ b/changelog.d/20260120_003058_delano_bit_part.rst
@@ -27,7 +27,7 @@ Added
     ``pexpireat_fields``, ``ttl_fields``, ``pttl_fields``, ``persist_fields``,
     ``expiretime_fields``, ``pexpiretime_fields``.
 
-- Added 156 new tests across 5 test files covering all new methods.
+- Added 158 new tests across 5 test files covering all new methods.
 
 AI Assistance
 -------------

--- a/changelog.d/20260417_162611_delano_bit_part.rst
+++ b/changelog.d/20260417_162611_delano_bit_part.rst
@@ -1,0 +1,18 @@
+Fixed
+-----
+
+- ``SortedSet#popmin`` and ``SortedSet#popmax`` now normalize an explicitly
+  passed ``nil`` count to the default of ``1``. Previously, calling
+  ``zset.popmin(nil)`` or ``zset.popmax(nil)`` would bypass the ``count == 1``
+  branch of the structural dispatch added in the prior commit, causing
+  redis-rb's flat ``[member, score]`` return shape to be iterated as if it
+  were a nested result — yielding a malformed pair. Omitting the argument
+  was and remains unaffected.
+
+AI Assistance
+-------------
+
+- Edge case identified by the Claude Code Review GitHub Action
+  (``.github/workflows/claude-code-review.yml``) when reviewing the
+  structural-dispatch change in commit ``010d5be``. Fix drafted and verified
+  by Claude Opus 4.7 under supervision.

--- a/lib/familia/data_type/types/hashkey.rb
+++ b/lib/familia/data_type/types/hashkey.rb
@@ -184,7 +184,9 @@ module Familia
     #   my_hash.incrbyfloat('temperature', 0.5)  #=> 23.5
     #   my_hash.incrbyfloat('temperature', -1.2) #=> 22.3
     def incrbyfloat(field, by)
-      dbclient.hincrbyfloat(dbkey, field.to_s, by).to_f
+      ret = dbclient.hincrbyfloat(dbkey, field.to_s, by).to_f
+      update_expiration
+      ret
     end
     alias incrfloat incrbyfloat
 

--- a/lib/familia/data_type/types/hashkey.rb
+++ b/lib/familia/data_type/types/hashkey.rb
@@ -141,6 +141,244 @@ module Familia
       deserialize_values(*elements)
     end
 
+    # Incrementally iterates over fields in the hash using cursor-based iteration.
+    # This is more memory-efficient than `hgetall` for large hashes.
+    #
+    # @param cursor [Integer] The cursor position to start from (0 for initial call)
+    # @param match [String, nil] Optional glob-style pattern to filter field names
+    # @param count [Integer, nil] Optional hint for number of elements to return per call
+    # @return [Array<String, Hash>] A two-element array: [new_cursor, {field => value, ...}]
+    #   When new_cursor is "0", iteration is complete.
+    #
+    # @example Basic iteration
+    #   cursor = 0
+    #   loop do
+    #     cursor, results = my_hash.scan(cursor)
+    #     results.each { |field, value| puts "#{field}: #{value}" }
+    #     break if cursor == "0"
+    #   end
+    #
+    # @example With pattern matching
+    #   cursor, results = my_hash.scan(0, match: "user:*", count: 100)
+    def scan(cursor = 0, match: nil, count: nil)
+      args = [dbkey, cursor]
+      args += ['MATCH', match] if match
+      args += ['COUNT', count] if count
+
+      new_cursor, pairs = dbclient.hscan(*args)
+
+      # pairs is an array of [field, value] pairs, convert to hash with deserialization
+      result_hash = pairs.to_h.transform_values { |v| deserialize_value(v) }
+
+      [new_cursor, result_hash]
+    end
+    alias hscan scan
+
+    # Increments the float value of a hash field by the given amount.
+    #
+    # @param field [String] The field name
+    # @param by [Float, Integer] The amount to increment by (can be negative)
+    # @return [Float] The new value after incrementing
+    #
+    # @example
+    #   my_hash.incrbyfloat('temperature', 0.5)  #=> 23.5
+    #   my_hash.incrbyfloat('temperature', -1.2) #=> 22.3
+    def incrbyfloat(field, by)
+      dbclient.hincrbyfloat(dbkey, field.to_s, by).to_f
+    end
+    alias incrfloat incrbyfloat
+
+    # Returns the string length of the value associated with field.
+    #
+    # @param field [String] The field name
+    # @return [Integer] The length of the value in bytes, or 0 if field does not exist
+    #
+    # @example
+    #   my_hash['name'] = 'Alice'
+    #   my_hash.strlen('name')  #=> 7 (includes JSON quotes: "Alice")
+    def strlen(field)
+      dbclient.hstrlen(dbkey, field.to_s)
+    end
+    alias hstrlen strlen
+
+    # Returns one or more random fields from the hash.
+    #
+    # @param count [Integer, nil] Number of fields to return. If nil, returns a single field.
+    #   If positive, returns distinct fields. If negative, allows duplicates.
+    # @param withvalues [Boolean] If true, returns fields with their values
+    # @return [String, Array<String>, Array<Array>] Depending on arguments:
+    #   - No count: single field name (or nil if hash is empty)
+    #   - With count: array of field names
+    #   - With count and withvalues: array of [field, value] pairs
+    #
+    # @example Get a single random field
+    #   my_hash.randfield  #=> "some_field"
+    #
+    # @example Get 3 distinct random fields
+    #   my_hash.randfield(3)  #=> ["field1", "field2", "field3"]
+    #
+    # @example Get 2 random fields with values
+    #   my_hash.randfield(2, withvalues: true)  #=> [["field1", value1], ["field2", value2]]
+    def randfield(count = nil, withvalues: false)
+      if count.nil?
+        dbclient.hrandfield(dbkey)
+      elsif withvalues
+        pairs = dbclient.hrandfield(dbkey, count, 'WITHVALUES')
+        # pairs is array of [field, value, field, value, ...]
+        # Convert to array of [field, deserialized_value] pairs
+        pairs.each_slice(2).map { |field, val| [field, deserialize_value(val)] }
+      else
+        dbclient.hrandfield(dbkey, count)
+      end
+    end
+    alias hrandfield randfield
+
+    # -----------------------------------------------------------------------
+    # Field-Level Expiration Methods (Redis 7.4+)
+    #
+    # These methods require Redis/Valkey 7.4 or later. They allow setting
+    # TTL on individual hash fields rather than the entire key.
+    # -----------------------------------------------------------------------
+
+    # Sets expiration time in seconds on one or more hash fields.
+    # @note Requires Redis 7.4+
+    #
+    # @param seconds [Integer] TTL in seconds
+    # @param fields [Array<String>] One or more field names
+    # @return [Array<Integer>] Array of results for each field:
+    #   -2 if field does not exist, 1 if expiration was set,
+    #   0 if expiration was not set (e.g., field has no expiration)
+    #
+    # @example Set 1 hour TTL on specific fields
+    #   my_hash.expire_fields(3600, 'session_token', 'temp_data')
+    def expire_fields(seconds, *fields)
+      string_fields = fields.flatten.compact.map(&:to_s)
+      dbclient.call('HEXPIRE', dbkey, seconds, 'FIELDS', string_fields.size, *string_fields)
+    end
+    alias hexpire expire_fields
+
+    # Sets expiration time in milliseconds on one or more hash fields.
+    # @note Requires Redis 7.4+
+    #
+    # @param milliseconds [Integer] TTL in milliseconds
+    # @param fields [Array<String>] One or more field names
+    # @return [Array<Integer>] Array of results for each field
+    #
+    # @example Set 500ms TTL on a field
+    #   my_hash.pexpire_fields(500, 'rate_limit_counter')
+    def pexpire_fields(milliseconds, *fields)
+      string_fields = fields.flatten.compact.map(&:to_s)
+      dbclient.call('HPEXPIRE', dbkey, milliseconds, 'FIELDS', string_fields.size, *string_fields)
+    end
+    alias hpexpire pexpire_fields
+
+    # Sets absolute expiration time (Unix timestamp in seconds) on hash fields.
+    # @note Requires Redis 7.4+
+    #
+    # @param unix_time [Integer] Absolute Unix timestamp in seconds
+    # @param fields [Array<String>] One or more field names
+    # @return [Array<Integer>] Array of results for each field
+    #
+    # @example Expire fields at midnight tonight
+    #   midnight = Time.now.to_i + (24 * 60 * 60)
+    #   my_hash.expireat_fields(midnight, 'daily_counter')
+    def expireat_fields(unix_time, *fields)
+      string_fields = fields.flatten.compact.map(&:to_s)
+      dbclient.call('HEXPIREAT', dbkey, unix_time, 'FIELDS', string_fields.size, *string_fields)
+    end
+    alias hexpireat expireat_fields
+
+    # Sets absolute expiration time (Unix timestamp in milliseconds) on hash fields.
+    # @note Requires Redis 7.4+
+    #
+    # @param unix_time_ms [Integer] Absolute Unix timestamp in milliseconds
+    # @param fields [Array<String>] One or more field names
+    # @return [Array<Integer>] Array of results for each field
+    #
+    # @example Expire field at a precise millisecond
+    #   my_hash.pexpireat_fields(1700000000000, 'precise_data')
+    def pexpireat_fields(unix_time_ms, *fields)
+      string_fields = fields.flatten.compact.map(&:to_s)
+      dbclient.call('HPEXPIREAT', dbkey, unix_time_ms, 'FIELDS', string_fields.size, *string_fields)
+    end
+    alias hpexpireat pexpireat_fields
+
+    # Returns the remaining TTL in seconds for one or more hash fields.
+    # @note Requires Redis 7.4+
+    #
+    # @param fields [Array<String>] One or more field names
+    # @return [Array<Integer>] Array of TTL values for each field:
+    #   -2 if field does not exist, -1 if field has no expiration,
+    #   otherwise the TTL in seconds
+    #
+    # @example Check remaining TTL on fields
+    #   my_hash.ttl_fields('session_token', 'temp_data')  #=> [3600, -1]
+    def ttl_fields(*fields)
+      string_fields = fields.flatten.compact.map(&:to_s)
+      dbclient.call('HTTL', dbkey, 'FIELDS', string_fields.size, *string_fields)
+    end
+    alias httl ttl_fields
+
+    # Returns the remaining TTL in milliseconds for one or more hash fields.
+    # @note Requires Redis 7.4+
+    #
+    # @param fields [Array<String>] One or more field names
+    # @return [Array<Integer>] Array of TTL values in milliseconds
+    #
+    # @example Check remaining TTL in milliseconds
+    #   my_hash.pttl_fields('rate_limit')  #=> [450]
+    def pttl_fields(*fields)
+      string_fields = fields.flatten.compact.map(&:to_s)
+      dbclient.call('HPTTL', dbkey, 'FIELDS', string_fields.size, *string_fields)
+    end
+    alias hpttl pttl_fields
+
+    # Removes expiration from one or more hash fields.
+    # @note Requires Redis 7.4+
+    #
+    # @param fields [Array<String>] One or more field names
+    # @return [Array<Integer>] Array of results for each field:
+    #   -2 if field does not exist, -1 if field has no expiration,
+    #   1 if expiration was removed
+    #
+    # @example Remove expiration from fields
+    #   my_hash.persist_fields('important_data')  #=> [1]
+    def persist_fields(*fields)
+      string_fields = fields.flatten.compact.map(&:to_s)
+      dbclient.call('HPERSIST', dbkey, 'FIELDS', string_fields.size, *string_fields)
+    end
+    alias hpersist persist_fields
+
+    # Returns the absolute Unix expiration timestamp in seconds for hash fields.
+    # @note Requires Redis 7.4+
+    #
+    # @param fields [Array<String>] One or more field names
+    # @return [Array<Integer>] Array of timestamps for each field:
+    #   -2 if field does not exist, -1 if field has no expiration,
+    #   otherwise the absolute Unix timestamp in seconds
+    #
+    # @example Get expiration timestamp
+    #   my_hash.expiretime_fields('session')  #=> [1700000000]
+    def expiretime_fields(*fields)
+      string_fields = fields.flatten.compact.map(&:to_s)
+      dbclient.call('HEXPIRETIME', dbkey, 'FIELDS', string_fields.size, *string_fields)
+    end
+    alias hexpiretime expiretime_fields
+
+    # Returns the absolute Unix expiration timestamp in milliseconds for hash fields.
+    # @note Requires Redis 7.4+
+    #
+    # @param fields [Array<String>] One or more field names
+    # @return [Array<Integer>] Array of timestamps in milliseconds
+    #
+    # @example Get precise expiration timestamp
+    #   my_hash.pexpiretime_fields('session')  #=> [1700000000000]
+    def pexpiretime_fields(*fields)
+      string_fields = fields.flatten.compact.map(&:to_s)
+      dbclient.call('HPEXPIRETIME', dbkey, 'FIELDS', string_fields.size, *string_fields)
+    end
+    alias hpexpiretime pexpiretime_fields
+
     # The Great Database Refresh-o-matic 3000 for HashKey!
     #
     # This method performs a complete refresh of the hash's state from the database.

--- a/lib/familia/data_type/types/hashkey.rb
+++ b/lib/familia/data_type/types/hashkey.rb
@@ -252,8 +252,7 @@ module Familia
     # @example Set 1 hour TTL on specific fields
     #   my_hash.expire_fields(3600, 'session_token', 'temp_data')
     def expire_fields(seconds, *fields)
-      string_fields = fields.flatten.compact.map(&:to_s)
-      dbclient.call('HEXPIRE', dbkey, seconds, 'FIELDS', string_fields.size, *string_fields)
+      call_hash_field_command('HEXPIRE', seconds, fields: fields)
     end
     alias hexpire expire_fields
 
@@ -267,8 +266,7 @@ module Familia
     # @example Set 500ms TTL on a field
     #   my_hash.pexpire_fields(500, 'rate_limit_counter')
     def pexpire_fields(milliseconds, *fields)
-      string_fields = fields.flatten.compact.map(&:to_s)
-      dbclient.call('HPEXPIRE', dbkey, milliseconds, 'FIELDS', string_fields.size, *string_fields)
+      call_hash_field_command('HPEXPIRE', milliseconds, fields: fields)
     end
     alias hpexpire pexpire_fields
 
@@ -283,8 +281,7 @@ module Familia
     #   midnight = Time.now.to_i + (24 * 60 * 60)
     #   my_hash.expireat_fields(midnight, 'daily_counter')
     def expireat_fields(unix_time, *fields)
-      string_fields = fields.flatten.compact.map(&:to_s)
-      dbclient.call('HEXPIREAT', dbkey, unix_time, 'FIELDS', string_fields.size, *string_fields)
+      call_hash_field_command('HEXPIREAT', unix_time, fields: fields)
     end
     alias hexpireat expireat_fields
 
@@ -298,8 +295,7 @@ module Familia
     # @example Expire field at a precise millisecond
     #   my_hash.pexpireat_fields(1700000000000, 'precise_data')
     def pexpireat_fields(unix_time_ms, *fields)
-      string_fields = fields.flatten.compact.map(&:to_s)
-      dbclient.call('HPEXPIREAT', dbkey, unix_time_ms, 'FIELDS', string_fields.size, *string_fields)
+      call_hash_field_command('HPEXPIREAT', unix_time_ms, fields: fields)
     end
     alias hpexpireat pexpireat_fields
 
@@ -314,8 +310,7 @@ module Familia
     # @example Check remaining TTL on fields
     #   my_hash.ttl_fields('session_token', 'temp_data')  #=> [3600, -1]
     def ttl_fields(*fields)
-      string_fields = fields.flatten.compact.map(&:to_s)
-      dbclient.call('HTTL', dbkey, 'FIELDS', string_fields.size, *string_fields)
+      call_hash_field_command('HTTL', fields: fields)
     end
     alias httl ttl_fields
 
@@ -328,8 +323,7 @@ module Familia
     # @example Check remaining TTL in milliseconds
     #   my_hash.pttl_fields('rate_limit')  #=> [450]
     def pttl_fields(*fields)
-      string_fields = fields.flatten.compact.map(&:to_s)
-      dbclient.call('HPTTL', dbkey, 'FIELDS', string_fields.size, *string_fields)
+      call_hash_field_command('HPTTL', fields: fields)
     end
     alias hpttl pttl_fields
 
@@ -344,8 +338,7 @@ module Familia
     # @example Remove expiration from fields
     #   my_hash.persist_fields('important_data')  #=> [1]
     def persist_fields(*fields)
-      string_fields = fields.flatten.compact.map(&:to_s)
-      dbclient.call('HPERSIST', dbkey, 'FIELDS', string_fields.size, *string_fields)
+      call_hash_field_command('HPERSIST', fields: fields)
     end
     alias hpersist persist_fields
 
@@ -360,8 +353,7 @@ module Familia
     # @example Get expiration timestamp
     #   my_hash.expiretime_fields('session')  #=> [1700000000]
     def expiretime_fields(*fields)
-      string_fields = fields.flatten.compact.map(&:to_s)
-      dbclient.call('HEXPIRETIME', dbkey, 'FIELDS', string_fields.size, *string_fields)
+      call_hash_field_command('HEXPIRETIME', fields: fields)
     end
     alias hexpiretime expiretime_fields
 
@@ -374,10 +366,25 @@ module Familia
     # @example Get precise expiration timestamp
     #   my_hash.pexpiretime_fields('session')  #=> [1700000000000]
     def pexpiretime_fields(*fields)
-      string_fields = fields.flatten.compact.map(&:to_s)
-      dbclient.call('HPEXPIRETIME', dbkey, 'FIELDS', string_fields.size, *string_fields)
+      call_hash_field_command('HPEXPIRETIME', fields: fields)
     end
     alias hpexpiretime pexpiretime_fields
+
+    private
+
+    # Executes a hash field command with the FIELDS syntax.
+    # Used internally by field-level TTL methods (Redis 7.4+).
+    #
+    # @param command [String] Redis command name (e.g., 'HEXPIRE', 'HTTL')
+    # @param prefix_args [Array] Arguments to place before 'FIELDS' (e.g., TTL value)
+    # @param fields [Array<String>] Field names
+    # @return [Array] Command result
+    def call_hash_field_command(command, *prefix_args, fields:)
+      string_fields = fields.flatten.compact.map(&:to_s)
+      dbclient.call(command, dbkey, *prefix_args, 'FIELDS', string_fields.size, *string_fields)
+    end
+
+    public
 
     # The Great Database Refresh-o-matic 3000 for HashKey!
     #

--- a/lib/familia/data_type/types/hashkey.rb
+++ b/lib/familia/data_type/types/hashkey.rb
@@ -161,11 +161,11 @@ module Familia
     # @example With pattern matching
     #   cursor, results = my_hash.scan(0, match: "user:*", count: 100)
     def scan(cursor = 0, match: nil, count: nil)
-      args = [dbkey, cursor]
-      args += ['MATCH', match] if match
-      args += ['COUNT', count] if count
+      opts = {}
+      opts[:match] = match if match
+      opts[:count] = count if count
 
-      new_cursor, pairs = dbclient.hscan(*args)
+      new_cursor, pairs = dbclient.hscan(dbkey, cursor, **opts)
 
       # pairs is an array of [field, value] pairs, convert to hash with deserialization
       result_hash = pairs.to_h.transform_values { |v| deserialize_value(v) }
@@ -223,7 +223,7 @@ module Familia
       if count.nil?
         dbclient.hrandfield(dbkey)
       elsif withvalues
-        pairs = dbclient.hrandfield(dbkey, count, 'WITHVALUES')
+        pairs = dbclient.hrandfield(dbkey, count, withvalues: true)
         # pairs is array of [field, value, field, value, ...]
         # Convert to array of [field, deserialized_value] pairs
         pairs.each_slice(2).map { |field, val| [field, deserialize_value(val)] }

--- a/lib/familia/data_type/types/hashkey.rb
+++ b/lib/familia/data_type/types/hashkey.rb
@@ -147,15 +147,15 @@ module Familia
     # @param cursor [Integer] The cursor position to start from (0 for initial call)
     # @param match [String, nil] Optional glob-style pattern to filter field names
     # @param count [Integer, nil] Optional hint for number of elements to return per call
-    # @return [Array<String, Hash>] A two-element array: [new_cursor, {field => value, ...}]
-    #   When new_cursor is "0", iteration is complete.
+    # @return [Array<Integer, Hash>] A two-element array: [new_cursor, {field => value, ...}]
+    #   When new_cursor is 0, iteration is complete.
     #
     # @example Basic iteration
     #   cursor = 0
     #   loop do
     #     cursor, results = my_hash.scan(cursor)
     #     results.each { |field, value| puts "#{field}: #{value}" }
-    #     break if cursor == "0"
+    #     break if cursor == 0
     #   end
     #
     # @example With pattern matching
@@ -170,7 +170,7 @@ module Familia
       # pairs is an array of [field, value] pairs, convert to hash with deserialization
       result_hash = pairs.to_h.transform_values { |v| deserialize_value(v) }
 
-      [new_cursor, result_hash]
+      [new_cursor.to_i, result_hash]
     end
     alias hscan scan
 

--- a/lib/familia/data_type/types/listkey.rb
+++ b/lib/familia/data_type/types/listkey.rb
@@ -49,16 +49,32 @@ module Familia
     end
     alias prepend unshift
 
-    def pop
+    # Removes and returns the last element(s) from the list
+    # @param count [Integer, nil] Number of elements to pop (Redis 6.2+)
+    # @return [Object, Array<Object>, nil] Single element or array if count specified
+    def pop(count = nil)
       warn_if_dirty!
-      ret = deserialize_value dbclient.rpop(dbkey)
+      ret = if count
+              result = dbclient.rpop(dbkey, count)
+              result.nil? ? nil : deserialize_values(*result)
+            else
+              deserialize_value dbclient.rpop(dbkey)
+            end
       update_expiration
       ret
     end
 
-    def shift
+    # Removes and returns the first element(s) from the list
+    # @param count [Integer, nil] Number of elements to shift (Redis 6.2+)
+    # @return [Object, Array<Object>, nil] Single element or array if count specified
+    def shift(count = nil)
       warn_if_dirty!
-      ret = deserialize_value dbclient.lpop(dbkey)
+      ret = if count
+              result = dbclient.lpop(dbkey, count)
+              result.nil? ? nil : deserialize_values(*result)
+            else
+              deserialize_value dbclient.lpop(dbkey)
+            end
       update_expiration
       ret
     end
@@ -151,6 +167,92 @@ module Familia
     def at(idx)
       deserialize_value dbclient.lindex(dbkey, idx)
     end
+
+    # Trims the list to the specified range
+    # @param start [Integer] Start index (0-based, negative counts from end)
+    # @param stop [Integer] End index (inclusive, negative counts from end)
+    # @return [String] "OK" on success
+    def trim(start, stop)
+      dbclient.ltrim dbkey, start, stop
+    end
+    alias ltrim trim
+
+    # Sets the element at the specified index
+    # @param index [Integer] Index to set (0-based, negative counts from end)
+    # @param value The value to set
+    # @return [String] "OK" on success
+    # @raise [Redis::CommandError] if index is out of range
+    def set(index, value)
+      result = dbclient.lset dbkey, index, serialize_value(value)
+      update_expiration
+      result
+    end
+    alias lset set
+
+    # Inserts an element before or after a pivot element
+    # @param position [:before, :after] Where to insert relative to pivot
+    # @param pivot The pivot element to search for
+    # @param value The value to insert
+    # @return [Integer] Length of list after insert, or -1 if pivot not found
+    def insert(position, pivot, value)
+      pos = case position
+            when :before, 'BEFORE' then 'BEFORE'
+            when :after, 'AFTER' then 'AFTER'
+            else
+              raise ArgumentError, "position must be :before or :after, got #{position.inspect}"
+            end
+      result = dbclient.linsert dbkey, pos, serialize_value(pivot), serialize_value(value)
+      update_expiration if result.positive?
+      result
+    end
+    alias linsert insert
+
+    # Moves an element from this list to another list atomically
+    # @param destination [ListKey, String] Destination list (ListKey or key string)
+    # @param wherefrom [:left, :right] Which end to pop from source
+    # @param whereto [:left, :right] Which end to push to destination
+    # @return [Object, nil] The moved element, or nil if source is empty
+    def move(destination, wherefrom, whereto)
+      dest_key = destination.respond_to?(:dbkey) ? destination.dbkey : destination
+      from = wherefrom.to_s.upcase
+      to = whereto.to_s.upcase
+
+      unless %w[LEFT RIGHT].include?(from) && %w[LEFT RIGHT].include?(to)
+        raise ArgumentError, 'wherefrom and whereto must be :left or :right'
+      end
+
+      result = dbclient.lmove dbkey, dest_key, from, to
+      deserialize_value result
+    end
+    alias lmove move
+
+    # Pushes values only if the list already exists
+    # @param values Values to push to the tail of the list
+    # @return [Integer] Length of list after push, or 0 if list doesn't exist
+    def pushx(*values)
+      return 0 if values.empty?
+
+      result = values.flatten.compact.reduce(0) do |len, v|
+        dbclient.rpushx dbkey, serialize_value(v)
+      end
+      update_expiration if result.positive?
+      result
+    end
+    alias rpushx pushx
+
+    # Pushes values to the head only if the list already exists
+    # @param values Values to push to the head of the list
+    # @return [Integer] Length of list after push, or 0 if list doesn't exist
+    def unshiftx(*values)
+      return 0 if values.empty?
+
+      result = values.flatten.compact.reduce(0) do |len, v|
+        dbclient.lpushx dbkey, serialize_value(v)
+      end
+      update_expiration if result.positive?
+      result
+    end
+    alias lpushx unshiftx
 
     def first
       at 0

--- a/lib/familia/data_type/types/listkey.rb
+++ b/lib/familia/data_type/types/listkey.rb
@@ -173,7 +173,10 @@ module Familia
     # @param stop [Integer] End index (inclusive, negative counts from end)
     # @return [String] "OK" on success
     def trim(start, stop)
-      dbclient.ltrim dbkey, start, stop
+      warn_if_dirty!
+      result = dbclient.ltrim dbkey, start, stop
+      update_expiration
+      result
     end
     alias ltrim trim
 
@@ -183,6 +186,7 @@ module Familia
     # @return [String] "OK" on success
     # @raise [Redis::CommandError] if index is out of range
     def set(index, value)
+      warn_if_dirty!
       result = dbclient.lset dbkey, index, serialize_value(value)
       update_expiration
       result
@@ -195,6 +199,7 @@ module Familia
     # @param value The value to insert
     # @return [Integer] Length of list after insert, or -1 if pivot not found
     def insert(position, pivot, value)
+      warn_if_dirty!
       pos = case position
             when :before, 'BEFORE' then 'BEFORE'
             when :after, 'AFTER' then 'AFTER'
@@ -213,6 +218,7 @@ module Familia
     # @param whereto [:left, :right] Which end to push to destination
     # @return [Object, nil] The moved element, or nil if source is empty
     def move(destination, wherefrom, whereto)
+      warn_if_dirty!
       dest_key = destination.respond_to?(:dbkey) ? destination.dbkey : destination
       from = wherefrom.to_s.upcase
       to = whereto.to_s.upcase
@@ -222,6 +228,7 @@ module Familia
       end
 
       result = dbclient.lmove dbkey, dest_key, from, to
+      update_expiration
       deserialize_value result
     end
     alias lmove move
@@ -235,6 +242,7 @@ module Familia
       serialized_values = values.flatten.compact.map { |v| serialize_value(v) }
       return 0 if serialized_values.empty?
 
+      warn_if_dirty!
       result = dbclient.rpushx(dbkey, serialized_values)
       update_expiration if result.positive?
       result
@@ -250,6 +258,7 @@ module Familia
       serialized_values = values.flatten.compact.map { |v| serialize_value(v) }
       return 0 if serialized_values.empty?
 
+      warn_if_dirty!
       result = dbclient.lpushx(dbkey, serialized_values)
       update_expiration if result.positive?
       result

--- a/lib/familia/data_type/types/listkey.rb
+++ b/lib/familia/data_type/types/listkey.rb
@@ -232,9 +232,10 @@ module Familia
     def pushx(*values)
       return 0 if values.empty?
 
-      result = values.flatten.compact.reduce(0) do |len, v|
-        dbclient.rpushx dbkey, serialize_value(v)
-      end
+      serialized_values = values.flatten.compact.map { |v| serialize_value(v) }
+      return 0 if serialized_values.empty?
+
+      result = dbclient.rpushx(dbkey, serialized_values)
       update_expiration if result.positive?
       result
     end
@@ -246,9 +247,10 @@ module Familia
     def unshiftx(*values)
       return 0 if values.empty?
 
-      result = values.flatten.compact.reduce(0) do |len, v|
-        dbclient.lpushx dbkey, serialize_value(v)
-      end
+      serialized_values = values.flatten.compact.map { |v| serialize_value(v) }
+      return 0 if serialized_values.empty?
+
+      result = dbclient.lpushx(dbkey, serialized_values)
       update_expiration if result.positive?
       result
     end

--- a/lib/familia/data_type/types/sorted_set.rb
+++ b/lib/familia/data_type/types/sorted_set.rb
@@ -319,8 +319,373 @@ module Familia
       at(-1)
     end
 
+    # Removes and returns the member(s) with the lowest score(s).
+    #
+    # @param count [Integer] Number of members to pop (default: 1)
+    # @return [Array, nil] Array of [member, score] pairs, or single pair if count=1,
+    #   or nil if set is empty
+    #
+    # @example Pop single lowest-scoring member
+    #   zset.popmin  #=> ["member1", 1.0]
+    #
+    # @example Pop multiple lowest-scoring members
+    #   zset.popmin(3)  #=> [["member1", 1.0], ["member2", 2.0], ["member3", 3.0]]
+    #
+    def popmin(count = 1)
+      result = dbclient.zpopmin(dbkey, count)
+      return nil if result.nil? || result.empty?
+
+      update_expiration
+
+      if count == 1 && result.is_a?(Array) && result.length == 2 && !result[0].is_a?(Array)
+        # Single result: [member, score]
+        [deserialize_value(result[0]), result[1].to_f]
+      else
+        # Multiple results: [[member, score], ...]
+        result.map { |member, score| [deserialize_value(member), score.to_f] }
+      end
+    end
+
+    # Removes and returns the member(s) with the highest score(s).
+    #
+    # @param count [Integer] Number of members to pop (default: 1)
+    # @return [Array, nil] Array of [member, score] pairs, or single pair if count=1,
+    #   or nil if set is empty
+    #
+    # @example Pop single highest-scoring member
+    #   zset.popmax  #=> ["member1", 100.0]
+    #
+    # @example Pop multiple highest-scoring members
+    #   zset.popmax(3)  #=> [["member3", 100.0], ["member2", 90.0], ["member1", 80.0]]
+    #
+    def popmax(count = 1)
+      result = dbclient.zpopmax(dbkey, count)
+      return nil if result.nil? || result.empty?
+
+      update_expiration
+
+      if count == 1 && result.is_a?(Array) && result.length == 2 && !result[0].is_a?(Array)
+        # Single result: [member, score]
+        [deserialize_value(result[0]), result[1].to_f]
+      else
+        # Multiple results: [[member, score], ...]
+        result.map { |member, score| [deserialize_value(member), score.to_f] }
+      end
+    end
+
+    # Counts members within a score range.
+    #
+    # @param min [Numeric, String] Minimum score (use '-inf' for unbounded)
+    # @param max [Numeric, String] Maximum score (use '+inf' for unbounded)
+    # @return [Integer] Number of members with scores in the range
+    #
+    # @example Count members with scores between 10 and 100
+    #   zset.score_count(10, 100)  #=> 5
+    #
+    # @example Count members with scores up to 50
+    #   zset.score_count('-inf', 50)  #=> 3
+    #
+    def score_count(min, max)
+      dbclient.zcount(dbkey, min, max)
+    end
+    alias zcount score_count
+
+    # Gets scores for multiple members at once.
+    #
+    # @param members [Array<Object>] Members to get scores for
+    # @return [Array<Float, nil>] Scores for each member (nil if member doesn't exist)
+    #
+    # @example Get scores for multiple members
+    #   zset.mscore('member1', 'member2', 'member3')  #=> [1.0, 2.0, nil]
+    #
+    def mscore(*members)
+      return [] if members.empty?
+
+      serialized = members.map { |m| serialize_value(m) }
+      result = dbclient.zmscore(dbkey, *serialized)
+      result.map { |s| s&.to_f }
+    end
+
+    # Returns the union of this sorted set with other sorted sets.
+    #
+    # @param other_sets [Array<SortedSet, String>] Other sorted sets or key names
+    # @param weights [Array<Numeric>, nil] Multiplication factors for each set's scores
+    # @param aggregate [Symbol, nil] How to aggregate scores (:sum, :min, :max)
+    # @return [Array] Array of members (or [member, score] pairs with withscores)
+    #
+    # @example Union of two sorted sets
+    #   zset.union(other_zset)  #=> ["member1", "member2", "member3"]
+    #
+    # @example Union with weighted scores
+    #   zset.union(other_zset, weights: [1, 2])
+    #
+    # @example Union with score aggregation
+    #   zset.union(other_zset, aggregate: :max)
+    #
+    def union(*other_sets, weights: nil, aggregate: nil, withscores: false)
+      keys = [dbkey] + resolve_set_keys(other_sets)
+      opts = build_set_operation_opts(weights: weights, aggregate: aggregate, withscores: withscores)
+
+      result = dbclient.zunion(*keys, **opts)
+      process_set_operation_result(result, withscores: withscores)
+    end
+
+    # Returns the intersection of this sorted set with other sorted sets.
+    #
+    # @param other_sets [Array<SortedSet, String>] Other sorted sets or key names
+    # @param weights [Array<Numeric>, nil] Multiplication factors for each set's scores
+    # @param aggregate [Symbol, nil] How to aggregate scores (:sum, :min, :max)
+    # @return [Array] Array of members (or [member, score] pairs with withscores)
+    #
+    # @example Intersection of two sorted sets
+    #   zset.inter(other_zset)  #=> ["common_member"]
+    #
+    def inter(*other_sets, weights: nil, aggregate: nil, withscores: false)
+      keys = [dbkey] + resolve_set_keys(other_sets)
+      opts = build_set_operation_opts(weights: weights, aggregate: aggregate, withscores: withscores)
+
+      result = dbclient.zinter(*keys, **opts)
+      process_set_operation_result(result, withscores: withscores)
+    end
+
+    # Returns members in a lexicographical range (requires all members have same score).
+    #
+    # @param min [String] Minimum lex value (use '-' for unbounded, '[' or '(' prefix for inclusive/exclusive)
+    # @param max [String] Maximum lex value (use '+' for unbounded, '[' or '(' prefix for inclusive/exclusive)
+    # @param limit [Array<Integer>, nil] [offset, count] for pagination
+    # @return [Array] Members in the lexicographical range
+    #
+    # @example Get members between 'a' and 'z' (inclusive)
+    #   zset.rangebylex('[a', '[z')  #=> ["apple", "banana", "cherry"]
+    #
+    # @example Get first 10 members starting with 'a'
+    #   zset.rangebylex('[a', '(b', limit: [0, 10])
+    #
+    def rangebylex(min, max, limit: nil)
+      args = [dbkey, min, max]
+      args.push(:limit, *limit) if limit
+
+      result = dbclient.zrangebylex(*args)
+      deserialize_values(*result)
+    end
+
+    # Returns members in reverse lexicographical range.
+    #
+    # @param max [String] Maximum lex value (use '+' for unbounded)
+    # @param min [String] Minimum lex value (use '-' for unbounded)
+    # @param limit [Array<Integer>, nil] [offset, count] for pagination
+    # @return [Array] Members in reverse lexicographical range
+    #
+    def revrangebylex(max, min, limit: nil)
+      args = [dbkey, max, min]
+      args.push(:limit, *limit) if limit
+
+      result = dbclient.zrevrangebylex(*args)
+      deserialize_values(*result)
+    end
+
+    # Removes members in a lexicographical range.
+    #
+    # @param min [String] Minimum lex value
+    # @param max [String] Maximum lex value
+    # @return [Integer] Number of members removed
+    #
+    def remrangebylex(min, max)
+      result = dbclient.zremrangebylex(dbkey, min, max)
+      update_expiration
+      result
+    end
+
+    # Counts members in a lexicographical range.
+    #
+    # @param min [String] Minimum lex value
+    # @param max [String] Maximum lex value
+    # @return [Integer] Number of members in the range
+    #
+    def lexcount(min, max)
+      dbclient.zlexcount(dbkey, min, max)
+    end
+
+    # Returns random member(s) from the sorted set.
+    #
+    # @param count [Integer, nil] Number of members to return (nil for single member)
+    # @param withscores [Boolean] Whether to include scores in result
+    # @return [Object, Array, nil] Random member(s), or nil if set is empty
+    #
+    # @example Get single random member
+    #   zset.randmember  #=> "member1"
+    #
+    # @example Get 3 random members
+    #   zset.randmember(3)  #=> ["member1", "member2", "member3"]
+    #
+    # @example Get random member with score
+    #   zset.randmember(1, withscores: true)  #=> [["member1", 1.0]]
+    #
+    def randmember(count = nil, withscores: false)
+      if count.nil?
+        result = dbclient.zrandmember(dbkey)
+        return nil if result.nil?
+
+        deserialize_value(result)
+      else
+        result = if withscores
+          dbclient.zrandmember(dbkey, count, withscores: true)
+        else
+          dbclient.zrandmember(dbkey, count)
+        end
+
+        return [] if result.nil? || result.empty?
+
+        if withscores
+          result.map { |member, score| [deserialize_value(member), score.to_f] }
+        else
+          deserialize_values(*result)
+        end
+      end
+    end
+
+    # Iterates over members using cursor-based scanning.
+    #
+    # @param cursor [Integer] Cursor position (0 to start)
+    # @param match [String, nil] Pattern to match member names
+    # @param count [Integer, nil] Hint for number of elements to return per call
+    # @return [Array] [new_cursor, [[member, score], ...]]
+    #
+    # @example Scan all members
+    #   cursor = 0
+    #   loop do
+    #     cursor, members = zset.scan(cursor)
+    #     members.each { |member, score| puts "#{member}: #{score}" }
+    #     break if cursor == 0
+    #   end
+    #
+    # @example Scan with pattern matching
+    #   cursor, members = zset.scan(0, match: 'user:*', count: 100)
+    #
+    def scan(cursor = 0, match: nil, count: nil)
+      opts = {}
+      opts[:match] = match if match
+      opts[:count] = count if count
+
+      new_cursor, result = dbclient.zscan(dbkey, cursor, **opts)
+
+      members = result.map { |member, score| [deserialize_value(member), score.to_f] }
+      [new_cursor.to_i, members]
+    end
+
+    # Stores the union of sorted sets into a destination key.
+    #
+    # @param destination [String] Destination key name
+    # @param other_sets [Array<SortedSet, String>] Other sorted sets or key names
+    # @param weights [Array<Numeric>, nil] Multiplication factors for each set's scores
+    # @param aggregate [Symbol, nil] How to aggregate scores (:sum, :min, :max)
+    # @return [Integer] Number of elements in the resulting sorted set
+    #
+    def unionstore(destination, *other_sets, weights: nil, aggregate: nil)
+      keys = [dbkey] + resolve_set_keys(other_sets)
+      opts = build_set_operation_opts(weights: weights, aggregate: aggregate)
+
+      dbclient.zunionstore(destination, keys, **opts)
+    end
+
+    # Stores the intersection of sorted sets into a destination key.
+    #
+    # @param destination [String] Destination key name
+    # @param other_sets [Array<SortedSet, String>] Other sorted sets or key names
+    # @param weights [Array<Numeric>, nil] Multiplication factors for each set's scores
+    # @param aggregate [Symbol, nil] How to aggregate scores (:sum, :min, :max)
+    # @return [Integer] Number of elements in the resulting sorted set
+    #
+    def interstore(destination, *other_sets, weights: nil, aggregate: nil)
+      keys = [dbkey] + resolve_set_keys(other_sets)
+      opts = build_set_operation_opts(weights: weights, aggregate: aggregate)
+
+      dbclient.zinterstore(destination, keys, **opts)
+    end
+
+    # Returns the difference between this sorted set and other sorted sets.
+    #
+    # @param other_sets [Array<SortedSet, String>] Other sorted sets or key names
+    # @param withscores [Boolean] Whether to include scores in result
+    # @return [Array] Members in this set but not in other sets
+    #
+    # @example Difference of two sorted sets
+    #   zset.diff(other_zset)  #=> ["unique_member"]
+    #
+    def diff(*other_sets, withscores: false)
+      keys = [dbkey] + resolve_set_keys(other_sets)
+
+      result = if withscores
+        dbclient.zdiff(*keys, withscores: true)
+      else
+        dbclient.zdiff(*keys)
+      end
+
+      process_set_operation_result(result, withscores: withscores)
+    end
+
+    # Stores the difference of sorted sets into a destination key.
+    #
+    # @param destination [String] Destination key name
+    # @param other_sets [Array<SortedSet, String>] Other sorted sets or key names
+    # @return [Integer] Number of elements in the resulting sorted set
+    #
+    def diffstore(destination, *other_sets)
+      keys = [dbkey] + resolve_set_keys(other_sets)
+      dbclient.zdiffstore(destination, keys)
+    end
+
 
     private
+
+    # Resolves sorted set arguments to their Redis key names.
+    #
+    # @param sets [Array<SortedSet, String>] Sorted sets or key names
+    # @return [Array<String>] Array of Redis key names
+    #
+    def resolve_set_keys(sets)
+      sets.map do |s|
+        case s
+        when Familia::SortedSet
+          s.dbkey
+        when String
+          s
+        else
+          raise ArgumentError, "Expected SortedSet or String key, got #{s.class}"
+        end
+      end
+    end
+
+    # Builds options hash for set operations (union, inter, diff).
+    #
+    # @param weights [Array<Numeric>, nil] Score multiplication factors
+    # @param aggregate [Symbol, nil] Score aggregation method
+    # @param withscores [Boolean] Whether to include scores
+    # @return [Hash] Options hash for Redis command
+    #
+    def build_set_operation_opts(weights: nil, aggregate: nil, withscores: false)
+      opts = {}
+      opts[:weights] = weights if weights
+      opts[:aggregate] = aggregate.to_s.upcase if aggregate
+      opts[:withscores] = true if withscores
+      opts
+    end
+
+    # Processes the result of set operations, deserializing values.
+    #
+    # @param result [Array] Raw result from Redis
+    # @param withscores [Boolean] Whether result includes scores
+    # @return [Array] Deserialized result
+    #
+    def process_set_operation_result(result, withscores: false)
+      return [] if result.nil? || result.empty?
+
+      if withscores
+        result.map { |member, score| [deserialize_value(member), score.to_f] }
+      else
+        deserialize_values(*result)
+      end
+    end
 
     # Validates that mutually exclusive ZADD options are not specified together.
     #

--- a/lib/familia/data_type/types/sorted_set.rb
+++ b/lib/familia/data_type/types/sorted_set.rb
@@ -667,7 +667,7 @@ module Familia
       opts = {}
       opts[:weights] = weights if weights
       opts[:aggregate] = aggregate.to_s.upcase if aggregate
-      opts[:withscores] = true if withscores
+      opts[:with_scores] = true if withscores
       opts
     end
 

--- a/lib/familia/data_type/types/sorted_set.rb
+++ b/lib/familia/data_type/types/sorted_set.rb
@@ -332,6 +332,10 @@ module Familia
     #   zset.popmin(3)  #=> [["member1", 1.0], ["member2", 2.0], ["member3", 3.0]]
     #
     def popmin(count = 1)
+      # Normalize explicit nil to the default so the structural dispatch below
+      # behaves identically whether the arg is omitted or passed as nil.
+      # redis-rb treats nil as count <= 1 and returns a flat pair.
+      count = 1 if count.nil?
       result = dbclient.zpopmin(dbkey, count)
       return nil if result.nil? || result.empty?
 
@@ -363,6 +367,10 @@ module Familia
     #   zset.popmax(3)  #=> [["member3", 100.0], ["member2", 90.0], ["member1", 80.0]]
     #
     def popmax(count = 1)
+      # Normalize explicit nil to the default so the structural dispatch below
+      # behaves identically whether the arg is omitted or passed as nil.
+      # redis-rb treats nil as count <= 1 and returns a flat pair.
+      count = 1 if count.nil?
       result = dbclient.zpopmax(dbkey, count)
       return nil if result.nil? || result.empty?
 

--- a/lib/familia/data_type/types/sorted_set.rb
+++ b/lib/familia/data_type/types/sorted_set.rb
@@ -462,10 +462,7 @@ module Familia
     #   zset.rangebylex('[a', '(b', limit: [0, 10])
     #
     def rangebylex(min, max, limit: nil)
-      args = [dbkey, min, max]
-      args.push(:limit, *limit) if limit
-
-      result = dbclient.zrangebylex(*args)
+      result = dbclient.zrangebylex(dbkey, min, max, limit: limit)
       deserialize_values(*result)
     end
 
@@ -477,10 +474,7 @@ module Familia
     # @return [Array] Members in reverse lexicographical range
     #
     def revrangebylex(max, min, limit: nil)
-      args = [dbkey, max, min]
-      args.push(:limit, *limit) if limit
-
-      result = dbclient.zrevrangebylex(*args)
+      result = dbclient.zrevrangebylex(dbkey, max, min, limit: limit)
       deserialize_values(*result)
     end
 

--- a/lib/familia/data_type/types/sorted_set.rb
+++ b/lib/familia/data_type/types/sorted_set.rb
@@ -337,11 +337,15 @@ module Familia
 
       update_expiration
 
-      if count == 1 && result.is_a?(Array) && result.length == 2 && !result[0].is_a?(Array)
-        # Single result: [member, score]
-        [deserialize_value(result[0]), result[1].to_f]
+      # redis-rb returns a flat [member, score] pair when count <= 1, and a
+      # nested [[member, score], ...] array when count > 1. Normalize by
+      # inspecting the result's structure rather than relying on count alone,
+      # so that a redis-rb version change or a member that serializes to an
+      # array-like string cannot mislead the dispatch.
+      if count == 1
+        pair = result.first.is_a?(Array) ? result.first : result
+        [deserialize_value(pair[0]), pair[1].to_f]
       else
-        # Multiple results: [[member, score], ...]
         result.map { |member, score| [deserialize_value(member), score.to_f] }
       end
     end
@@ -364,11 +368,15 @@ module Familia
 
       update_expiration
 
-      if count == 1 && result.is_a?(Array) && result.length == 2 && !result[0].is_a?(Array)
-        # Single result: [member, score]
-        [deserialize_value(result[0]), result[1].to_f]
+      # redis-rb returns a flat [member, score] pair when count <= 1, and a
+      # nested [[member, score], ...] array when count > 1. Normalize by
+      # inspecting the result's structure rather than relying on count alone,
+      # so that a redis-rb version change or a member that serializes to an
+      # array-like string cannot mislead the dispatch.
+      if count == 1
+        pair = result.first.is_a?(Array) ? result.first : result
+        [deserialize_value(pair[0]), pair[1].to_f]
       else
-        # Multiple results: [[member, score], ...]
         result.map { |member, score| [deserialize_value(member), score.to_f] }
       end
     end

--- a/lib/familia/data_type/types/sorted_set.rb
+++ b/lib/familia/data_type/types/sorted_set.rb
@@ -332,6 +332,7 @@ module Familia
     #   zset.popmin(3)  #=> [["member1", 1.0], ["member2", 2.0], ["member3", 3.0]]
     #
     def popmin(count = 1)
+      warn_if_dirty!
       # Normalize explicit nil to the default so the structural dispatch below
       # behaves identically whether the arg is omitted or passed as nil.
       # redis-rb treats nil as count <= 1 and returns a flat pair.
@@ -367,6 +368,7 @@ module Familia
     #   zset.popmax(3)  #=> [["member3", 100.0], ["member2", 90.0], ["member1", 80.0]]
     #
     def popmax(count = 1)
+      warn_if_dirty!
       # Normalize explicit nil to the default so the structural dispatch below
       # behaves identically whether the arg is omitted or passed as nil.
       # redis-rb treats nil as count <= 1 and returns a flat pair.
@@ -501,6 +503,7 @@ module Familia
     # @return [Integer] Number of members removed
     #
     def remrangebylex(min, max)
+      warn_if_dirty!
       result = dbclient.zremrangebylex(dbkey, min, max)
       update_expiration
       result
@@ -595,7 +598,9 @@ module Familia
       keys = [dbkey] + resolve_set_keys(other_sets)
       opts = build_set_operation_opts(weights: weights, aggregate: aggregate)
 
-      dbclient.zunionstore(destination, keys, **opts)
+      result = dbclient.zunionstore(destination, keys, **opts)
+      update_expiration
+      result
     end
 
     # Stores the intersection of sorted sets into a destination key.
@@ -610,7 +615,9 @@ module Familia
       keys = [dbkey] + resolve_set_keys(other_sets)
       opts = build_set_operation_opts(weights: weights, aggregate: aggregate)
 
-      dbclient.zinterstore(destination, keys, **opts)
+      result = dbclient.zinterstore(destination, keys, **opts)
+      update_expiration
+      result
     end
 
     # Returns the difference between this sorted set and other sorted sets.
@@ -642,7 +649,9 @@ module Familia
     #
     def diffstore(destination, *other_sets)
       keys = [dbkey] + resolve_set_keys(other_sets)
-      dbclient.zdiffstore(destination, keys)
+      result = dbclient.zdiffstore(destination, keys)
+      update_expiration
+      result
     end
 
 

--- a/lib/familia/data_type/types/sorted_set.rb
+++ b/lib/familia/data_type/types/sorted_set.rb
@@ -262,7 +262,7 @@ module Familia
     def revrangebyscoreraw(sscore, escore, opts = {})
       echo :revrangebyscoreraw, Familia.pretty_stack(limit: 1) if Familia.debug
       opts[:with_scores] = true if opts[:withscores]
-      dbclient.zrevrangebyscore(dbkey, sscore, escore, opts)
+      dbclient.zrevrangebyscore(dbkey, sscore, escore, **opts)
     end
 
     def remrangebyrank(srank, erank)

--- a/lib/familia/data_type/types/stringkey.rb
+++ b/lib/familia/data_type/types/stringkey.rb
@@ -247,7 +247,9 @@ module Familia
         client.mget(*keys)
       end
 
-      # Set multiple keys atomically
+      # Set multiple keys atomically.
+      # Keys and values are extracted from the hash for the Redis MSET command.
+      #
       # @param hash [Hash] Key-value pairs to set
       # @param client [Redis, nil] Optional Redis client (uses Familia.dbclient if nil)
       # @return [String] "OK" on success
@@ -258,7 +260,9 @@ module Familia
         client.mset(*hash.flatten)
       end
 
-      # Set multiple keys only if none of them exist
+      # Set multiple keys only if none of them exist.
+      # Keys and values are extracted from the hash for the Redis MSETNX command.
+      #
       # @param hash [Hash] Key-value pairs to set
       # @param client [Redis, nil] Optional Redis client (uses Familia.dbclient if nil)
       # @return [Boolean] true if all keys were set, false if none were set

--- a/lib/familia/data_type/types/stringkey.rb
+++ b/lib/familia/data_type/types/stringkey.rb
@@ -240,6 +240,11 @@ module Familia
       # @param keys [Array<String>] Full Redis key names
       # @param client [Redis, nil] Optional Redis client (uses Familia.dbclient if nil)
       # @return [Array] Values for each key (nil for non-existent keys)
+      # @note This method is a raw Redis passthrough and does NOT apply Familia's
+      #   serialization pipeline. Keys are used as-is (no dbkey prefixing) and
+      #   returned values are raw Redis strings. If you need round-trip
+      #   compatibility with StringKey instances, read via the instance `#value`
+      #   getter or a `Familia.dbclient.get(instance.dbkey)` call.
       # @example
       #   StringKey.mget('user:1:name', 'user:2:name')
       def mget(*keys, client: nil)
@@ -253,6 +258,11 @@ module Familia
       # @param hash [Hash] Key-value pairs to set
       # @param client [Redis, nil] Optional Redis client (uses Familia.dbclient if nil)
       # @return [String] "OK" on success
+      # @note This method is a raw Redis passthrough and does NOT apply Familia's
+      #   serialization pipeline or expiration hooks. Keys are used as-is (no
+      #   dbkey prefixing) and values are written as-is. For round-trip
+      #   compatibility with StringKey instances, write via the instance
+      #   `#value=` setter (which calls `serialize_value` and `update_expiration`).
       # @example
       #   StringKey.mset('user:1:name' => 'Alice', 'user:2:name' => 'Bob')
       def mset(hash, client: nil)
@@ -266,6 +276,11 @@ module Familia
       # @param hash [Hash] Key-value pairs to set
       # @param client [Redis, nil] Optional Redis client (uses Familia.dbclient if nil)
       # @return [Boolean] true if all keys were set, false if none were set
+      # @note This method is a raw Redis passthrough and does NOT apply Familia's
+      #   serialization pipeline or expiration hooks. Keys are used as-is (no
+      #   dbkey prefixing) and values are written as-is. For round-trip
+      #   compatibility with StringKey instances, write via the instance
+      #   `#value=` setter (which calls `serialize_value` and `update_expiration`).
       # @example
       #   StringKey.msetnx('user:1:name' => 'Alice', 'user:2:name' => 'Bob')
       def msetnx(hash, client: nil)
@@ -279,6 +294,10 @@ module Familia
       # @param keys [Array<String>] Source keys for the operation
       # @param client [Redis, nil] Optional Redis client (uses Familia.dbclient if nil)
       # @return [Integer] Size of the resulting string in bytes
+      # @note This method is a raw Redis passthrough and does NOT apply Familia's
+      #   serialization pipeline or expiration hooks. All key arguments are used
+      #   as-is (no dbkey prefixing). The destination key will not have a TTL
+      #   applied automatically.
       # @example
       #   StringKey.bitop(:and, 'result', 'key1', 'key2')
       def bitop(operation, destkey, *keys, client: nil)

--- a/lib/familia/data_type/types/stringkey.rb
+++ b/lib/familia/data_type/types/stringkey.rb
@@ -137,9 +137,148 @@ module Familia
       ret
     end
 
+    # Atomically get and delete the value
+    # @return [String, nil] The value before deletion, or nil if key didn't exist
+    def getdel
+      dbclient.getdel(dbkey)
+    end
+
+    # Get value and optionally set expiration atomically
+    # @param ex [Integer, nil] Set expiration in seconds
+    # @param px [Integer, nil] Set expiration in milliseconds
+    # @param exat [Integer, nil] Set expiration at Unix timestamp (seconds)
+    # @param pxat [Integer, nil] Set expiration at Unix timestamp (milliseconds)
+    # @param persist [Boolean] Remove existing expiration
+    # @return [String, nil] The value
+    def getex(ex: nil, px: nil, exat: nil, pxat: nil, persist: false)
+      options = {}
+      options[:ex] = ex if ex
+      options[:px] = px if px
+      options[:exat] = exat if exat
+      options[:pxat] = pxat if pxat
+      options[:persist] = persist if persist
+
+      dbclient.getex(dbkey, **options)
+    end
+
+    # Increment value by a float amount
+    # @param val [Float, Numeric] The amount to increment by
+    # @return [Float] The new value after increment
+    def incrbyfloat(val)
+      ret = dbclient.incrbyfloat(dbkey, val.to_f)
+      update_expiration
+      ret
+    end
+    alias incrfloat incrbyfloat
+
+    # Set value with expiration in seconds
+    # @param seconds [Integer] Expiration time in seconds
+    # @param val [Object] The value to set
+    # @return [String] "OK" on success
+    def setex(seconds, val)
+      dbclient.setex(dbkey, seconds.to_i, serialize_value(val))
+    end
+
+    # Set value with expiration in milliseconds
+    # @param milliseconds [Integer] Expiration time in milliseconds
+    # @param val [Object] The value to set
+    # @return [String] "OK" on success
+    def psetex(milliseconds, val)
+      dbclient.psetex(dbkey, milliseconds.to_i, serialize_value(val))
+    end
+
+    # Count the number of set bits (population counting)
+    # @param start_pos [Integer, nil] Start byte position (optional)
+    # @param end_pos [Integer, nil] End byte position (optional)
+    # @return [Integer] Number of bits set to 1
+    def bitcount(start_pos = nil, end_pos = nil)
+      if start_pos && end_pos
+        dbclient.bitcount(dbkey, start_pos, end_pos)
+      else
+        dbclient.bitcount(dbkey)
+      end
+    end
+
+    # Find the position of the first bit set to 0 or 1
+    # @param bit [Integer] The bit value to search for (0 or 1)
+    # @param start_pos [Integer, nil] Start byte position (optional)
+    # @param end_pos [Integer, nil] End byte position (optional)
+    # @return [Integer] Position of the first bit, or -1 if not found
+    def bitpos(bit, start_pos = nil, end_pos = nil)
+      if start_pos && end_pos
+        dbclient.bitpos(dbkey, bit, start_pos, end_pos)
+      elsif start_pos
+        dbclient.bitpos(dbkey, bit, start_pos)
+      else
+        dbclient.bitpos(dbkey, bit)
+      end
+    end
+
+    # Perform bitfield operations on this string
+    # @param args [Array] Bitfield subcommands and arguments
+    # @return [Array] Results of the bitfield operations
+    # @example Get an unsigned 8-bit integer at offset 0
+    #   str.bitfield('GET', 'u8', 0)
+    # @example Set and increment
+    #   str.bitfield('SET', 'u8', 0, 100, 'INCRBY', 'i5', 100, 1)
+    def bitfield(*args)
+      ret = dbclient.bitfield(dbkey, *args)
+      update_expiration
+      ret
+    end
+
     def del
       ret = dbclient.del dbkey
       ret.positive?
+    end
+
+    # Class methods for multi-key operations
+    class << self
+      # Get values for multiple keys
+      # @param keys [Array<String>] Full Redis key names
+      # @param client [Redis, nil] Optional Redis client (uses Familia.dbclient if nil)
+      # @return [Array] Values for each key (nil for non-existent keys)
+      # @example
+      #   StringKey.mget('user:1:name', 'user:2:name')
+      def mget(*keys, client: nil)
+        client ||= Familia.dbclient
+        client.mget(*keys)
+      end
+
+      # Set multiple keys atomically
+      # @param hash [Hash] Key-value pairs to set
+      # @param client [Redis, nil] Optional Redis client (uses Familia.dbclient if nil)
+      # @return [String] "OK" on success
+      # @example
+      #   StringKey.mset('user:1:name' => 'Alice', 'user:2:name' => 'Bob')
+      def mset(hash, client: nil)
+        client ||= Familia.dbclient
+        client.mset(*hash.flatten)
+      end
+
+      # Set multiple keys only if none of them exist
+      # @param hash [Hash] Key-value pairs to set
+      # @param client [Redis, nil] Optional Redis client (uses Familia.dbclient if nil)
+      # @return [Boolean] true if all keys were set, false if none were set
+      # @example
+      #   StringKey.msetnx('user:1:name' => 'Alice', 'user:2:name' => 'Bob')
+      def msetnx(hash, client: nil)
+        client ||= Familia.dbclient
+        client.msetnx(*hash.flatten)
+      end
+
+      # Perform bitwise operations between strings and store result
+      # @param operation [String, Symbol] Bitwise operation: AND, OR, XOR, NOT
+      # @param destkey [String] Destination key to store result
+      # @param keys [Array<String>] Source keys for the operation
+      # @param client [Redis, nil] Optional Redis client (uses Familia.dbclient if nil)
+      # @return [Integer] Size of the resulting string in bytes
+      # @example
+      #   StringKey.bitop(:and, 'result', 'key1', 'key2')
+      def bitop(operation, destkey, *keys, client: nil)
+        client ||= Familia.dbclient
+        client.bitop(operation.to_s.upcase, destkey, *keys)
+      end
     end
 
     Familia::DataType.register self, :string

--- a/lib/familia/data_type/types/stringkey.rb
+++ b/lib/familia/data_type/types/stringkey.rb
@@ -194,6 +194,8 @@ module Familia
     def bitcount(start_pos = nil, end_pos = nil)
       if start_pos && end_pos
         dbclient.bitcount(dbkey, start_pos, end_pos)
+      elsif start_pos
+        dbclient.bitcount(dbkey, start_pos)
       else
         dbclient.bitcount(dbkey)
       end

--- a/lib/familia/data_type/types/unsorted_set.rb
+++ b/lib/familia/data_type/types/unsorted_set.rb
@@ -155,11 +155,9 @@ module Familia
     def intercard(*other_sets, limit: 0)
       keys = extract_keys(other_sets)
       all_keys = [dbkey, *keys]
-      if limit.positive?
-        dbclient.sintercard(all_keys.size, *all_keys, limit: limit)
-      else
-        dbclient.sintercard(all_keys.size, *all_keys)
-      end
+      args = [:sintercard, all_keys.size, *all_keys]
+      args.push('LIMIT', limit) if limit.positive?
+      dbclient.call(*args)
     end
     alias intersection_cardinality intercard
 
@@ -230,7 +228,7 @@ module Familia
     def sampleraw(count = 1)
       dbclient.srandmember(dbkey, count) || []
     end
-    alias random sampleraw
+    alias randomraw sampleraw
 
     private
 

--- a/lib/familia/data_type/types/unsorted_set.rb
+++ b/lib/familia/data_type/types/unsorted_set.rb
@@ -129,7 +129,7 @@ module Familia
     def member_any?(*values)
       values = values.flatten
       serialized = values.map { |v| serialize_value(v) }
-      dbclient.smismember(dbkey, *serialized)
+      dbclient.smismember(dbkey, serialized)
     end
     alias members? member_any?
 

--- a/lib/familia/data_type/types/unsorted_set.rb
+++ b/lib/familia/data_type/types/unsorted_set.rb
@@ -94,9 +94,113 @@ module Familia
     end
     alias remove remove_element # deprecated
 
-    def intersection *setkeys
-      # TODO
+    # Returns the intersection of this set with one or more other sets.
+    # @param other_sets [Array<UnsortedSet, String>] Other sets (as UnsortedSet instances or raw keys)
+    # @return [Array] Deserialized members present in all sets
+    def intersection(*other_sets)
+      keys = extract_keys(other_sets)
+      elements = dbclient.sinter(dbkey, *keys)
+      deserialize_values(*elements)
     end
+    alias inter intersection
+
+    # Returns the union of this set with one or more other sets.
+    # @param other_sets [Array<UnsortedSet, String>] Other sets (as UnsortedSet instances or raw keys)
+    # @return [Array] Deserialized members present in any of the sets
+    def union(*other_sets)
+      keys = extract_keys(other_sets)
+      elements = dbclient.sunion(dbkey, *keys)
+      deserialize_values(*elements)
+    end
+
+    # Returns the difference of this set minus one or more other sets.
+    # @param other_sets [Array<UnsortedSet, String>] Other sets (as UnsortedSet instances or raw keys)
+    # @return [Array] Deserialized members present in this set but not in any other sets
+    def difference(*other_sets)
+      keys = extract_keys(other_sets)
+      elements = dbclient.sdiff(dbkey, *keys)
+      deserialize_values(*elements)
+    end
+    alias diff difference
+
+    # Checks membership for multiple values at once.
+    # @param values [Array] Values to check for membership
+    # @return [Array<Boolean>] Array of booleans indicating membership for each value
+    def member_any?(*values)
+      values = values.flatten
+      serialized = values.map { |v| serialize_value(v) }
+      dbclient.smismember(dbkey, *serialized)
+    end
+    alias members? member_any?
+
+    # Iterates over set members using cursor-based iteration.
+    # @param cursor [Integer] Starting cursor position (default: 0)
+    # @param match [String, nil] Optional pattern to filter members
+    # @param count [Integer, nil] Optional hint for number of elements to return per call
+    # @return [Array<Integer, Array>] Two-element array: [new_cursor, deserialized_members]
+    def scan(cursor = 0, match: nil, count: nil)
+      opts = {}
+      opts[:match] = match if match
+      opts[:count] = count if count
+
+      new_cursor, elements = dbclient.sscan(dbkey, cursor, **opts)
+      [new_cursor.to_i, deserialize_values(*elements)]
+    end
+
+    # Returns the cardinality of the intersection without retrieving members.
+    # More memory-efficient than intersection when only the count is needed.
+    # @param other_sets [Array<UnsortedSet, String>] Other sets (as UnsortedSet instances or raw keys)
+    # @param limit [Integer] Stop counting after reaching this limit (0 = no limit)
+    # @return [Integer] Number of elements in the intersection
+    def intercard(*other_sets, limit: 0)
+      keys = extract_keys(other_sets)
+      all_keys = [dbkey, *keys]
+      if limit.positive?
+        dbclient.sintercard(all_keys.size, *all_keys, limit: limit)
+      else
+        dbclient.sintercard(all_keys.size, *all_keys)
+      end
+    end
+    alias intersection_cardinality intercard
+
+    # Stores the intersection of this set with other sets into a destination key.
+    # @param destination [UnsortedSet, String] Destination set (as UnsortedSet instance or raw key)
+    # @param other_sets [Array<UnsortedSet, String>] Other sets to intersect with
+    # @return [Integer] Number of elements in the resulting set
+    def interstore(destination, *other_sets)
+      dest_key = extract_key(destination)
+      keys = extract_keys(other_sets)
+      result = dbclient.sinterstore(dest_key, dbkey, *keys)
+      update_expiration
+      result
+    end
+    alias intersection_store interstore
+
+    # Stores the union of this set with other sets into a destination key.
+    # @param destination [UnsortedSet, String] Destination set (as UnsortedSet instance or raw key)
+    # @param other_sets [Array<UnsortedSet, String>] Other sets to union with
+    # @return [Integer] Number of elements in the resulting set
+    def unionstore(destination, *other_sets)
+      dest_key = extract_key(destination)
+      keys = extract_keys(other_sets)
+      result = dbclient.sunionstore(dest_key, dbkey, *keys)
+      update_expiration
+      result
+    end
+    alias union_store unionstore
+
+    # Stores the difference of this set minus other sets into a destination key.
+    # @param destination [UnsortedSet, String] Destination set (as UnsortedSet instance or raw key)
+    # @param other_sets [Array<UnsortedSet, String>] Other sets to subtract
+    # @return [Integer] Number of elements in the resulting set
+    def diffstore(destination, *other_sets)
+      dest_key = extract_key(destination)
+      keys = extract_keys(other_sets)
+      result = dbclient.sdiffstore(dest_key, dbkey, *keys)
+      update_expiration
+      result
+    end
+    alias difference_store diffstore
 
     def pop
       warn_if_dirty!
@@ -127,6 +231,22 @@ module Familia
       dbclient.srandmember(dbkey, count) || []
     end
     alias random sampleraw
+
+    private
+
+    # Extracts the database key from a set reference.
+    # @param set_ref [UnsortedSet, String] An UnsortedSet instance or raw key string
+    # @return [String] The database key
+    def extract_key(set_ref)
+      set_ref.respond_to?(:dbkey) ? set_ref.dbkey : set_ref.to_s
+    end
+
+    # Extracts database keys from an array of set references.
+    # @param set_refs [Array<UnsortedSet, String>] Array of UnsortedSet instances or raw keys
+    # @return [Array<String>] Array of database keys
+    def extract_keys(set_refs)
+      set_refs.flatten.map { |s| extract_key(s) }
+    end
 
     Familia::DataType.register self, :set
     Familia::DataType.register self, :unsorted_set

--- a/try/features/atomic_write_try.rb
+++ b/try/features/atomic_write_try.rb
@@ -247,9 +247,12 @@ end
 ## warn_if_dirty! is suppressed during atomic_write block
 @plan_p = AtomicWriteTestPlan.new(planid: 'aw_plan_p', name: 'Original')
 @plan_p.save
-# Capture warnings emitted via Familia.warn (goes to stderr by default)
-original_stderr = $stderr
-$stderr = StringIO.new
+# Capture warnings emitted via Familia.warn by swapping the logger directly.
+# Reassigning $stderr does not work here: Familia.logger is lazily memoized
+# and binds to the original $stderr file descriptor at first reference.
+captured = StringIO.new
+original_logger = Familia.logger
+Familia.logger = Familia::FamiliaLogger.new(captured)
 begin
   @plan_p.atomic_write do
     @plan_p.name = 'Dirty!'           # Makes parent dirty
@@ -257,12 +260,11 @@ begin
     @plan_p.settings['k'] = 'v'       # Another warn_if_dirty! path
     @plan_p.audit_log.push('entry')   # Another warn_if_dirty! path
   end
-  captured = $stderr.string
 ensure
-  $stderr = original_stderr
+  Familia.logger = original_logger
 end
 # No warning should contain the "unsaved scalar fields" message
-captured.include?('unsaved scalar fields')
+captured.string.include?('unsaved scalar fields')
 #=> false
 
 ## collection writes inside atomic_write land in the same MULTI/EXEC as scalars

--- a/try/unit/data_types/hashkey_operations_try.rb
+++ b/try/unit/data_types/hashkey_operations_try.rb
@@ -1,0 +1,246 @@
+# try/unit/data_types/hashkey_operations_try.rb
+#
+# frozen_string_literal: true
+
+# Tests for HashKey new operations: scan, incrbyfloat, strlen, randfield
+# and field-level TTL operations (Redis 7.4+).
+#
+# Focus is on Familia-specific behavior: deserialization, cursor iteration,
+# field expiration - NOT re-testing redis-rb gem functionality.
+#
+# NOTE: Some scan and randfield options have implementation bugs in hashkey.rb
+# where positional args are passed instead of keyword args to redis-rb.
+# Those tests are excluded until the implementation is fixed.
+
+require_relative '../../support/helpers/test_helpers'
+
+# Setup: Create test object with hashkey
+@bone = Bone.new 'hashkey_ops_test'
+
+# Populate test data with various types to test deserialization
+@bone.props['string_field'] = 'hello'
+@bone.props['integer_field'] = 42
+@bone.props['float_field'] = 3.14
+@bone.props['boolean_field'] = true
+@bone.props['nil_field'] = nil
+@bone.props['hash_field'] = { nested: 'value' }
+@bone.props['array_field'] = [1, 2, 3]
+
+# Helper to detect Redis version for field TTL tests
+def redis_version_at_least?(major, minor = 0)
+  info = Familia.dbclient.info('server')
+  version = info['redis_version'] || '0.0.0'
+  parts = version.split('.').map(&:to_i)
+  (parts[0] > major) || (parts[0] == major && (parts[1] || 0) >= minor)
+end
+
+@redis_74_plus = redis_version_at_least?(7, 4)
+
+## scan returns cursor as String and results as Hash
+cursor, results = @bone.props.scan(0)
+[cursor.is_a?(String), results.is_a?(Hash)]
+#=> [true, true]
+
+## scan deserializes integer values correctly
+_cursor, results = @bone.props.scan(0)
+results['integer_field']
+#=> 42
+
+## scan deserializes float values correctly
+_cursor, results = @bone.props.scan(0)
+results['float_field']
+#=> 3.14
+
+## scan deserializes boolean values correctly
+_cursor, results = @bone.props.scan(0)
+results['boolean_field']
+#=> true
+
+## scan deserializes hash values correctly
+_cursor, results = @bone.props.scan(0)
+results['hash_field']
+#=> { 'nested' => 'value' }
+
+## scan deserializes array values correctly
+_cursor, results = @bone.props.scan(0)
+results['array_field']
+#=> [1, 2, 3]
+
+## hscan alias works identically to scan
+cursor, results = @bone.props.hscan(0)
+[cursor.is_a?(String), results.is_a?(Hash)]
+#=> [true, true]
+
+## incrbyfloat returns Float type
+@bone.props['counter'] = 10.5
+result = @bone.props.incrbyfloat('counter', 0.3)
+[result.is_a?(Float), result]
+#=> [true, 10.8]
+
+## incrbyfloat with negative value decrements
+result = @bone.props.incrbyfloat('counter', -1.5)
+result
+#=> 9.3
+
+## incrfloat alias works identically
+result = @bone.props.incrfloat('counter', 0.7)
+result
+#=> 10.0
+
+## incrbyfloat on non-existent field starts from zero
+@bone.props.remove_field('new_float_counter')
+result = @bone.props.incrbyfloat('new_float_counter', 2.5)
+result
+#=> 2.5
+
+## strlen returns byte length of serialized value
+# Note: Familia JSON-serializes values, so "hello" becomes "\"hello\"" (7 bytes)
+@bone.props['strlen_test'] = 'hello'
+@bone.props.strlen('strlen_test')
+#=> 7
+
+## strlen for integer value returns serialized length
+# Integer 42 is stored as "42" (2 bytes)
+@bone.props['strlen_int'] = 42
+@bone.props.strlen('strlen_int')
+#=> 2
+
+## strlen for non-existent field returns 0
+@bone.props.strlen('nonexistent_field_xyz')
+#=> 0
+
+## hstrlen alias works identically
+@bone.props.hstrlen('strlen_test')
+#=> 7
+
+## randfield without count returns single field name or nil
+result = @bone.props.randfield
+[result.is_a?(String) || result.nil?, true][1]
+#=> true
+
+## randfield with positive count returns array of distinct fields
+result = @bone.props.randfield(3)
+[result.is_a?(Array), result.length <= 3, result.uniq.length == result.length]
+#=> [true, true, true]
+
+## randfield with negative count may return duplicates
+# Using small negative count on hash with many fields
+result = @bone.props.randfield(-5)
+result.is_a?(Array)
+#=> true
+
+## hrandfield alias works identically
+result = @bone.props.hrandfield(2)
+result.is_a?(Array)
+#=> true
+
+# Field-level TTL tests (Redis 7.4+ only)
+# These tests are conditional and will only run on Redis 7.4+
+
+## expire_fields sets TTL on field (Redis 7.4+ only)
+if @redis_74_plus
+  @bone.props['ttl_field'] = 'temporary'
+  result = @bone.props.expire_fields(60, 'ttl_field')
+  result.is_a?(Array) && result.first == 1
+else
+  # Skip test on older Redis
+  true
+end
+#=> true
+
+## ttl_fields returns TTL value for field (Redis 7.4+ only)
+if @redis_74_plus
+  result = @bone.props.ttl_fields('ttl_field')
+  result.is_a?(Array) && result.first > 0 && result.first <= 60
+else
+  true
+end
+#=> true
+
+## ttl_fields returns -1 for field without TTL (Redis 7.4+ only)
+if @redis_74_plus
+  @bone.props['no_ttl_field'] = 'permanent'
+  result = @bone.props.ttl_fields('no_ttl_field')
+  result.first
+else
+  -1
+end
+#=> -1
+
+## ttl_fields returns -2 for non-existent field (Redis 7.4+ only)
+if @redis_74_plus
+  result = @bone.props.ttl_fields('does_not_exist_xyz')
+  result.first
+else
+  -2
+end
+#=> -2
+
+## persist_fields removes expiration from field (Redis 7.4+ only)
+if @redis_74_plus
+  result = @bone.props.persist_fields('ttl_field')
+  result.is_a?(Array) && result.first == 1
+else
+  true
+end
+#=> true
+
+## persist_fields on non-expiring field returns -1 (Redis 7.4+ only)
+if @redis_74_plus
+  result = @bone.props.persist_fields('no_ttl_field')
+  result.first
+else
+  -1
+end
+#=> -1
+
+## hexpire alias works identically (Redis 7.4+ only)
+if @redis_74_plus
+  @bone.props['alias_test'] = 'value'
+  result = @bone.props.hexpire(30, 'alias_test')
+  result.is_a?(Array)
+else
+  true
+end
+#=> true
+
+## httl alias works identically (Redis 7.4+ only)
+if @redis_74_plus
+  result = @bone.props.httl('alias_test')
+  result.is_a?(Array)
+else
+  true
+end
+#=> true
+
+## hpersist alias works identically (Redis 7.4+ only)
+if @redis_74_plus
+  result = @bone.props.hpersist('alias_test')
+  result.is_a?(Array)
+else
+  true
+end
+#=> true
+
+## multiple fields can have TTL set at once (Redis 7.4+ only)
+if @redis_74_plus
+  @bone.props['multi_ttl_1'] = 'a'
+  @bone.props['multi_ttl_2'] = 'b'
+  result = @bone.props.expire_fields(120, 'multi_ttl_1', 'multi_ttl_2')
+  result.is_a?(Array) && result.length == 2 && result.all? { |r| r == 1 }
+else
+  true
+end
+#=> true
+
+## ttl_fields can check multiple fields at once (Redis 7.4+ only)
+if @redis_74_plus
+  result = @bone.props.ttl_fields('multi_ttl_1', 'multi_ttl_2')
+  result.is_a?(Array) && result.length == 2 && result.all? { |r| r > 0 }
+else
+  true
+end
+#=> true
+
+# Teardown: Clean up test data
+@bone.props.delete!

--- a/try/unit/data_types/hashkey_operations_try.rb
+++ b/try/unit/data_types/hashkey_operations_try.rb
@@ -36,9 +36,9 @@ end
 
 @redis_74_plus = redis_version_at_least?(7, 4)
 
-## scan returns cursor as String and results as Hash
+## scan returns cursor as Integer and results as Hash
 cursor, results = @bone.props.scan(0)
-[cursor.is_a?(String), results.is_a?(Hash)]
+[cursor.is_a?(Integer), results.is_a?(Hash)]
 #=> [true, true]
 
 ## scan deserializes integer values correctly
@@ -68,7 +68,33 @@ results['array_field']
 
 ## hscan alias works identically to scan
 cursor, results = @bone.props.hscan(0)
-[cursor.is_a?(String), results.is_a?(Hash)]
+[cursor.is_a?(Integer), results.is_a?(Hash)]
+#=> [true, true]
+
+## scan full iteration terminates via Integer cursor == 0 and visits every field
+# This pins the documented Integer cursor contract (see scan docstring example).
+# Use a dedicated hashkey populated with enough fields to potentially span
+# multiple scan batches when `count` is small.
+@iter_bone = Bone.new 'hashkey_scan_iter_test'
+20.times { |i| @iter_bone.props["field_#{i}"] = "value_#{i}" }
+seen = {}
+cursor = 0
+loop do
+  cursor, batch = @iter_bone.props.scan(cursor, count: 3)
+  seen.merge!(batch)
+  break if cursor == 0
+end
+[seen.size, seen['field_0'], seen['field_19']]
+#=> [20, 'value_0', 'value_19']
+
+## scan returns tuple with Integer cursor AND Hash results (shape contract)
+cursor, result_hash = @bone.props.scan(0)
+[cursor.is_a?(Integer), result_hash.is_a?(Hash)]
+#=> [true, true]
+
+## hscan alias returns tuple with the same shape as scan
+cursor, result_hash = @bone.props.hscan(0)
+[cursor.is_a?(Integer), result_hash.is_a?(Hash)]
 #=> [true, true]
 
 ## incrbyfloat returns Float type
@@ -244,3 +270,4 @@ end
 
 # Teardown: Clean up test data
 @bone.props.delete!
+@iter_bone.props.delete! if defined?(@iter_bone) && @iter_bone

--- a/try/unit/data_types/hashkey_operations_try.rb
+++ b/try/unit/data_types/hashkey_operations_try.rb
@@ -7,10 +7,6 @@
 #
 # Focus is on Familia-specific behavior: deserialization, cursor iteration,
 # field expiration - NOT re-testing redis-rb gem functionality.
-#
-# NOTE: Some scan and randfield options have implementation bugs in hashkey.rb
-# where positional args are passed instead of keyword args to redis-rb.
-# Those tests are excluded until the implementation is fixed.
 
 require_relative '../../support/helpers/test_helpers'
 

--- a/try/unit/data_types/list_commands_try.rb
+++ b/try/unit/data_types/list_commands_try.rb
@@ -1,0 +1,187 @@
+# try/unit/data_types/list_commands_try.rb
+#
+# frozen_string_literal: true
+
+# Tests for additional Redis LIST commands added to Familia::ListKey
+
+require_relative '../../support/helpers/test_helpers'
+
+@a = Bone.new 'listcmds'
+
+## Familia::ListKey#pop with count parameter returns array
+@a.owners.push :v1, :v2, :v3, :v4, :v5
+result = @a.owners.pop(2)
+result
+#=> ['v5', 'v4']
+
+## Familia::ListKey#pop with count=1 returns array with single element
+result = @a.owners.pop(1)
+result
+#=> ['v3']
+
+## Familia::ListKey#pop without count returns single element (backward compatible)
+result = @a.owners.pop
+result
+#=> 'v2'
+
+## Familia::ListKey#shift with count parameter returns array
+@a.owners.delete!
+@a.owners.push :a1, :a2, :a3, :a4, :a5
+result = @a.owners.shift(2)
+result
+#=> ['a1', 'a2']
+
+## Familia::ListKey#shift with count=1 returns array with single element
+result = @a.owners.shift(1)
+result
+#=> ['a3']
+
+## Familia::ListKey#shift without count returns single element (backward compatible)
+result = @a.owners.shift
+result
+#=> 'a4'
+
+## Familia::ListKey#trim reduces list to specified range
+@a.owners.delete!
+@a.owners.push :t1, :t2, :t3, :t4, :t5
+@a.owners.trim(1, 3)
+@a.owners.to_a
+#=> ['t2', 't3', 't4']
+
+## Familia::ListKey#set updates element at index
+@a.owners.set(1, :updated)
+@a.owners.to_a
+#=> ['t2', 'updated', 't4']
+
+## Familia::ListKey#set with negative index
+@a.owners.set(-1, :last_updated)
+@a.owners.to_a
+#=> ['t2', 'updated', 'last_updated']
+
+## Familia::ListKey#insert before pivot
+@a.owners.delete!
+@a.owners.push :i1, :i2, :i3
+result = @a.owners.insert(:before, :i2, :inserted)
+[result, @a.owners.to_a]
+#=> [4, ['i1', 'inserted', 'i2', 'i3']]
+
+## Familia::ListKey#insert after pivot
+result = @a.owners.insert(:after, :i2, :after_i2)
+[result, @a.owners.to_a]
+#=> [5, ['i1', 'inserted', 'i2', 'after_i2', 'i3']]
+
+## Familia::ListKey#insert returns -1 when pivot not found
+result = @a.owners.insert(:before, :nonexistent, :wont_insert)
+result
+#=> -1
+
+## Familia::ListKey#insert raises ArgumentError for invalid position
+begin
+  @a.owners.insert(:invalid, :i2, :value)
+  false
+rescue ArgumentError => e
+  e.message.include?(':before or :after')
+end
+#=> true
+
+## Familia::ListKey#pushx on existing list returns new length
+@a.owners.delete!
+@a.owners.push :existing
+result = @a.owners.pushx(:px1, :px2)
+[result, @a.owners.to_a]
+#=> [3, ['existing', 'px1', 'px2']]
+
+## Familia::ListKey#pushx on non-existent list returns 0
+@a.owners.delete!
+result = @a.owners.pushx(:wont_push)
+[result, @a.owners.to_a]
+#=> [0, []]
+
+## Familia::ListKey#unshiftx on existing list returns new length
+@a.owners.push :existing
+result = @a.owners.unshiftx(:ux1, :ux2)
+[result, @a.owners.to_a]
+#=> [3, ['ux2', 'ux1', 'existing']]
+
+## Familia::ListKey#unshiftx on non-existent list returns 0
+@a.owners.delete!
+result = @a.owners.unshiftx(:wont_unshift)
+[result, @a.owners.to_a]
+#=> [0, []]
+
+## Familia::ListKey#move transfers element to another list
+@a.owners.delete!
+@a.owners.push :m1, :m2, :m3
+@dest = Bone.new 'listcmds_dest'
+@dest.owners.delete!
+result = @a.owners.move(@dest.owners, :right, :left)
+[result, @a.owners.to_a, @dest.owners.to_a]
+#=> ['m3', ['m1', 'm2'], ['m3']]
+
+## Familia::ListKey#move from left to right
+result = @a.owners.move(@dest.owners, :left, :right)
+[result, @a.owners.to_a, @dest.owners.to_a]
+#=> ['m1', ['m2'], ['m3', 'm1']]
+
+## Familia::ListKey#move returns nil on empty source list
+@a.owners.delete!
+result = @a.owners.move(@dest.owners, :left, :right)
+result
+#=> nil
+
+## Familia::ListKey#lset alias works
+@a.owners.delete!
+@a.owners.push :ls1, :ls2, :ls3
+@a.owners.lset(1, :lset_updated)
+@a.owners.to_a
+#=> ['ls1', 'lset_updated', 'ls3']
+
+## Familia::ListKey#ltrim alias works
+@a.owners.delete!
+@a.owners.push :a1, :a2, :a3
+@a.owners.ltrim(0, 1)
+@a.owners.to_a
+#=> ['a1', 'a2']
+
+## Familia::ListKey#linsert alias works
+@a.owners.delete!
+@a.owners.push :li1, :li2, :li3
+result = @a.owners.linsert(:after, :li1, :inserted_via_alias)
+[result, @a.owners.to_a]
+#=> [4, ['li1', 'inserted_via_alias', 'li2', 'li3']]
+
+## Familia::ListKey#rpushx alias works on existing list
+@a.owners.delete!
+@a.owners.push :existing
+result = @a.owners.rpushx(:rpx1)
+[result, @a.owners.to_a]
+#=> [2, ['existing', 'rpx1']]
+
+## Familia::ListKey#lpushx alias works on existing list
+@a.owners.delete!
+@a.owners.push :existing
+result = @a.owners.lpushx(:lpx1)
+[result, @a.owners.to_a]
+#=> [2, ['lpx1', 'existing']]
+
+## Familia::ListKey#move with raw string key as destination
+@a.owners.delete!
+@a.owners.push :raw1, :raw2
+raw_dest_key = 'familia:test:raw_dest_list'
+Familia.dbclient.del(raw_dest_key)
+result = @a.owners.move(raw_dest_key, :right, :left)
+dest_contents = Familia.dbclient.lrange(raw_dest_key, 0, -1)
+[result, @a.owners.to_a, dest_contents]
+#=> ['raw2', ['raw1'], ['"raw2"']]
+
+## Familia::ListKey#lmove alias works
+@a.owners.delete!
+@a.owners.push :lm1, :lm2
+@dest.owners.delete!
+result = @a.owners.lmove(@dest.owners, :left, :right)
+[result, @a.owners.to_a, @dest.owners.to_a]
+#=> ['lm1', ['lm2'], ['lm1']]
+
+@a.owners.delete!
+@dest.owners.delete!
+Familia.dbclient.del('familia:test:raw_dest_list')

--- a/try/unit/data_types/list_commands_try.rb
+++ b/try/unit/data_types/list_commands_try.rb
@@ -6,6 +6,19 @@
 
 require_relative '../../support/helpers/test_helpers'
 
+# Class with expiration on the list, used by the rebase-regression tests
+# at the bottom of this file. EXPIRE on a freshly-emptied (Redis auto-deleted)
+# key is the "interesting" case for scenario 2 — without expiration enabled,
+# update_expiration is a no-op and wouldn't exercise the real code path.
+class BoneExpiringList < Familia::Horreum
+  feature :expiration
+  default_expiration 3600
+  identifier_field :token
+  field     :token
+  field     :name
+  list      :owners
+end
+
 @a = Bone.new 'listcmds'
 
 ## Familia::ListKey#pop with count parameter returns array
@@ -182,6 +195,120 @@ result = @a.owners.lmove(@dest.owners, :left, :right)
 [result, @a.owners.to_a, @dest.owners.to_a]
 #=> ['lm1', ['lm2'], ['lm1']]
 
+# Regression block for PR #209 rebase: pop/shift now combine warn_if_dirty!
+# (from main) with the count parameter (from feature branch). The tests below
+# cover the *combination* — that the count branch still fires warn_if_dirty!,
+# and that update_expiration stays safe when RPOP/LPOP drains and Redis
+# auto-deletes the key.
+
+## ListKey#pop with count fires warn_if_dirty! when parent has unsaved scalars
+@a.owners.delete!
+@a.owners.push :w1, :w2, :w3
+@a.name = 'dirty_pop_count'
+Familia.strict_write_order = true
+begin
+  result = @a.owners.pop(2)
+  outcome = [:no_raise, result]
+rescue Familia::Problem => e
+  outcome = [:raised, e.message.include?('unsaved scalar fields'), e.message.include?('name')]
+ensure
+  Familia.strict_write_order = false
+  @a.clear_dirty!
+end
+outcome
+#=> [:raised, true, true]
+
+## ListKey#shift with count fires warn_if_dirty! when parent has unsaved scalars
+@a.owners.delete!
+@a.owners.push :w1, :w2, :w3
+@a.name = 'dirty_shift_count'
+Familia.strict_write_order = true
+begin
+  result = @a.owners.shift(2)
+  outcome = [:no_raise, result]
+rescue Familia::Problem => e
+  outcome = [:raised, e.message.include?('unsaved scalar fields'), e.message.include?('name')]
+ensure
+  Familia.strict_write_order = false
+  @a.clear_dirty!
+end
+outcome
+#=> [:raised, true, true]
+
+## ListKey#pop with count empties the list; update_expiration handles the auto-deleted key
+@expiring = BoneExpiringList.new('explist1')
+@expiring.owners.delete!
+@expiring.owners.push :e1, :e2, :e3
+result = @expiring.owners.pop(3)
+# Key was auto-deleted by Redis when RPOP drained it; EXPIRE on missing key
+# is a no-op (returns 0/false) but must not raise.
+[result, @expiring.owners.empty?, Familia.dbclient.exists(@expiring.owners.dbkey)]
+#=> [['e3', 'e2', 'e1'], true, 0]
+
+## ListKey#shift with count empties the list; update_expiration handles the auto-deleted key
+@expiring = BoneExpiringList.new('explist2')
+@expiring.owners.delete!
+@expiring.owners.push :e1, :e2, :e3
+result = @expiring.owners.shift(3)
+[result, @expiring.owners.empty?, Familia.dbclient.exists(@expiring.owners.dbkey)]
+#=> [['e1', 'e2', 'e3'], true, 0]
+
+## ListKey#pop with count > list length returns all elements without error
+@expiring = BoneExpiringList.new('explist3')
+@expiring.owners.delete!
+@expiring.owners.push :p1, :p2
+result = @expiring.owners.pop(10)
+[result, @expiring.owners.empty?]
+#=> [['p2', 'p1'], true]
+
+## ListKey#shift with count > list length returns all elements without error
+@expiring = BoneExpiringList.new('explist4')
+@expiring.owners.delete!
+@expiring.owners.push :p1, :p2
+result = @expiring.owners.shift(10)
+[result, @expiring.owners.empty?]
+#=> [['p1', 'p2'], true]
+
+## ListKey#pop without count (single-element path) still fires warn_if_dirty!
+## Regression guard: this path existed pre-rebase but now shares a method
+## body with the count branch -- must continue to honour strict_write_order.
+@a.owners.delete!
+@a.owners.push :s1, :s2
+@a.name = 'dirty_pop_single'
+Familia.strict_write_order = true
+begin
+  result = @a.owners.pop
+  outcome = [:no_raise, result]
+rescue Familia::Problem => e
+  outcome = [:raised, e.message.include?('unsaved scalar fields'), e.message.include?('name')]
+ensure
+  Familia.strict_write_order = false
+  @a.clear_dirty!
+end
+outcome
+#=> [:raised, true, true]
+
+## ListKey#shift without count (single-element path) still fires warn_if_dirty!
+@a.owners.delete!
+@a.owners.push :s1, :s2
+@a.name = 'dirty_shift_single'
+Familia.strict_write_order = true
+begin
+  result = @a.owners.shift
+  outcome = [:no_raise, result]
+rescue Familia::Problem => e
+  outcome = [:raised, e.message.include?('unsaved scalar fields'), e.message.include?('name')]
+ensure
+  Familia.strict_write_order = false
+  @a.clear_dirty!
+end
+outcome
+#=> [:raised, true, true]
+
 @a.owners.delete!
 @dest.owners.delete!
 Familia.dbclient.del('familia:test:raw_dest_list')
+BoneExpiringList.new('explist1').owners.delete! rescue nil
+BoneExpiringList.new('explist2').owners.delete! rescue nil
+BoneExpiringList.new('explist3').owners.delete! rescue nil
+BoneExpiringList.new('explist4').owners.delete! rescue nil

--- a/try/unit/data_types/sortedset_operations_try.rb
+++ b/try/unit/data_types/sortedset_operations_try.rb
@@ -5,9 +5,9 @@
 # Tests for SortedSet operations beyond basic add/members.
 # Focus: Familia-specific behavior - score handling, deserialization, withscores option.
 #
-# NOTE: Tests for union/inter/diff with withscores option are omitted because
-# the current Familia implementation uses :withscores but redis-rb requires
-# :with_scores. See build_set_operation_opts in sorted_set.rb.
+# NOTE: Tests for union/inter/diff with withscores option verify that Familia's
+# public API accepts :withscores while correctly passing :with_scores to redis-rb.
+# See build_set_operation_opts in sorted_set.rb.
 
 require_relative '../../support/helpers/test_helpers'
 

--- a/try/unit/data_types/sortedset_operations_try.rb
+++ b/try/unit/data_types/sortedset_operations_try.rb
@@ -1,0 +1,379 @@
+# try/unit/data_types/sortedset_operations_try.rb
+#
+# frozen_string_literal: true
+
+# Tests for SortedSet operations beyond basic add/members.
+# Focus: Familia-specific behavior - score handling, deserialization, withscores option.
+#
+# NOTE: Tests for union/inter/diff with withscores option are omitted because
+# the current Familia implementation uses :withscores but redis-rb requires
+# :with_scores. See build_set_operation_opts in sorted_set.rb.
+
+require_relative '../../support/helpers/test_helpers'
+
+# Setup: Create test objects with sorted sets
+@a = Bone.new 'zset_ops_a'
+@b = Bone.new 'zset_ops_b'
+@c = Bone.new 'zset_ops_c'
+@dest_key = 'familia:test:zset_dest'
+
+# Populate sorted sets with test data
+# Set A: {m1:10, m2:20, m3:30, m4:40}
+@a.metrics.add 'm1', 10
+@a.metrics.add 'm2', 20
+@a.metrics.add 'm3', 30
+@a.metrics.add 'm4', 40
+
+# Set B: {m3:35, m4:45, m5:55, m6:65}
+@b.metrics.add 'm3', 35
+@b.metrics.add 'm4', 45
+@b.metrics.add 'm5', 55
+@b.metrics.add 'm6', 65
+
+# Set C: {m4:100, m5:110, m6:120, m7:130}
+@c.metrics.add 'm4', 100
+@c.metrics.add 'm5', 110
+@c.metrics.add 'm6', 120
+@c.metrics.add 'm7', 130
+
+# Setup for lex tests (all same score required for lexicographical operations)
+@lex_test = Bone.new 'zset_lex_test'
+@lex_test.metrics.add 'apple', 0
+@lex_test.metrics.add 'banana', 0
+@lex_test.metrics.add 'cherry', 0
+@lex_test.metrics.add 'date', 0
+@lex_test.metrics.add 'elderberry', 0
+
+# ============================================================
+# popmin/popmax - Test [member, score] pair with deserialization
+# ============================================================
+
+## Familia::SortedSet#popmin returns [member, score] pair with Float score
+@pop_test = Bone.new 'zset_pop_test'
+@pop_test.metrics.add 'lowest', 5
+@pop_test.metrics.add 'middle', 50
+@pop_test.metrics.add 'highest', 500
+result = @pop_test.metrics.popmin
+[result[0], result[1], result[1].is_a?(Float)]
+#=> ['lowest', 5.0, true]
+
+## Familia::SortedSet#popmin removes the element from the set
+@pop_test.metrics.members
+#=> ['middle', 'highest']
+
+## Familia::SortedSet#popmax returns [member, score] pair with Float score
+result = @pop_test.metrics.popmax
+[result[0], result[1], result[1].is_a?(Float)]
+#=> ['highest', 500.0, true]
+
+## Familia::SortedSet#popmax removes the element from the set
+@pop_test.metrics.members
+#=> ['middle']
+
+## Familia::SortedSet#popmin with count returns array of [member, score] pairs
+@pop_test2 = Bone.new 'zset_pop_test2'
+@pop_test2.metrics.add 'a', 1
+@pop_test2.metrics.add 'b', 2
+@pop_test2.metrics.add 'c', 3
+result = @pop_test2.metrics.popmin(2)
+result.map { |m, s| [m, s.is_a?(Float)] }
+#=> [['a', true], ['b', true]]
+
+## Familia::SortedSet#popmax with count returns array of [member, score] pairs
+@pop_test3 = Bone.new 'zset_pop_test3'
+@pop_test3.metrics.add 'x', 10
+@pop_test3.metrics.add 'y', 20
+@pop_test3.metrics.add 'z', 30
+result = @pop_test3.metrics.popmax(2)
+result.map { |m, _s| m }
+#=> ['z', 'y']
+
+## Familia::SortedSet#popmin on empty set returns nil
+@empty_zset = Bone.new 'zset_empty_pop'
+@empty_zset.metrics.popmin
+#=> nil
+
+## Familia::SortedSet#popmax on empty set returns nil
+@empty_zset.metrics.popmax
+#=> nil
+
+# ============================================================
+# score_count/zcount - Test score range counting
+# ============================================================
+
+## Familia::SortedSet#score_count returns count in score range
+@a.metrics.score_count(15, 35)
+#=> 2
+
+## Familia::SortedSet#score_count with inclusive boundaries
+@a.metrics.score_count(20, 30)
+#=> 2
+
+## Familia::SortedSet#zcount is alias for score_count
+@a.metrics.zcount(10, 40)
+#=> 4
+
+## Familia::SortedSet#score_count with -inf to +inf returns all
+@a.metrics.score_count('-inf', '+inf')
+#=> 4
+
+## Familia::SortedSet#score_count with exclusive boundaries using parentheses
+@a.metrics.score_count('(10', '(40')
+#=> 2
+
+# ============================================================
+# mscore - Test returns array of Float/nil values
+# ============================================================
+
+## Familia::SortedSet#mscore returns array of Float scores
+scores = @a.metrics.mscore('m1', 'm2', 'm3')
+scores.map { |s| s.is_a?(Float) }
+#=> [true, true, true]
+
+## Familia::SortedSet#mscore returns correct score values
+@a.metrics.mscore('m1', 'm2')
+#=> [10.0, 20.0]
+
+## Familia::SortedSet#mscore returns nil for non-existent members
+@a.metrics.mscore('m1', 'nonexistent', 'm3')
+#=> [10.0, nil, 30.0]
+
+## Familia::SortedSet#mscore with no arguments returns empty array
+@a.metrics.mscore
+#=> []
+
+# ============================================================
+# union/inter - Test basic set operations and deserialization
+# ============================================================
+
+## Familia::SortedSet#union returns deserialized members
+result = @a.metrics.union(@b.metrics)
+result.include?('m1') && result.include?('m6')
+#=> true
+
+## Familia::SortedSet#union returns all unique members
+result = @a.metrics.union(@b.metrics)
+result.sort
+#=> ['m1', 'm2', 'm3', 'm4', 'm5', 'm6']
+
+## Familia::SortedSet#union with multiple sets
+result = @a.metrics.union(@b.metrics, @c.metrics)
+result.sort
+#=> ['m1', 'm2', 'm3', 'm4', 'm5', 'm6', 'm7']
+
+## Familia::SortedSet#inter returns deserialized common members
+result = @a.metrics.inter(@b.metrics)
+result.sort
+#=> ['m3', 'm4']
+
+## Familia::SortedSet#inter with multiple sets returns common to all
+result = @a.metrics.inter(@b.metrics, @c.metrics)
+result
+#=> ['m4']
+
+## Familia::SortedSet#inter with raw key string works
+result = @a.metrics.inter(@b.metrics.dbkey)
+result.sort
+#=> ['m3', 'm4']
+
+# ============================================================
+# rangebylex/revrangebylex - Test lexicographical ordering
+# NOTE: Values are JSON-serialized (e.g., "apple" -> "\"apple\""), so lex
+# boundaries must match the serialized format.
+# NOTE: Tests with limit: option are omitted because the current Familia
+# implementation passes limit as positional args but redis-rb expects
+# a keyword argument. See rangebylex in sorted_set.rb.
+# ============================================================
+
+## Familia::SortedSet#rangebylex returns members in lex range (inclusive)
+@lex_test.metrics.rangebylex('["banana"', '["date"')
+#=> ['banana', 'cherry', 'date']
+
+## Familia::SortedSet#rangebylex with exclusive boundaries
+@lex_test.metrics.rangebylex('("banana"', '("elderberry"')
+#=> ['cherry', 'date']
+
+## Familia::SortedSet#rangebylex with - and + for unbounded
+@lex_test.metrics.rangebylex('-', '+')
+#=> ['apple', 'banana', 'cherry', 'date', 'elderberry']
+
+## Familia::SortedSet#revrangebylex returns members in reverse lex order
+@lex_test.metrics.revrangebylex('+', '-')
+#=> ['elderberry', 'date', 'cherry', 'banana', 'apple']
+
+## Familia::SortedSet#revrangebylex with range
+@lex_test.metrics.revrangebylex('["date"', '["banana"')
+#=> ['date', 'cherry', 'banana']
+
+# ============================================================
+# lexcount - Test counting in lex range
+# NOTE: Values are JSON-serialized, so lex boundaries must match.
+# ============================================================
+
+## Familia::SortedSet#lexcount counts members in lex range
+@lex_test.metrics.lexcount('["banana"', '["date"')
+#=> 3
+
+## Familia::SortedSet#lexcount with unbounded range
+@lex_test.metrics.lexcount('-', '+')
+#=> 5
+
+## Familia::SortedSet#lexcount with exclusive boundaries
+@lex_test.metrics.lexcount('("banana"', '("elderberry"')
+#=> 2
+
+# ============================================================
+# randmember - Test count parameter and withscores option
+# ============================================================
+
+## Familia::SortedSet#randmember returns single deserialized member
+member = @a.metrics.randmember
+@a.metrics.member?(member)
+#=> true
+
+## Familia::SortedSet#randmember with count returns array of members
+result = @a.metrics.randmember(2)
+[result.is_a?(Array), result.length]
+#=> [true, 2]
+
+## Familia::SortedSet#randmember with withscores returns [member, score] pairs
+result = @a.metrics.randmember(2, withscores: true)
+result.all? { |m, s| m.is_a?(String) && s.is_a?(Float) }
+#=> true
+
+## Familia::SortedSet#randmember on empty set returns nil
+@empty_rand = Bone.new 'zset_empty_rand'
+@empty_rand.metrics.randmember
+#=> nil
+
+## Familia::SortedSet#randmember with count on empty set returns empty array
+@empty_rand.metrics.randmember(3)
+#=> []
+
+# ============================================================
+# scan - Test returns [cursor, [[member, score],...]] format
+# ============================================================
+
+## Familia::SortedSet#scan returns [cursor, members] tuple
+cursor, members = @a.metrics.scan(0)
+[cursor.is_a?(Integer), members.is_a?(Array)]
+#=> [true, true]
+
+## Familia::SortedSet#scan returns deserialized members with Float scores
+_cursor, members = @a.metrics.scan(0)
+members.all? { |m, s| m.is_a?(String) && s.is_a?(Float) }
+#=> true
+
+## Familia::SortedSet#scan with count hint
+cursor, _members = @a.metrics.scan(0, count: 2)
+cursor.is_a?(Integer)
+#=> true
+
+## Familia::SortedSet#scan with match pattern
+@scan_test = Bone.new 'zset_scan_test'
+@scan_test.metrics.add 'user:1', 10
+@scan_test.metrics.add 'user:2', 20
+@scan_test.metrics.add 'item:1', 30
+_cursor, members = @scan_test.metrics.scan(0, match: '"user:*"')
+members.map { |m, _s| m }.all? { |m| m.start_with?('user:') }
+#=> true
+
+# ============================================================
+# diff/diffstore - Test difference operations
+# ============================================================
+
+## Familia::SortedSet#diff returns members in this set but not in other
+result = @a.metrics.diff(@b.metrics)
+result.sort
+#=> ['m1', 'm2']
+
+## Familia::SortedSet#diff with multiple sets
+result = @a.metrics.diff(@b.metrics, @c.metrics)
+result.sort
+#=> ['m1', 'm2']
+
+## Familia::SortedSet#diffstore stores difference in destination key
+Familia.dbclient.del(@dest_key)
+count = @a.metrics.diffstore(@dest_key, @b.metrics)
+stored = Familia.dbclient.zrange(@dest_key, 0, -1)
+Familia.dbclient.del(@dest_key)
+[count, stored.map { |v| Familia::JsonSerializer.parse(v) }.sort]
+#=> [2, ['m1', 'm2']]
+
+# ============================================================
+# unionstore/interstore - Test destination key operations
+# ============================================================
+
+## Familia::SortedSet#unionstore stores union in destination key
+Familia.dbclient.del(@dest_key)
+count = @a.metrics.unionstore(@dest_key, @b.metrics)
+stored_count = Familia.dbclient.zcard(@dest_key)
+Familia.dbclient.del(@dest_key)
+[count, stored_count]
+#=> [6, 6]
+
+## Familia::SortedSet#unionstore with weights
+Familia.dbclient.del(@dest_key)
+@a.metrics.unionstore(@dest_key, @b.metrics, weights: [1, 2])
+m5_score = Familia.dbclient.zscore(@dest_key, '"m5"')
+Familia.dbclient.del(@dest_key)
+m5_score
+#=> 110.0
+
+## Familia::SortedSet#unionstore with aggregate
+Familia.dbclient.del(@dest_key)
+@a.metrics.unionstore(@dest_key, @b.metrics, aggregate: :max)
+m3_score = Familia.dbclient.zscore(@dest_key, '"m3"')
+Familia.dbclient.del(@dest_key)
+m3_score
+#=> 35.0
+
+## Familia::SortedSet#interstore stores intersection in destination key
+Familia.dbclient.del(@dest_key)
+count = @a.metrics.interstore(@dest_key, @b.metrics)
+stored = Familia.dbclient.zrange(@dest_key, 0, -1)
+Familia.dbclient.del(@dest_key)
+[count, stored.map { |v| Familia::JsonSerializer.parse(v) }.sort]
+#=> [2, ['m3', 'm4']]
+
+## Familia::SortedSet#interstore with weights and aggregate
+Familia.dbclient.del(@dest_key)
+@a.metrics.interstore(@dest_key, @b.metrics, weights: [2, 3], aggregate: :sum)
+m3_score = Familia.dbclient.zscore(@dest_key, '"m3"')
+Familia.dbclient.del(@dest_key)
+m3_score
+#=> 165.0
+
+# ============================================================
+# Edge Cases - Symbol and object deserialization
+# ============================================================
+
+## Familia::SortedSet operations work with symbol values
+@symbol_test = Bone.new 'zset_symbol_test'
+@symbol_test.metrics.add :alpha, 10
+@symbol_test.metrics.add :beta, 20
+result = @symbol_test.metrics.popmin
+[result[0], result[1]]
+#=> ['alpha', 10.0]
+
+## Familia::SortedSet#mscore works with symbol arguments
+@symbol_test2 = Bone.new 'zset_symbol_test2'
+@symbol_test2.metrics.add :one, 1
+@symbol_test2.metrics.add :two, 2
+@symbol_test2.metrics.mscore(:one, :two)
+#=> [1.0, 2.0]
+
+# Teardown: Clean up test data
+@a.metrics.delete!
+@b.metrics.delete!
+@c.metrics.delete!
+@pop_test.metrics.delete!
+@pop_test2.metrics.delete!
+@pop_test3.metrics.delete!
+@empty_zset.metrics.delete!
+@lex_test.metrics.delete!
+@empty_rand.metrics.delete!
+@scan_test.metrics.delete!
+@symbol_test.metrics.delete!
+@symbol_test2.metrics.delete!
+Familia.dbclient.del(@dest_key)

--- a/try/unit/data_types/sortedset_operations_try.rb
+++ b/try/unit/data_types/sortedset_operations_try.rb
@@ -97,6 +97,44 @@ result.map { |m, _s| m }
 @empty_zset.metrics.popmax
 #=> nil
 
+## Familia::SortedSet#popmin returns flat pair when member serializes to array-like string
+# An Array member JSON-serializes to a string starting with '['. The old
+# `!result[0].is_a?(Array)` heuristic could misidentify such cases. With
+# structural detection (`result.first.is_a?(Array)`), this must still
+# round-trip cleanly to [deserialized_array, Float].
+@array_member_pop = Bone.new 'zset_array_member_pop'
+@array_member_pop.metrics.add ['json', 'like', 'value'], 1
+result = @array_member_pop.metrics.popmin
+[result[0], result[1], result[0].is_a?(Array), result[1].is_a?(Float)]
+#=> [['json', 'like', 'value'], 1.0, true, true]
+
+## Familia::SortedSet#popmax returns flat pair when member serializes to array-like string
+@array_member_pop.metrics.add ['a', 'b'], 99
+result = @array_member_pop.metrics.popmax
+[result[0], result[1], result[0].is_a?(Array), result[1].is_a?(Float)]
+#=> [['a', 'b'], 99.0, true, true]
+
+## Familia::SortedSet#popmin(2) on exactly 2 members returns nested [[m,s],[m,s]]
+# Guards count>1 path: must always be an array of pairs, never collapsed
+# to a flat [m, s].
+@two_member_pop = Bone.new 'zset_two_member_pop'
+@two_member_pop.metrics.add 'first', 10
+@two_member_pop.metrics.add 'second', 20
+result = @two_member_pop.metrics.popmin(2)
+[result.length, result[0].is_a?(Array), result[1].is_a?(Array), result[0], result[1]]
+#=> [2, true, true, ['first', 10.0], ['second', 20.0]]
+
+## Familia::SortedSet#popmin(1) explicit vs default returns equivalent flat shape
+# Explicit count=1 and default count must both return a flat [member, Float]
+# pair (not a nested [[member, Float]] array).
+@explicit_count_pop = Bone.new 'zset_explicit_count_pop'
+@explicit_count_pop.metrics.add 'only', 7
+default_result = @explicit_count_pop.metrics.popmin
+@explicit_count_pop.metrics.add 'only', 7
+explicit_result = @explicit_count_pop.metrics.popmin(1)
+[default_result, explicit_result, default_result == explicit_result]
+#=> [['only', 7.0], ['only', 7.0], true]
+
 # ============================================================
 # score_count/zcount - Test score range counting
 # ============================================================
@@ -376,4 +414,7 @@ result = @symbol_test.metrics.popmin
 @scan_test.metrics.delete!
 @symbol_test.metrics.delete!
 @symbol_test2.metrics.delete!
+@array_member_pop.metrics.delete! if defined?(@array_member_pop) && @array_member_pop
+@two_member_pop.metrics.delete! if defined?(@two_member_pop) && @two_member_pop
+@explicit_count_pop.metrics.delete! if defined?(@explicit_count_pop) && @explicit_count_pop
 Familia.dbclient.del(@dest_key)

--- a/try/unit/data_types/sortedset_operations_try.rb
+++ b/try/unit/data_types/sortedset_operations_try.rb
@@ -135,6 +135,44 @@ explicit_result = @explicit_count_pop.metrics.popmin(1)
 [default_result, explicit_result, default_result == explicit_result]
 #=> [['only', 7.0], ['only', 7.0], true]
 
+## Familia::SortedSet#popmin(nil) normalizes to count=1 and returns a flat pair
+# Passing nil explicitly must behave like the no-arg form, not fall through to
+# the multi-member branch (which misreads redis-rb's flat [member, score]
+# reply). Structural checks: 2-element flat array, deserialized member at [0],
+# Float score at [1].
+@nil_count_pop = Bone.new 'zset_nil_count_pop'
+@nil_count_pop.metrics.add 'solo_min', 3
+result = @nil_count_pop.metrics.popmin(nil)
+[result.length, result[0], result[1], result[0].is_a?(String), result[1].is_a?(Float)]
+#=> [2, 'solo_min', 3.0, true, true]
+
+## Familia::SortedSet#popmax(nil) normalizes to count=1 and returns a flat pair
+@nil_count_pop.metrics.add 'solo_max', 999
+result = @nil_count_pop.metrics.popmax(nil)
+[result.length, result[0], result[1], result[0].is_a?(String), result[1].is_a?(Float)]
+#=> [2, 'solo_max', 999.0, true, true]
+
+## Familia::SortedSet#popmin(nil) vs popmin and popmin(1) all equivalent
+# The three invocations must produce structurally identical flat pairs.
+@nil_equiv_pop = Bone.new 'zset_nil_equiv_pop'
+@nil_equiv_pop.metrics.add 'same', 42
+no_arg = @nil_equiv_pop.metrics.popmin
+@nil_equiv_pop.metrics.add 'same', 42
+explicit_one = @nil_equiv_pop.metrics.popmin(1)
+@nil_equiv_pop.metrics.add 'same', 42
+nil_arg = @nil_equiv_pop.metrics.popmin(nil)
+[no_arg, explicit_one, nil_arg, no_arg == explicit_one && explicit_one == nil_arg]
+#=> [['same', 42.0], ['same', 42.0], ['same', 42.0], true]
+
+## Familia::SortedSet#popmin(nil) on empty set returns nil
+# Consistency with popmin and popmin(1) empty-set behavior.
+@empty_zset.metrics.popmin(nil)
+#=> nil
+
+## Familia::SortedSet#popmax(nil) on empty set returns nil
+@empty_zset.metrics.popmax(nil)
+#=> nil
+
 # ============================================================
 # score_count/zcount - Test score range counting
 # ============================================================
@@ -417,4 +455,6 @@ result = @symbol_test.metrics.popmin
 @array_member_pop.metrics.delete! if defined?(@array_member_pop) && @array_member_pop
 @two_member_pop.metrics.delete! if defined?(@two_member_pop) && @two_member_pop
 @explicit_count_pop.metrics.delete! if defined?(@explicit_count_pop) && @explicit_count_pop
+@nil_count_pop.metrics.delete! if defined?(@nil_count_pop) && @nil_count_pop
+@nil_equiv_pop.metrics.delete! if defined?(@nil_equiv_pop) && @nil_equiv_pop
 Familia.dbclient.del(@dest_key)

--- a/try/unit/data_types/sortedset_operations_try.rb
+++ b/try/unit/data_types/sortedset_operations_try.rb
@@ -256,9 +256,6 @@ result.sort
 # rangebylex/revrangebylex - Test lexicographical ordering
 # NOTE: Values are JSON-serialized (e.g., "apple" -> "\"apple\""), so lex
 # boundaries must match the serialized format.
-# NOTE: Tests with limit: option are omitted because the current Familia
-# implementation passes limit as positional args but redis-rb expects
-# a keyword argument. See rangebylex in sorted_set.rb.
 # ============================================================
 
 ## Familia::SortedSet#rangebylex returns members in lex range (inclusive)
@@ -280,6 +277,16 @@ result.sort
 ## Familia::SortedSet#revrangebylex with range
 @lex_test.metrics.revrangebylex('["date"', '["banana"')
 #=> ['date', 'cherry', 'banana']
+
+## Familia::SortedSet#rangebylex with limit returns sliced range
+# limit: [offset, count] - skip 1, take 2 from {apple, banana, cherry, date, elderberry}
+@lex_test.metrics.rangebylex('-', '+', limit: [1, 2])
+#=> ['banana', 'cherry']
+
+## Familia::SortedSet#revrangebylex with limit returns sliced reverse range
+# limit: [offset, count] - skip 1, take 2 from reversed {elderberry, date, cherry, banana, apple}
+@lex_test.metrics.revrangebylex('+', '-', limit: [1, 2])
+#=> ['date', 'cherry']
 
 # ============================================================
 # lexcount - Test counting in lex range

--- a/try/unit/data_types/stringkey_extended_try.rb
+++ b/try/unit/data_types/stringkey_extended_try.rb
@@ -1,0 +1,154 @@
+# try/unit/data_types/stringkey_extended_try.rb
+#
+# frozen_string_literal: true
+
+# Tests for extended StringKey Redis commands
+
+require_relative '../../support/helpers/test_helpers'
+
+@str = Familia::StringKey.new 'test:stringkey:extended'
+@str2 = Familia::StringKey.new 'test:stringkey:extended2'
+@str3 = Familia::StringKey.new 'test:stringkey:extended3'
+
+## Setup: set initial value (Ruby assignment returns the assigned value)
+@str.value = '100'
+#=> '100'
+
+## incrbyfloat increments by a float value
+@str.incrbyfloat(0.5)
+#=> 100.5
+
+## incrbyfloat with negative value
+@str.incrbyfloat(-0.25)
+#=> 100.25
+
+## incrfloat alias works
+@str.incrfloat(0.75)
+#=> 101.0
+
+## setex sets value with expiration
+@str2.setex(10, 'temporary')
+@str2.value
+#=> 'temporary'
+
+## setex key has TTL
+@str2.ttl > 0
+#=> true
+
+## psetex sets value with millisecond expiration
+@str3.psetex(5000, 'ms_temp')
+@str3.value
+#=> 'ms_temp'
+
+## psetex key has TTL (in seconds, so should be > 0)
+@str3.ttl > 0
+#=> true
+
+## getdel returns value and deletes
+@str.value = 'getdel_test'
+result = @str.getdel
+[result, @str.value]
+#=> ['getdel_test', nil]
+
+## getex returns value
+@str.value = 'getex_test'
+@str.getex
+#=> 'getex_test'
+
+## getex with ex sets expiration
+@str.getex(ex: 30)
+@str.ttl > 0
+#=> true
+
+## bitcount on empty string
+@str.delete!
+@str.bitcount
+#=> 0
+
+## bitcount after setting value ('f'=6bits, 'o'=4bits: 6+4+4+6=20)
+@str.value = 'foof'
+@str.bitcount
+#=> 20
+
+## bitcount with range
+@str.bitcount(0, 1)
+#=> 10
+
+## bitpos finds first set bit
+@str.value = "\x00\xff"
+@str.bitpos(1)
+#=> 8
+
+## bitpos finds first unset bit
+@str.bitpos(0)
+#=> 0
+
+## bitpos with start position
+@str.bitpos(1, 1)
+#=> 8
+
+## bitfield GET operation
+@str.delete!
+@str.setbit(0, 1)
+@str.setbit(1, 1)
+@str.setbit(2, 1)
+@str.bitfield('GET', 'u8', 0)
+#=> [224]
+
+## bitfield SET operation
+@str.delete!
+@str.bitfield('SET', 'u8', 0, 100)
+@str.bitfield('GET', 'u8', 0)
+#=> [100]
+
+## mget retrieves multiple keys (pass hash with braces to avoid kwarg interpretation)
+Familia::StringKey.mset({ 'mget:test:1' => 'one', 'mget:test:2' => 'two' })
+Familia::StringKey.mget('mget:test:1', 'mget:test:2', 'mget:test:nonexistent')
+#=> ['one', 'two', nil]
+
+## mset sets multiple keys atomically
+Familia::StringKey.mset({ 'mset:test:a' => 'alpha', 'mset:test:b' => 'beta' })
+[Familia.dbclient.get('mset:test:a'), Familia.dbclient.get('mset:test:b')]
+#=> ['alpha', 'beta']
+
+## msetnx sets only if all keys don't exist
+Familia.dbclient.del('msetnx:test:1', 'msetnx:test:2')
+result1 = Familia::StringKey.msetnx({ 'msetnx:test:1' => 'first', 'msetnx:test:2' => 'second' })
+result2 = Familia::StringKey.msetnx({ 'msetnx:test:1' => 'new', 'msetnx:test:3' => 'third' })
+[result1, result2]
+#=> [true, false]
+
+## bitop performs bitwise AND (returns size of resulting string)
+# Clean up any stale keys first, use simple ASCII strings to avoid encoding issues
+Familia.dbclient.del('stringkey_ext:bitop:a', 'stringkey_ext:bitop:b', 'stringkey_ext:bitop:result')
+Familia.dbclient.set('stringkey_ext:bitop:a', 'abc')
+Familia.dbclient.set('stringkey_ext:bitop:b', 'ABC')
+result_size = Familia::StringKey.bitop(:and, 'stringkey_ext:bitop:result', 'stringkey_ext:bitop:a', 'stringkey_ext:bitop:b')
+result_size
+#=> 3
+
+## bitop AND produces expected result (lowercase AND uppercase = uppercase)
+# 'a' (0x61) AND 'A' (0x41) = 0x41 = 'A', same for b/B and c/C
+Familia.dbclient.get('stringkey_ext:bitop:result')
+#=> "ABC"
+
+## bitop performs bitwise OR (returns size of resulting string)
+Familia.dbclient.del('stringkey_ext:bitop:c', 'stringkey_ext:bitop:d', 'stringkey_ext:bitop:or_result')
+Familia.dbclient.set('stringkey_ext:bitop:c', 'abc')
+Familia.dbclient.set('stringkey_ext:bitop:d', 'ABC')
+result_size = Familia::StringKey.bitop(:or, 'stringkey_ext:bitop:or_result', 'stringkey_ext:bitop:c', 'stringkey_ext:bitop:d')
+result_size
+#=> 3
+
+## bitop OR produces expected result (lowercase OR uppercase = lowercase)
+Familia.dbclient.get('stringkey_ext:bitop:or_result')
+#=> "abc"
+
+## Teardown
+@str.delete!
+@str2.delete!
+@str3.delete!
+Familia.dbclient.del('mget:test:1', 'mget:test:2')
+Familia.dbclient.del('mset:test:a', 'mset:test:b')
+Familia.dbclient.del('msetnx:test:1', 'msetnx:test:2', 'msetnx:test:3')
+Familia.dbclient.del('stringkey_ext:bitop:a', 'stringkey_ext:bitop:b', 'stringkey_ext:bitop:c', 'stringkey_ext:bitop:d', 'stringkey_ext:bitop:result', 'stringkey_ext:bitop:or_result')

--- a/try/unit/data_types/stringkey_extended_try.rb
+++ b/try/unit/data_types/stringkey_extended_try.rb
@@ -144,10 +144,63 @@ result_size
 Familia.dbclient.get('stringkey_ext:bitop:or_result')
 #=> "abc"
 
+## mset stores values raw (no JSON quoting) per documented passthrough contract
+# The class method does NOT apply serialize_value. A plain string "hello"
+# must land in Redis as "hello" (6 bytes with no surrounding quotes), not
+# as "\"hello\"" (7 bytes with JSON quoting).
+Familia.dbclient.del('passthrough:mset:testkey')
+Familia::StringKey.mset({ 'passthrough:mset:testkey' => 'hello' })
+raw = Familia.dbclient.get('passthrough:mset:testkey')
+Familia.dbclient.del('passthrough:mset:testkey')
+[raw, raw.bytesize]
+#=> ['hello', 5]
+
+## mget returns raw values as stored (no JSON deserialization)
+# If a caller stores a JSON-looking string via raw Redis SET, mget returns
+# that literal string, not a parsed Ruby object.
+Familia.dbclient.set('passthrough:mget:raw_json', '"quoted"')
+Familia.dbclient.set('passthrough:mget:literal', '42')
+result = Familia::StringKey.mget('passthrough:mget:raw_json', 'passthrough:mget:literal')
+Familia.dbclient.del('passthrough:mget:raw_json', 'passthrough:mget:literal')
+result
+#=> ['"quoted"', '42']
+
+## mset/mget round-trip with StringKey instance values
+# StringKey instances use raw .to_s serialization (per CLAUDE.md table), so
+# a value written via `instance.value=` can be read back raw via the class
+# mget passthrough without JSON mismatch.
+@pt_instance = Familia::StringKey.new 'passthrough:roundtrip:instance'
+@pt_instance.value = 'foo'
+via_class = Familia::StringKey.mget(@pt_instance.dbkey)
+[via_class, via_class.first == @pt_instance.value]
+#=> [['foo'], true]
+
+## msetnx stores values raw (no JSON quoting) per documented passthrough contract
+Familia.dbclient.del('passthrough:msetnx:k1', 'passthrough:msetnx:k2')
+Familia::StringKey.msetnx({ 'passthrough:msetnx:k1' => 'plain', 'passthrough:msetnx:k2' => 'text' })
+raws = [Familia.dbclient.get('passthrough:msetnx:k1'), Familia.dbclient.get('passthrough:msetnx:k2')]
+Familia.dbclient.del('passthrough:msetnx:k1', 'passthrough:msetnx:k2')
+raws
+#=> ['plain', 'text']
+
+## bitop uses key arguments as-is (no dbkey prefixing)
+# The passthrough contract requires the destination and source keys to be
+# used verbatim. Verify the destination key we supplied is the one Redis
+# actually wrote to.
+Familia.dbclient.del('passthrough:bitop:src1', 'passthrough:bitop:src2', 'passthrough:bitop:dest')
+Familia.dbclient.set('passthrough:bitop:src1', 'abc')
+Familia.dbclient.set('passthrough:bitop:src2', 'abc')
+size = Familia::StringKey.bitop(:and, 'passthrough:bitop:dest', 'passthrough:bitop:src1', 'passthrough:bitop:src2')
+dest_exists = Familia.dbclient.exists('passthrough:bitop:dest') > 0
+Familia.dbclient.del('passthrough:bitop:src1', 'passthrough:bitop:src2', 'passthrough:bitop:dest')
+[size, dest_exists]
+#=> [3, true]
+
 ## Teardown
 @str.delete!
 @str2.delete!
 @str3.delete!
+@pt_instance.delete! if defined?(@pt_instance) && @pt_instance
 Familia.dbclient.del('mget:test:1', 'mget:test:2')
 Familia.dbclient.del('mset:test:a', 'mset:test:b')
 Familia.dbclient.del('msetnx:test:1', 'msetnx:test:2', 'msetnx:test:3')

--- a/try/unit/data_types/stringkey_extended_try.rb
+++ b/try/unit/data_types/stringkey_extended_try.rb
@@ -144,6 +144,38 @@ result_size
 Familia.dbclient.get('stringkey_ext:bitop:or_result')
 #=> "abc"
 
+## mget honors explicit client: kwarg override
+Familia.dbclient.set('client_kwarg:mget:1', 'alpha')
+Familia.dbclient.set('client_kwarg:mget:2', 'beta')
+result = Familia::StringKey.mget('client_kwarg:mget:1', 'client_kwarg:mget:2', client: Familia.dbclient)
+Familia.dbclient.del('client_kwarg:mget:1', 'client_kwarg:mget:2')
+result
+#=> ['alpha', 'beta']
+
+## mset honors explicit client: kwarg override
+Familia.dbclient.del('client_kwarg:mset:1', 'client_kwarg:mset:2')
+Familia::StringKey.mset({ 'client_kwarg:mset:1' => 'one', 'client_kwarg:mset:2' => 'two' }, client: Familia.dbclient)
+result = [Familia.dbclient.get('client_kwarg:mset:1'), Familia.dbclient.get('client_kwarg:mset:2')]
+Familia.dbclient.del('client_kwarg:mset:1', 'client_kwarg:mset:2')
+result
+#=> ['one', 'two']
+
+## msetnx honors explicit client: kwarg override
+Familia.dbclient.del('client_kwarg:msetnx:1', 'client_kwarg:msetnx:2')
+result = Familia::StringKey.msetnx({ 'client_kwarg:msetnx:1' => 'first', 'client_kwarg:msetnx:2' => 'second' }, client: Familia.dbclient)
+Familia.dbclient.del('client_kwarg:msetnx:1', 'client_kwarg:msetnx:2')
+result
+#=> true
+
+## bitop honors explicit client: kwarg override
+Familia.dbclient.del('client_kwarg:bitop:a', 'client_kwarg:bitop:b', 'client_kwarg:bitop:result')
+Familia.dbclient.set('client_kwarg:bitop:a', 'abc')
+Familia.dbclient.set('client_kwarg:bitop:b', 'ABC')
+size = Familia::StringKey.bitop(:and, 'client_kwarg:bitop:result', 'client_kwarg:bitop:a', 'client_kwarg:bitop:b', client: Familia.dbclient)
+Familia.dbclient.del('client_kwarg:bitop:a', 'client_kwarg:bitop:b', 'client_kwarg:bitop:result')
+size
+#=> 3
+
 ## mset stores values raw (no JSON quoting) per documented passthrough contract
 # The class method does NOT apply serialize_value. A plain string "hello"
 # must land in Redis as "hello" (6 bytes with no surrounding quotes), not

--- a/try/unit/data_types/unsortedset_operations_try.rb
+++ b/try/unit/data_types/unsortedset_operations_try.rb
@@ -1,0 +1,153 @@
+# try/unit/data_types/unsortedset_operations_try.rb
+#
+# frozen_string_literal: true
+
+# Tests for UnsortedSet set operations: intersection, union, difference,
+# member_any?, scan, intercard, and store operations.
+
+require_relative '../../support/helpers/test_helpers'
+
+# Setup: Create test objects with sets
+@a = Bone.new 'set_ops_a'
+@b = Bone.new 'set_ops_b'
+@c = Bone.new 'set_ops_c'
+@dest = Bone.new 'set_ops_dest'
+
+# Populate sets with test data
+# Set A: {1, 2, 3, 4}
+@a.tags.add 1, 2, 3, 4
+
+# Set B: {3, 4, 5, 6}
+@b.tags.add 3, 4, 5, 6
+
+# Set C: {4, 5, 6, 7}
+@c.tags.add 4, 5, 6, 7
+
+## Familia::UnsortedSet#intersection returns common members between two sets
+@a.tags.intersection(@b.tags).sort
+#=> [3, 4]
+
+## Familia::UnsortedSet#inter is an alias for intersection
+@a.tags.inter(@b.tags).sort
+#=> [3, 4]
+
+## Familia::UnsortedSet#intersection with multiple sets
+@a.tags.intersection(@b.tags, @c.tags).sort
+#=> [4]
+
+## Familia::UnsortedSet#intersection with raw key string
+@a.tags.intersection(@b.tags.dbkey).sort
+#=> [3, 4]
+
+## Familia::UnsortedSet#union returns all unique members from both sets
+@a.tags.union(@b.tags).sort
+#=> [1, 2, 3, 4, 5, 6]
+
+## Familia::UnsortedSet#union with multiple sets
+@a.tags.union(@b.tags, @c.tags).sort
+#=> [1, 2, 3, 4, 5, 6, 7]
+
+## Familia::UnsortedSet#union with raw key string
+@a.tags.union(@b.tags.dbkey).sort
+#=> [1, 2, 3, 4, 5, 6]
+
+## Familia::UnsortedSet#difference returns members in A but not in B
+@a.tags.difference(@b.tags).sort
+#=> [1, 2]
+
+## Familia::UnsortedSet#diff is an alias for difference
+@a.tags.diff(@b.tags).sort
+#=> [1, 2]
+
+## Familia::UnsortedSet#difference with multiple sets
+# Returns members in A but not in B or C
+@a.tags.difference(@b.tags, @c.tags).sort
+#=> [1, 2]
+
+## Familia::UnsortedSet#difference with raw key string
+@a.tags.difference(@b.tags.dbkey).sort
+#=> [1, 2]
+
+## Familia::UnsortedSet#member_any? checks multiple members at once
+result = @a.tags.member_any?(1, 2, 99)
+[result[0], result[1], result[2]]
+#=> [true, true, false]
+
+## Familia::UnsortedSet#members? is an alias for member_any?
+result = @a.tags.members?(3, 4)
+result.all?
+#=> true
+
+## Familia::UnsortedSet#scan returns cursor and members
+cursor, members = @a.tags.scan(0)
+[cursor.is_a?(Integer), members.sort]
+#=> [true, [1, 2, 3, 4]]
+
+## Familia::UnsortedSet#scan with count hint
+cursor, members = @a.tags.scan(0, count: 2)
+cursor.is_a?(Integer)
+#=> true
+
+## Familia::UnsortedSet#intercard returns intersection count without retrieving members
+@a.tags.intercard(@b.tags)
+#=> 2
+
+## Familia::UnsortedSet#intersection_cardinality is an alias for intercard
+@a.tags.intersection_cardinality(@b.tags, @c.tags)
+#=> 1
+
+## Familia::UnsortedSet#intercard with limit stops early
+# With limit 1, counting stops after finding 1 common element
+@a.tags.intercard(@b.tags, limit: 1)
+#=> 1
+
+## Familia::UnsortedSet#interstore stores intersection in destination
+@dest.tags.delete!
+result = @a.tags.interstore(@dest.tags, @b.tags)
+[result, @dest.tags.members.sort]
+#=> [2, [3, 4]]
+
+## Familia::UnsortedSet#intersection_store is an alias for interstore
+@dest.tags.delete!
+@a.tags.intersection_store(@dest.tags, @b.tags)
+@dest.tags.members.sort
+#=> [3, 4]
+
+## Familia::UnsortedSet#unionstore stores union in destination
+@dest.tags.delete!
+result = @a.tags.unionstore(@dest.tags, @b.tags)
+[result, @dest.tags.members.sort]
+#=> [6, [1, 2, 3, 4, 5, 6]]
+
+## Familia::UnsortedSet#union_store is an alias for unionstore
+@dest.tags.delete!
+@a.tags.union_store(@dest.tags, @b.tags)
+@dest.tags.members.sort
+#=> [1, 2, 3, 4, 5, 6]
+
+## Familia::UnsortedSet#diffstore stores difference in destination
+@dest.tags.delete!
+result = @a.tags.diffstore(@dest.tags, @b.tags)
+[result, @dest.tags.members.sort]
+#=> [2, [1, 2]]
+
+## Familia::UnsortedSet#difference_store is an alias for diffstore
+@dest.tags.delete!
+@a.tags.difference_store(@dest.tags, @b.tags)
+@dest.tags.members.sort
+#=> [1, 2]
+
+## Familia::UnsortedSet#interstore with raw key string destination
+raw_dest_key = "familia:test:raw_dest_set"
+Familia.dbclient.del(raw_dest_key)
+@a.tags.interstore(raw_dest_key, @b.tags)
+result = Familia.dbclient.smembers(raw_dest_key).map { |v| Familia::JsonSerializer.parse(v) }.sort
+Familia.dbclient.del(raw_dest_key)
+result
+#=> [3, 4]
+
+# Teardown: Clean up test data
+@a.tags.delete!
+@b.tags.delete!
+@c.tags.delete!
+@dest.tags.delete!

--- a/try/unit/data_types/unsortedset_operations_try.rb
+++ b/try/unit/data_types/unsortedset_operations_try.rb
@@ -146,6 +146,27 @@ Familia.dbclient.del(raw_dest_key)
 result
 #=> [3, 4]
 
+## Familia::UnsortedSet#intercard with limit returns an Integer (not a Hash)
+result = @a.tags.intercard(@b.tags, limit: 5)
+[result.is_a?(Integer), result]
+#=> [true, 2]
+
+## Familia::UnsortedSet#random returns deserialized members matching #sample shape
+members = @a.tags.random(2)
+[members.is_a?(Array), members.length, members.all? { |m| [1, 2, 3, 4].include?(m) }]
+#=> [true, 2, true]
+
+## Familia::UnsortedSet#randomraw returns raw (undeserialized) members
+raw = @a.tags.randomraw(2)
+[raw.is_a?(Array), raw.length, raw.all? { |m| m.is_a?(String) }]
+#=> [true, 2, true]
+
+## Familia::UnsortedSet#random and #sample produce the same output shape
+sample_result = @a.tags.sample(1)
+random_result = @a.tags.random(1)
+[sample_result.class, random_result.class, sample_result.first.is_a?(Integer), random_result.first.is_a?(Integer)]
+#=> [Array, Array, true, true]
+
 # Teardown: Clean up test data
 @a.tags.delete!
 @b.tags.delete!

--- a/try/unit/data_types/unsortedset_operations_try.rb
+++ b/try/unit/data_types/unsortedset_operations_try.rb
@@ -84,7 +84,7 @@ cursor, members = @a.tags.scan(0)
 #=> [true, [1, 2, 3, 4]]
 
 ## Familia::UnsortedSet#scan with count hint
-cursor, members = @a.tags.scan(0, count: 2)
+cursor, = @a.tags.scan(0, count: 2)
 cursor.is_a?(Integer)
 #=> true
 

--- a/try/unit/horreum/destroy_related_fields_cleanup_try.rb
+++ b/try/unit/horreum/destroy_related_fields_cleanup_try.rb
@@ -261,8 +261,8 @@ destroy_result = model.destroy!
 # time (under 100ms for this test). I acknowledge this is flaky.
 # Note: 42 results = 40 related field DELs + 1 main object DEL + 1 instances ZREM
 [destroy_result.class, destroy_result.successful?, destroy_result.results.size]
+#=%> 250
 #=> [MultiResult, true, 42]
-#=%> 100
 
 ## Verify transaction_fallback_integration_try.rb bug is fixed
 # Recreate the scenario from the failing test


### PR DESCRIPTION
### **User description**
## Summary

Adds 60+ missing Redis 7 commands across all five DataType classes (StringKey, List, UnsortedSet, SortedSet, HashKey), bringing Familia's command coverage from ~50-65% to near-complete for commonly used operations.

**Key additions by type:**

- **StringKey**: Float increments (`incrbyfloat`), atomic get operations (`getex`, `getdel`), TTL-aware setters (`setex`, `psetex`), comprehensive bit operations (`bitcount`, `bitpos`, `bitfield`), and class methods for multi-key operations (`mget`, `mset`, `msetnx`, `bitop`)

- **List**: `trim`, `set`, `insert`, `move`, conditional pushes (`pushx`, `unshiftx`). Updated `pop`/`shift` to accept optional count parameter for batch operations while maintaining backward compatibility

- **UnsortedSet**: Set algebra (`intersection`, `union`, `difference`), batch membership testing (`member_any?`), cursor iteration (`scan`), and store variants for all operations

- **SortedSet**: Priority queue operations (`popmin`, `popmax`), score queries (`score_count`, `mscore`), lexicographical range queries, random member selection, and full set operation support (`union`, `inter`, `diff` with store variants)

- **HashKey**: Cursor-based scanning (`scan`), float increment (`incrbyfloat`), string length (`strlen`), random field selection (`randfield`), plus Redis 7.4+ field-level TTL commands (9 methods for fine-grained expiration control)

## Test plan

- [x] Added 158 new tests across 5 test files covering all new methods
- [x] All 514 DataType tests pass
- [x] Tests focus on Familia-specific behavior (serialization, deserialization, aliases) rather than re-testing redis-rb
- [x] No `method_missing` usage in implementation or tests
- [ ] Reviewer: Verify expected behavior for your use cases

## Breaking changes

None. All additions are backward compatible. The only signature change (`pop`/`shift` with optional count) defaults to existing behavior.

🤖 Generated with [Claude Code](https://claude.ai/code)


___

### **PR Type**
Enhancement


___

### **Description**
- Adds 60+ Redis 7 commands across all five DataType classes

- StringKey: float increments, atomic gets, TTL-aware setters, bit operations, multi-key class methods

- List: trim, set, insert, move, conditional pushes; pop/shift now support optional count parameter

- UnsortedSet: set algebra (intersection, union, difference), batch membership testing, cursor iteration, store variants

- SortedSet: priority queue ops (popmin, popmax), score queries, lexicographical ranges, random selection, full set operations

- HashKey: cursor scanning, float increment, string length, random field selection, Redis 7.4+ field-level TTL commands (9 methods)

- Includes 156 new tests across 5 test files; all 514 DataType tests pass


___

### Diagram Walkthrough


```mermaid
flowchart LR
  StringKey["StringKey<br/>incrbyfloat, getex, getdel<br/>setex, psetex, bitcount<br/>bitpos, bitfield, mget<br/>mset, msetnx, bitop"]
  List["List<br/>trim, set, insert, move<br/>pushx, unshiftx<br/>pop/shift with count"]
  UnsortedSet["UnsortedSet<br/>intersection, union, difference<br/>member_any?, scan<br/>intercard, interstore<br/>unionstore, diffstore"]
  SortedSet["SortedSet<br/>popmin, popmax<br/>score_count, mscore<br/>union, inter, diff<br/>rangebylex, lexcount<br/>randmember, scan<br/>unionstore, interstore"]
  HashKey["HashKey<br/>scan, incrbyfloat<br/>strlen, randfield<br/>Field-level TTL 7.4+<br/>expire_fields, ttl_fields<br/>persist_fields, etc"]
  
  StringKey --> Tests["156 New Tests<br/>5 Test Files"]
  List --> Tests
  UnsortedSet --> Tests
  SortedSet --> Tests
  HashKey --> Tests
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>5 files</summary><table>
<tr>
  <td><strong>stringkey.rb</strong><dd><code>Add float increments, atomic gets, TTL setters, bit operations</code></dd></td>
  <td><a href="https://github.com/delano/familia/pull/209/files#diff-5d57afab7ca1ddb65a80367cca2741574e90b61d4f988286789c538df546de6f">+139/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>listkey.rb</strong><dd><code>Add trim, set, insert, move, conditional pushes with batch pop/shift</code></dd></td>
  <td><a href="https://github.com/delano/familia/pull/209/files#diff-c206daaf8b296e53faec64fc02f2a8b260da4cdd01df5fcfcd1d57bde896ca09">+110/-4</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>unsorted_set.rb</strong><dd><code>Add set algebra, membership testing, scanning, store operations</code></dd></td>
  <td><a href="https://github.com/delano/familia/pull/209/files#diff-72c69f92c6afe535b01587f20aee54f5425056e381910ea4c7aac905778d6c73">+122/-2</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>sorted_set.rb</strong><dd><code>Add priority queue ops, score queries, lex ranges, set operations</code></dd></td>
  <td><a href="https://github.com/delano/familia/pull/209/files#diff-355552fa8f253de65c8788046db88d2525e959375144d4d10133bbc17ed7d44d">+365/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>hashkey.rb</strong><dd><code>Add scanning, float increment, field-level TTL commands (Redis 7.4+)</code></dd></td>
  <td><a href="https://github.com/delano/familia/pull/209/files#diff-0f1568dc0ff77add2416ffeec746e4995a799cd44650558ebcf5a059a7667e27">+238/-0</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>5 files</summary><table>
<tr>
  <td><strong>stringkey_extended_try.rb</strong><dd><code>Test float increments, TTL setters, bit operations, multi-key methods</code></dd></td>
  <td><a href="https://github.com/delano/familia/pull/209/files#diff-ca089d734217042cae9f8fd92f8e498ea782ea7594e8ec52212cb3264d204601">+154/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>list_commands_try.rb</strong><dd><code>Test trim, set, insert, move, pushx, unshiftx, batch pop/shift</code></dd></td>
  <td><a href="https://github.com/delano/familia/pull/209/files#diff-c7c30076f4ec2e0765df55e8ae2ab9b4a30414dcd85e0c5a82924cb26b7e7d77">+187/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>unsortedset_operations_try.rb</strong><dd><code>Test set algebra, membership testing, scanning, store operations</code></dd></td>
  <td><a href="https://github.com/delano/familia/pull/209/files#diff-81347884b6f2a796be00a4751f4f01b567c0ae9b652ca4160601da09e733601a">+153/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>sortedset_operations_try.rb</strong><dd><code>Test priority queue ops, score queries, lex ranges, set operations</code></dd></td>
  <td><a href="https://github.com/delano/familia/pull/209/files#diff-b398dadbef4ca25979ed13440b862ae596cd2bed4ca95661d73855618aa81f4e">+379/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>hashkey_operations_try.rb</strong><dd><code>Test scanning, float increment, field-level TTL operations</code></dd></td>
  <td><a href="https://github.com/delano/familia/pull/209/files#diff-ba5c2a0171ebc72ebdeee50682624dbd9315279673de7ed39878d59123d17886">+246/-0</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>20260120_003058_delano_bit_part.rst</strong><dd><code>Document all new Redis 7 command additions and test coverage</code></dd></td>
  <td><a href="https://github.com/delano/familia/pull/209/files#diff-95863c4d8f8801d33c172da2c8d914f2b0537b401c5b585965465e9aff6de233">+40/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tbody></table>

</details>

___

