### PR TITLE
Fix destroy! to remove class-level unique_index and multi_index entries

### DIFF
--- a/changelog.d/20260417_110137_delano_241_destroy_index_cleanup.rst
+++ b/changelog.d/20260417_110137_delano_241_destroy_index_cleanup.rst
@@ -1,0 +1,33 @@
+Fixed
+-----
+
+- ``Horreum#destroy!`` now cleans up class-level ``unique_index`` and
+  ``multi_index`` entries within the same transaction that deletes the
+  object hash and removes it from the ``instances`` timeline. Previously,
+  stale entries remained and caused ``RecordExistsError`` on a subsequent
+  ``create!`` with the same indexed value. Issue #241.
+
+- Aligned ``guard_unique_indexes!`` with the ``within`` filter used by
+  ``auto_update_class_indexes`` and the new ``remove_from_class_indexes!``
+  helper, keeping validate/update/cleanup paths symmetric for any future
+  ``unique_index`` declared ``within: :class``.
+
+Changed
+-------
+
+- Instance-scoped index entries (``unique_index`` / ``multi_index``
+  declared with ``within: SomeClass``) remain orphaned after ``destroy!``.
+  This is a known limitation carried over from prior releases and now
+  tracked separately as issue #244. Until that issue is closed, callers
+  using instance-scoped indexes should remove entries explicitly (e.g.,
+  ``employee.remove_from_company_badge_index(company)``) before
+  ``destroy!``.
+
+AI Assistance
+-------------
+
+- Issue triage, code review, failing-tryout authoring, and implementation
+  were coordinated across several specialized Claude Code agents
+  (qa-automation-engineer for test coverage, backend-dev for the fix,
+  feature-dev:code-reviewer for verification of transaction atomicity
+  and filter symmetry).

--- a/lib/familia/features/relationships/indexing_relationship.rb
+++ b/lib/familia/features/relationships/indexing_relationship.rb
@@ -41,6 +41,19 @@ module Familia
         def scope_class_config_name
           scope_class.config_name
         end
+
+        # Whether this is a class-level index (as opposed to instance-scoped).
+        #
+        # Class-level indexes live under the class and use `within: nil`
+        # (unique_index default) or `within: :class` (multi_index class scope).
+        # Instance-scoped indexes use `within: SomeClass` and require a scope
+        # instance to populate or query.
+        #
+        # @return [Boolean]
+        #
+        def class_level?
+          within.nil? || within == :class
+        end
       end
     end
   end

--- a/lib/familia/horreum/persistence.rb
+++ b/lib/familia/horreum/persistence.rb
@@ -544,6 +544,11 @@ module Familia
             end
           end
 
+          # Clean up class-level index entries (see issue #241).
+          # Instance-scoped indexes require a scope instance unavailable here;
+          # tracked separately in issue #244.
+          remove_from_class_indexes!
+
           # Remove from instances collection
           remove_from_instances!
         end
@@ -774,7 +779,9 @@ module Familia
           next unless rel.cardinality == :unique
 
           # Only validate class-level indexes (skip instance-scoped)
-          next if rel.within
+          # Matches the filter used by auto_update_class_indexes and
+          # remove_from_class_indexes! so guard/update/cleanup stay symmetric.
+          next if rel.within && rel.within != :class
 
           # Call the validation method if it exists
           validate_method = :"guard_unique_#{rel.index_name}!"
@@ -832,6 +839,32 @@ module Familia
           # Call the existing add_to_class_* methods
           add_method = :"add_to_class_#{rel.index_name}"
           send(add_method) if respond_to?(add_method)
+        end
+      end
+
+      # Remove class-level index entries during destroy!
+      #
+      # Iterates through class-level indexing relationships and calls their
+      # corresponding remove_from_class_* methods to purge stale entries.
+      # Only processes class-level indexes (where within is nil or :class),
+      # skipping instance-scoped indexes which require scope context that
+      # destroy! does not have. See issue #241 for the class-level fix;
+      # instance-scoped cleanup is tracked as a known limitation.
+      #
+      # Intended to be called from inside destroy!'s MULTI/EXEC transaction
+      # so index hash/set mutations are atomic with the object hash delete.
+      #
+      # @return [void]
+      #
+      def remove_from_class_indexes!
+        return unless self.class.respond_to?(:indexing_relationships)
+
+        self.class.indexing_relationships.each do |rel|
+          # Skip instance-scoped indexes (require scope context unavailable here)
+          next if rel.within && rel.within != :class
+
+          remove_method = :"remove_from_class_#{rel.index_name}"
+          send(remove_method) if respond_to?(remove_method)
         end
       end
 

--- a/lib/familia/horreum/persistence.rb
+++ b/lib/familia/horreum/persistence.rb
@@ -778,10 +778,7 @@ module Familia
           # Only validate unique indexes (not multi_index)
           next unless rel.cardinality == :unique
 
-          # Only validate class-level indexes (skip instance-scoped)
-          # Matches the filter used by auto_update_class_indexes and
-          # remove_from_class_indexes! so guard/update/cleanup stay symmetric.
-          next if rel.within && rel.within != :class
+          next unless rel.class_level?
 
           # Call the validation method if it exists
           validate_method = :"guard_unique_#{rel.index_name}!"
@@ -823,13 +820,7 @@ module Familia
         return unless self.class.respond_to?(:indexing_relationships)
 
         self.class.indexing_relationships.each do |rel|
-          # Skip instance-scoped indexes (require scope context)
-          # Instance-scoped indexes must be manually populated because they need
-          # the scope instance reference (e.g., employee.add_to_company_badge_index(company))
-          #
-          # Class-level indexes have within: nil (unique_index) or within: :class (multi_index)
-          # Instance-scoped indexes have within: SomeClass (a specific class)
-          if rel.within && rel.within != :class
+          unless rel.class_level?
             Familia.debug <<~LOG_MESSAGE
               [auto_update_class_indexes] Skipping #{rel.index_name} (requires scope context)
             LOG_MESSAGE
@@ -860,11 +851,16 @@ module Familia
         return unless self.class.respond_to?(:indexing_relationships)
 
         self.class.indexing_relationships.each do |rel|
-          # Skip instance-scoped indexes (require scope context unavailable here)
-          next if rel.within && rel.within != :class
+          next unless rel.class_level?
 
           remove_method = :"remove_from_class_#{rel.index_name}"
-          send(remove_method) if respond_to?(remove_method)
+          if respond_to?(remove_method)
+            send(remove_method)
+          else
+            Familia.debug <<~LOG_MESSAGE
+              [remove_from_class_indexes!] Missing #{remove_method} for #{self.class}##{rel.index_name}; stale index entries may remain
+            LOG_MESSAGE
+          end
         end
       end
 

--- a/try/unit/horreum/destroy_index_cleanup_try.rb
+++ b/try/unit/horreum/destroy_index_cleanup_try.rb
@@ -1,0 +1,157 @@
+# try/unit/horreum/destroy_index_cleanup_try.rb
+#
+# frozen_string_literal: true
+
+# Horreum destroy! Class-Level Index Cleanup Tryouts
+#
+# Reproduces GitHub issue #241: `Horreum#destroy!` removes the object hash,
+# related fields, and the entry from the class-level `instances` sorted set,
+# but does NOT remove entries from class-level `unique_index` hashes or
+# `multi_index` sets. Stale `email_index[value] -> objid` entries persist
+# after destroy and cause `RecordExistsError` on the next `create!` with
+# the same indexed value.
+#
+# Scope: class-level indexes only (`within: nil` / `within: :class`).
+# Instance-scoped indexes (`within: SomeClass`) are a known limitation
+# documented separately -- they are not covered by the #241 fix and
+# remain orphaned after destroy!.
+
+require_relative '../../support/helpers/test_helpers'
+
+Familia.debug = false
+
+# Throwaway test class that exercises both class-level unique and
+# multi-index mutation paths. Named with the issue number to avoid
+# colliding with any existing test fixtures.
+class ::Widget241 < Familia::Horreum
+  feature :relationships
+
+  identifier_field :objid
+  field :objid
+  field :name
+  field :category
+
+  # Class-level unique index -- stored as a single HashKey mapping
+  # name -> objid. Every object's save auto-populates; destroy! should
+  # remove the corresponding entry but currently does not (bug #241).
+  unique_index :name, :name_index
+
+  # Class-level multi-index -- stored per-value as an UnsortedSet named
+  # `category_index:<value>`. Every object's save auto-populates; destroy!
+  # should remove the identifier from the per-value set but currently
+  # does not (bug #241).
+  multi_index :category, :category_index
+end
+
+# Start from a clean slate for indexes so previous test runs don't leak.
+Familia.dbclient.flushdb
+
+## Class-level unique_index is populated by save
+@w1 = Widget241.create!(objid: 'w241-unique-001', name: 'alpha')
+Widget241.name_index.get('alpha')
+#=> 'w241-unique-001'
+
+## BUG #241: destroy! leaves a stale entry in the class-level unique_index
+# Expected behavior: after destroy!, the `name_index` no longer contains
+# an entry for 'alpha' (so a subsequent create! with the same name
+# succeeds instead of raising RecordExistsError).
+@w1.destroy!
+Widget241.name_index.get('alpha')
+#=> nil
+
+## BUG #241: re-creating with the same indexed value succeeds after destroy!
+# With the stale entry removed, this should not raise RecordExistsError.
+@w1b = Widget241.create!(objid: 'w241-unique-002', name: 'alpha')
+Widget241.name_index.get('alpha')
+#=> 'w241-unique-002'
+
+## Class-level multi_index is populated by save
+@m1 = Widget241.create!(objid: 'w241-multi-001', name: 'm-one',   category: 'tools')
+@m2 = Widget241.create!(objid: 'w241-multi-002', name: 'm-two',   category: 'tools')
+@m3 = Widget241.create!(objid: 'w241-multi-003', name: 'm-three', category: 'tools')
+Widget241.category_index_for('tools').members.sort
+#=> ['w241-multi-001', 'w241-multi-002', 'w241-multi-003']
+
+## BUG #241: destroy! leaves stale entries in the class-level multi_index
+# Expected behavior: after destroying m2, only m1 and m3 remain in the
+# per-value set for 'tools' -- m2's identifier should be gone.
+@m2.destroy!
+Widget241.category_index_for('tools').members.sort
+#=> ['w241-multi-001', 'w241-multi-003']
+
+## BUG #241: re-creating with the same multi_index value succeeds after destroy!
+# This verifies the per-value set is usable for new members after cleanup.
+@m2b = Widget241.create!(objid: 'w241-multi-004', name: 'm-two-again', category: 'tools')
+Widget241.category_index_for('tools').members.include?('w241-multi-004')
+#=> true
+
+## Regression: destroy! still removes the object hash
+# This is the unchanged existing behavior -- confirms we didn't break
+# the basic destroy! path while exercising the index cleanup bug.
+@r1 = Widget241.create!(objid: 'w241-regress-001', name: 'reg-one', category: 'regress')
+@r1.destroy!
+Widget241.exists?('w241-regress-001')
+#=> false
+
+## Regression: destroy! still removes from the instances timeline
+# Another existing guarantee: `remove_from_instances!` runs inside destroy!.
+Widget241.in_instances?('w241-regress-001')
+#=> false
+
+## Regression: destroy! on a never-persisted object does not raise
+# The generated remove_from_class_#{index_name} methods short-circuit via
+# `return unless field_value`, so destroying an instance that was never
+# saved (all indexed fields still nil) must be a safe no-op.
+begin
+  Widget241.new(objid: 'w241-unsaved-001').destroy!
+  :no_raise
+rescue StandardError => e
+  "raised: #{e.class.name}"
+end
+#=> :no_raise
+
+## Instance-scoped index cleanup is out of scope for #241 (documented limitation)
+# The fix in #241 covers only class-level indexes. Instance-scoped indexes
+# (`within: SomeClass`) require a parent context to resolve the set, so
+# destroy! -- which has no parent reference -- cannot clean them up here.
+# This test asserts the *current, unchanged* behavior so we notice if it
+# ever changes unintentionally. Do not "fix" this by making the assertion
+# match the class-level cleanup behavior; tracking is separate from #241.
+class ::Widget241ScopedCompany < Familia::Horreum
+  feature :relationships
+  identifier_field :company_id
+  field :company_id
+end
+
+class ::Widget241ScopedEmployee < Familia::Horreum
+  feature :relationships
+  identifier_field :emp_id
+  field :emp_id
+  field :badge
+
+  # Instance-scoped unique index -- parent context is Widget241ScopedCompany.
+  unique_index :badge, :badge_index, within: Widget241ScopedCompany
+end
+
+@scope_company = Widget241ScopedCompany.create!(company_id: 'w241co-001')
+@scope_emp = Widget241ScopedEmployee.create!(emp_id: 'w241emp-001', badge: 'B-42')
+# Instance-scoped indexes don't auto-populate -- they need the parent context.
+@scope_emp.add_to_widget241scoped_company_badge_index(@scope_company)
+@scope_company.badge_index.has_key?('B-42')
+#=> true
+
+## Documented limitation: instance-scoped entry persists after destroy!
+# This is the known gap outside #241's scope. Flipping this expectation
+# would require threading parent context through destroy! -- tracked
+# separately.
+@scope_emp.destroy!
+@scope_company.badge_index.has_key?('B-42')
+#=> true
+
+# Teardown: flush the database and remove throwaway constants so this
+# tryout doesn't pollute sibling suites (index keys in particular can
+# otherwise interfere with re-run iterations).
+Familia.dbclient.flushdb
+Object.send(:remove_const, :Widget241) if Object.const_defined?(:Widget241)
+Object.send(:remove_const, :Widget241ScopedEmployee) if Object.const_defined?(:Widget241ScopedEmployee)
+Object.send(:remove_const, :Widget241ScopedCompany) if Object.const_defined?(:Widget241ScopedCompany)

--- a/try/unit/horreum/destroy_index_cleanup_try.rb
+++ b/try/unit/horreum/destroy_index_cleanup_try.rb
@@ -110,6 +110,49 @@ rescue StandardError => e
 end
 #=> :no_raise
 
+## Regression: destroy! with mixed nil/non-nil indexed fields populates only non-nil index
+# A widget with `name` set but `category` nil populates only the unique_index --
+# the multi_index's generated add_to_class_* method short-circuits on nil.
+@mixed = Widget241.create!(objid: 'w241-mixed-001', name: 'mixed-alpha')
+Widget241.name_index.get('mixed-alpha')
+#=> 'w241-mixed-001'
+
+## Regression: destroy! with mixed nil/non-nil indexed fields does not raise
+# Cleanup must iterate every class-level index and short-circuit cleanly
+# when the field value is nil, without raising or leaving stale state.
+begin
+  @mixed.destroy!
+  :no_raise
+rescue StandardError => e
+  "raised: #{e.class.name}"
+end
+#=> :no_raise
+
+## Regression: destroy! with mixed fields removed the populated (name) entry
+Widget241.name_index.get('mixed-alpha')
+#=> nil
+
+## Regression: inverse mixed state -- category set, name nil (asymmetric iteration)
+# indexing_relationships.each walks in registration order (name_index first,
+# then category_index). This case hits the opposite ordering so the cleanup
+# loop exercises a nil unique_index followed by a populated multi_index.
+@inverse = Widget241.create!(objid: 'w241-mixed-002', category: 'asymm')
+Widget241.category_index_for('asymm').members.include?('w241-mixed-002')
+#=> true
+
+## Regression: inverse mixed state destroy! does not raise
+begin
+  @inverse.destroy!
+  :no_raise
+rescue StandardError => e
+  "raised: #{e.class.name}"
+end
+#=> :no_raise
+
+## Regression: inverse mixed state destroy! removed the populated (category) entry
+Widget241.category_index_for('asymm').members.include?('w241-mixed-002')
+#=> false
+
 ## Instance-scoped index cleanup is out of scope for #241 (documented limitation)
 # The fix in #241 covers only class-level indexes. Instance-scoped indexes
 # (`within: SomeClass`) require a parent context to resolve the set, so


### PR DESCRIPTION
\`Horreum#destroy!\` left stale entries in class-level \`unique_index\` hashes and \`multi_index\` sets, causing \`RecordExistsError\` on subsequent \`create!\` with the same indexed value. The fix iterates \`indexing_relationships\` inside the existing MULTI/EXEC block and calls the generated \`remove_from_class_<index_name>\` methods for each class-level entry.

Also aligns \`guard_unique_indexes!\` with the same \`within\` filter used by \`auto_update_class_indexes\` and the new \`remove_from_class_indexes!\` helper, keeping validate/update/cleanup paths symmetric.

Instance-scoped index cleanup is a known limitation, tracked in #244.

Closes #241