### PR TITLE
Include existing_id in RecordExistsError messages and attribute

### DIFF
--- a/changelog.d/20260417_105359_delano_242_record_exists_error_existing_id.rst
+++ b/changelog.d/20260417_105359_delano_242_record_exists_error_existing_id.rst
@@ -1,0 +1,18 @@
+Changed
+-------
+
+- ``Familia::RecordExistsError`` now exposes ``#existing_id`` and appends
+  ``(existing_id=<id>)`` to its message when raised by the unique-index
+  guards in ``guard_unique_indexes!``. Diagnosing stale-index drift no
+  longer requires a secondary ``HGET`` to compare the drifted identifier
+  against the one on the record being saved. The attribute defaults to
+  ``nil`` and the message format is unchanged when absent, so existing
+  rescue patterns and the primary-key collision raised by
+  ``save_if_not_exists!`` are untouched. Issue #242.
+
+AI Assistance
+-------------
+
+- Implementation and test coverage drafted with Claude Code
+  (backend-dev + qa-automation-engineer subagents), reviewed by
+  feature-dev:code-reviewer.

--- a/lib/familia/errors.rb
+++ b/lib/familia/errors.rb
@@ -105,15 +105,13 @@ module Familia
     def initialize(key, existing_id: nil)
       @existing_id = existing_id
       @key = key
-      super(message)
+      super(key)
     end
 
     def message
-      if existing_id.nil?
-        "Key already exists: #{key}"
-      else
-        "Key already exists: #{key} (existing_id=#{existing_id})"
-      end
+      msg = "Key already exists: #{key}"
+      msg << " (existing_id=#{existing_id})" unless existing_id.nil?
+      msg
     end
   end
 end

--- a/lib/familia/errors.rb
+++ b/lib/familia/errors.rb
@@ -100,15 +100,20 @@ module Familia
   # Raised when attempting to create an object that already
   # exists in the database
   class RecordExistsError < NonUniqueKey
-    attr_reader :key
+    attr_reader :key, :existing_id
 
-    def initialize(key)
+    def initialize(key, existing_id: nil)
+      @existing_id = existing_id
       @key = key
-      super
+      super(message)
     end
 
     def message
-      "Key already exists: #{key}"
+      if existing_id.nil?
+        "Key already exists: #{key}"
+      else
+        "Key already exists: #{key} (existing_id=#{existing_id})"
+      end
     end
   end
 end

--- a/lib/familia/features/relationships/indexing/unique_index_generators.rb
+++ b/lib/familia/features/relationships/indexing/unique_index_generators.rb
@@ -283,8 +283,10 @@ module Familia
                 existing_id = index_hash.get(field_value.to_s)
 
                 if existing_id && existing_id != identifier
-                  raise Familia::RecordExistsError,
-                    "#{self.class} exists in #{scope_instance.class} with #{field}=#{field_value}"
+                  raise Familia::RecordExistsError.new(
+                    "#{self.class} exists in #{scope_instance.class} with #{field}=#{field_value}",
+                    existing_id: existing_id,
+                  )
                 end
               end
 
@@ -432,7 +434,10 @@ module Familia
                 existing_id = index_hash.get(field_value.to_s)
 
                 if existing_id && existing_id != identifier
-                  raise Familia::RecordExistsError, "#{self.class} exists #{field}=#{field_value}"
+                  raise Familia::RecordExistsError.new(
+                    "#{self.class} exists #{field}=#{field_value}",
+                    existing_id: existing_id,
+                  )
                 end
               end
 

--- a/try/unit/core/errors_try.rb
+++ b/try/unit/core/errors_try.rb
@@ -102,6 +102,30 @@ end
 Familia::RecordExistsError.superclass
 #=> Familia::NonUniqueKey
 
+## RecordExistsError.existing_id defaults to nil when not provided
+Familia::RecordExistsError.new('my_key').existing_id
+#=> nil
+
+## RecordExistsError.existing_id is exposed when provided as kwarg
+Familia::RecordExistsError.new('my_key', existing_id: 'abc123').existing_id
+#=> "abc123"
+
+## RecordExistsError message format when existing_id is nil
+Familia::RecordExistsError.new('my_key').message
+#=> "Key already exists: my_key"
+
+## RecordExistsError message format when existing_id is set
+Familia::RecordExistsError.new('my_key', existing_id: 'abc123').message
+#=> "Key already exists: my_key (existing_id=abc123)"
+
+## Legacy call style (single positional arg via raise) still works - existing_id is nil
+begin
+  raise Familia::RecordExistsError, 'legacy:key'
+rescue Familia::RecordExistsError => e
+  [e.existing_id, e.message]
+end
+#=> [nil, "Key already exists: legacy:key"]
+
 ## All error classes inherit from Problem
 [
   Familia::NoIdentifier,

--- a/try/unit/core/errors_try.rb
+++ b/try/unit/core/errors_try.rb
@@ -126,6 +126,11 @@ rescue Familia::RecordExistsError => e
 end
 #=> [nil, "Key already exists: legacy:key"]
 
+## RecordExistsError#message is idempotent across repeated calls
+err = Familia::RecordExistsError.new('my_key', existing_id: 'abc123')
+[err.message, err.message, err.message].uniq
+#=> ["Key already exists: my_key (existing_id=abc123)"]
+
 ## All error classes inherit from Problem
 [
   Familia::NoIdentifier,

--- a/try/unit/horreum/unique_index_guard_validation_try.rb
+++ b/try/unit/horreum/unique_index_guard_validation_try.rb
@@ -264,12 +264,80 @@ email = "tx_unique_#{unique_timestamp}_#{unique_rand}@example.com"
 @user_tx_unique.send(:guard_unique_indexes!)
 #=> nil
 
+# =============================================
+# 6. Drift Scenarios - existing_id Exposure (Issue #242)
+# =============================================
+
+## Class-level guard exposes existing_id when drift is detected
+# Simulate drift: write a stale identifier directly into the class-level index hash
+@drift_email = "drift_#{rand(1000000)}@example.com"
+@drift_stale_id = "stale_user_#{rand(1000000)}"
+GuardUser.email_index[@drift_email] = @drift_stale_id
+@drift_user = GuardUser.new(user_id: "user_drift_#{rand(1000000)}", email: @drift_email, username: "driftuser_#{rand(1000000)}")
+begin
+  @drift_user.guard_unique_email_index!
+  nil
+rescue Familia::RecordExistsError => e
+  e.existing_id
+end
+#=> @drift_stale_id
+
+## Class-level guard message includes (existing_id=...) on drift
+begin
+  @drift_user.guard_unique_email_index!
+  nil
+rescue Familia::RecordExistsError => e
+  e.message.include?("(existing_id=#{@drift_stale_id})")
+end
+#=> true
+
+## Class-level guard error type and key on drift
+begin
+  @drift_user.guard_unique_email_index!
+  nil
+rescue Familia::RecordExistsError => e
+  [e.class, e.key.include?('GuardUser'), e.key.include?("email=#{@drift_email}")]
+end
+#=> [Familia::RecordExistsError, true, true]
+
+## Instance-scoped guard exposes existing_id when drift is detected
+# Simulate drift: write a stale identifier directly into the scope instance's index hash
+@drift_badge = "DRIFT_BADGE_#{rand(1000000)}"
+@drift_scope_stale_id = "stale_emp_#{rand(1000000)}"
+@company.badge_index[@drift_badge] = @drift_scope_stale_id
+@drift_emp = GuardEmployee.new(emp_id: "emp_drift_#{rand(1000000)}", badge_number: @drift_badge, email: "drift_emp_#{rand(1000000)}@example.com")
+begin
+  @drift_emp.guard_unique_guard_company_badge_index!(@company)
+  nil
+rescue Familia::RecordExistsError => e
+  e.existing_id
+end
+#=> @drift_scope_stale_id
+
+## Instance-scoped guard message includes (existing_id=...) on drift
+begin
+  @drift_emp.guard_unique_guard_company_badge_index!(@company)
+  nil
+rescue Familia::RecordExistsError => e
+  e.message.include?("(existing_id=#{@drift_scope_stale_id})")
+end
+#=> true
+
+## Instance-scoped guard error type and key on drift
+begin
+  @drift_emp.guard_unique_guard_company_badge_index!(@company)
+  nil
+rescue Familia::RecordExistsError => e
+  [e.class, e.key.include?('GuardEmployee'), e.key.include?('GuardCompany'), e.key.include?("badge_number=#{@drift_badge}")]
+end
+#=> [Familia::RecordExistsError, true, true, true]
+
 # Teardown - clean up test objects
-[@user1, @user2, @user_nil, @user_empty1, @user_empty2, @user_dup, @user_tx, @user_tx_unique].each do |obj|
+[@user1, @user2, @user_nil, @user_empty1, @user_empty2, @user_dup, @user_tx, @user_tx_unique, @drift_user].each do |obj|
   obj.destroy! if obj.respond_to?(:destroy!) && obj.respond_to?(:exists?) && obj.exists?
 end
 
-[@emp1, @emp2, @emp3, @emp_nil, @emp4, @emp5, @emp6].each do |obj|
+[@emp1, @emp2, @emp3, @emp_nil, @emp4, @emp5, @emp6, @drift_emp].each do |obj|
   obj.destroy! if obj.respond_to?(:destroy!) && obj.respond_to?(:exists?) && obj.exists?
 end
 


### PR DESCRIPTION
`RecordExistsError` raised by `guard_unique_indexes!` now exposes `#existing_id` and appends `(existing_id=...)` to its message. Diagnosing stale-index drift no longer requires a secondary `HGET` — the drifted identifier surfaces directly in the exception.

The attribute defaults to `nil` and the message format is unchanged when absent, so `save_if_not_exists!` and all existing rescue patterns are untouched.

11 new tryouts covering the default-nil case, kwarg accessor, message format with and without `existing_id`, and real Redis drift simulation via both the instance-scoped and class-level guards.

Closes #242