### PR TITLE
Re-encrypt fields no-op fix

### DIFF
--- a/.talismanrc
+++ b/.talismanrc
@@ -10,4 +10,6 @@ fileignoreconfig:
     checksum: dcc0dd135cd8c569b096c922e6260e446d25b65b7b97b8a4cb4ccaac59325b38
   - filename: try/features/object_identifier/object_identifier_try.rb
     checksum: 10c94f802b2fa3a39fa33bf7dc34dac2ecaa2dd453ff97a19313f96a32fadeff
+  - filename: examples/encrypted_fields.rb
+    checksum: 1640217c71f194a28e4ca42d0a4dd9a772693cbeb945daa27b33d2ea1f548953
 version: ""

--- a/.talismanrc
+++ b/.talismanrc
@@ -11,5 +11,5 @@ fileignoreconfig:
   - filename: try/features/object_identifier/object_identifier_try.rb
     checksum: 10c94f802b2fa3a39fa33bf7dc34dac2ecaa2dd453ff97a19313f96a32fadeff
   - filename: examples/encrypted_fields.rb
-    checksum: 1640217c71f194a28e4ca42d0a4dd9a772693cbeb945daa27b33d2ea1f548953
+    checksum: d1bd77f85d951d367e1c2bfd066a1d68d5f486346ee479121a3d5dcc2560bf52
 version: ""

--- a/changelog.d/20260417_000000_delano_fix_235_re_encrypt.rst
+++ b/changelog.d/20260417_000000_delano_fix_235_re_encrypt.rst
@@ -16,4 +16,4 @@ Documentation
 AI Assistance
 -------------
 
-- Bug diagnosis, fix implementation, example rework, and changelog drafting with Claude. Issue #235
+- Collaborated with Claude on isolating the no-op root cause (the setter's ConcealedString-preservation branch), drafting the raw-envelope regression canary that inspects ``key_version`` in stored JSON, reworking ``examples/encrypted_fields.rb`` to exercise the real rotation flow rather than pre-assigning plaintext, and adding edge-case coverage for nonce freshness, missing-old-key failures, type-guard assertions, and mixed encrypted/plain/transient field models. Issue #235

--- a/changelog.d/20260417_000000_delano_fix_235_re_encrypt.rst
+++ b/changelog.d/20260417_000000_delano_fix_235_re_encrypt.rst
@@ -1,0 +1,19 @@
+Fixed
+-----
+
+- **Encryption**: Fixed ``re_encrypt_fields!`` silently failing to re-encrypt fields under the current key version. Previously the method passed the existing ``ConcealedString`` back through the setter, which the setter preserves as-is for rehydration purposes, so no re-encryption occurred and the stored ciphertext retained its original ``key_version``. The method now reveals plaintext via ``ConcealedString#reveal`` and re-assigns it, forcing encryption under the current key version and algorithm. Issue #235
+
+Security
+--------
+
+- **Encryption**: Key rotation via ``re_encrypt_fields!`` was a silent no-op for fields already loaded as ``ConcealedString`` (the normal case for objects rehydrated from Redis). Callers who followed the documented rotation workflow -- load, ``re_encrypt_fields!``, ``save`` -- left data encrypted under old, potentially compromised keys while believing rotation had succeeded. The stored ciphertext's ``key_version`` remained unchanged. Issue #235
+
+Documentation
+-------------
+
+- Clarified in both ``docs/guides/encryption.md`` and ``docs/guides/feature-encrypted-fields.md`` that ``re_encrypt_fields!`` mutates in-memory state only and requires an explicit ``save`` to persist. Reworked the key rotation example in ``examples/encrypted_fields.rb`` to demonstrate the real rotation flow (save under v1, add v2, load fresh, re-encrypt, save) rather than pre-assigning plaintext (which masked the bug). Issue #235
+
+AI Assistance
+-------------
+
+- Bug diagnosis, fix implementation, example rework, and changelog drafting with Claude. Issue #235

--- a/docs/guides/encryption.md
+++ b/docs/guides/encryption.md
@@ -328,8 +328,11 @@ end
 vault.secret_key = "new-secret"  # Encrypted with v2 key
 vault.save
 
-# Step 3: Re-encrypt existing records
-vault.re_encrypt_fields!  # Uses current key version
+# Step 3: Re-encrypt existing records. re_encrypt_fields! rotates every
+# encrypted field on the instance to the current key version by decrypting
+# and re-assigning plaintext through the setter. It mutates in-memory state
+# only -- you MUST call save afterward to persist the new ciphertext.
+vault.re_encrypt_fields!
 vault.save
 
 # Step 4: After all data is re-encrypted, remove old key

--- a/docs/guides/feature-encrypted-fields.md
+++ b/docs/guides/feature-encrypted-fields.md
@@ -254,6 +254,10 @@ doc.save
 >
 > AAD prevents encrypted fields from being moved between objects. Use it for high-security scenarios where data integrity is critical.
 
+> **⚠️ Key Rotation with AAD**
+>
+> Do not mutate any `aad_fields` value between `load` and `re_encrypt_fields!`. The old ciphertext's AAD is bound to the values present at encryption time; changing an AAD field first causes `reveal` inside the rotation loop to fail with `Familia::EncryptionError`, leaving the in-memory object partially rotated (some encrypted fields re-encrypted, others still under the old key). Either re-encrypt before mutating AAD fields, or mutate AAD fields, `save`, re-load, and re-encrypt.
+
 ### Per-Field Provider Selection
 
 ```ruby
@@ -464,6 +468,10 @@ end
 
 # 4. Remove old key after migration
 ```
+
+> **🔑 Keyring Prerequisite**
+>
+> Every old key version that any record is currently encrypted under must remain in `Familia.config.encryption_keys` for the duration of the rotation. `re_encrypt_fields!` decrypts with the old key (looked up by `key_version` in the stored envelope) and re-encrypts with `current_key_version`. Records whose old key has been removed from the keyring will raise `Familia::EncryptionError` on both `load` and `re_encrypt_fields!`. Only drop an old key after every record has been re-encrypted and verified.
 
 ### Emergency Key Rotation
 

--- a/docs/guides/feature-encrypted-fields.md
+++ b/docs/guides/feature-encrypted-fields.md
@@ -444,6 +444,8 @@ class KeyRotationTask
       model_class.all.each_slice(100) do |batch|
         batch.each do |record|
           begin
+            # re_encrypt_fields! only mutates in-memory state; save is
+            # required to persist ciphertext under the current key version.
             record.re_encrypt_fields!
             record.save
           rescue => e
@@ -711,11 +713,14 @@ vault.encrypted_fields_cleared?  # => true
 ```
 
 #### `re_encrypt_fields!`
-Re-encrypt all encrypted fields with current encryption settings (useful for key rotation).
+Re-encrypt all encrypted fields with current encryption settings (useful for key rotation). The method rotates every encrypted field on the instance to the current key version and algorithm by decrypting existing ciphertext and re-assigning the plaintext through the setter.
+
+This mutates in-memory state only. The caller MUST call `save` (or equivalent) afterward to persist the re-encrypted values -- without `save`, the stored ciphertext remains under the old key version.
 
 ```ruby
-vault.re_encrypt_fields!
-vault.save  # Persists re-encrypted data
+vault = Vault.find_by_id(id)  # Loaded with v1 ciphertext
+vault.re_encrypt_fields!      # Decrypts with v1, re-encrypts with current (v2)
+vault.save                    # Persists v2 ciphertext -- required
 ```
 
 #### `encrypted_fields_status`

--- a/examples/encrypted_fields.rb
+++ b/examples/encrypted_fields.rb
@@ -186,35 +186,52 @@ class RotationTest < Familia::Horreum
 end
 
 puts 'Example 4: Key rotation demonstration'
-rotation_obj = RotationTest.new(
-  test_id: 'rotation_test',
-  sensitive_data: 'Original sensitive data encrypted with v2 key'
-)
-rotation_obj.save
 
-puts "Original data encrypted with key version: #{Familia.config.current_key_version}"
-puts "Data: #{rotation_obj.sensitive_data.reveal}"
-
-# Check encryption status before rotation
-status_before = rotation_obj.encrypted_fields_status
-puts "Encryption status before rotation: #{status_before}"
-
-# Simulate key rotation - switch to v1 for demonstration
+# Start with only v1 available so the initial save uses v1 as current.
+Familia.config.encryption_keys = {
+  v1: 'dGVzdGtleWZvcmV4YW1wbGVzMTIzNDU2Nzg5MA==',
+}
 Familia.config.current_key_version = :v1
 
-# Re-encrypt with new current key
-rotation_obj.sensitive_data = 'Updated data encrypted with v1 key'
-rotation_obj.re_encrypt_fields!
-rotation_obj.save
+RotationTest.new(
+  test_id: 'rotation_test',
+  sensitive_data: 'Original sensitive data encrypted with v1 key'
+).save
 
-puts "After rotation to key version: #{Familia.config.current_key_version}"
-puts "Data: #{rotation_obj.sensitive_data.reveal}"
+# Inspect raw storage to confirm encryption under v1.
+# e.g. redis-cli HGET rotationtest:rotation_test:object sensitive_data
+#   => {"algorithm":"...","key_version":"v1","nonce":"...","ciphertext":"..."}
 
-# Check encryption status after rotation
-status_after = rotation_obj.encrypted_fields_status
-puts "Encryption status after rotation: #{status_after}"
+# Rotate: add v2, promote v2 to current. v1 stays in the keyring so existing
+# ciphertext remains decryptable until it is re-encrypted.
+Familia.config.encryption_keys = {
+  v1: 'dGVzdGtleWZvcmV4YW1wbGVzMTIzNDU2Nzg5MA==',
+  v2: 'bmV3ZXJrZXlmb3JleGFtcGxlczEyMzQ1Njc4OTA=',
+}
+Familia.config.current_key_version = :v2
 
-# Switch back to v2
+# Load a fresh copy -- do NOT touch plaintext. The field holds a
+# ConcealedString wrapping v1 ciphertext.
+reloaded = RotationTest.find_by_id('rotation_test')
+puts "Loaded record, current key version: #{Familia.config.current_key_version}"
+
+# re_encrypt_fields! decrypts (using v1 from the keyring) and re-assigns
+# plaintext through the setter, which re-encrypts under v2. It only mutates
+# in-memory state; save is required to persist.
+reloaded.re_encrypt_fields!
+reloaded.save
+
+# Verify by loading again and inspecting. The stored ciphertext now has
+# key_version: "v2". Use debug_fields or inspect raw Redis to confirm:
+#   redis-cli HGET rotationtest:rotation_test:object sensitive_data
+verify = RotationTest.find_by_id('rotation_test')
+puts "After re-encrypt, status: #{verify.encrypted_fields_status}"
+
+# Restore the original key configuration for subsequent examples.
+Familia.config.encryption_keys = {
+  v1: 'dGVzdGtleWZvcmV4YW1wbGVzMTIzNDU2Nzg5MA==',
+  v2: 'bmV3ZXJrZXlmb3JleGFtcGxlczEyMzQ1Njc4OTA=',
+}
 Familia.config.current_key_version = :v2
 puts
 

--- a/examples/encrypted_fields.rb
+++ b/examples/encrypted_fields.rb
@@ -187,52 +187,57 @@ end
 
 puts 'Example 4: Key rotation demonstration'
 
-# Start with only v1 available so the initial save uses v1 as current.
-Familia.config.encryption_keys = {
-  v1: 'dGVzdGtleWZvcmV4YW1wbGVzMTIzNDU2Nzg5MA==',
-}
-Familia.config.current_key_version = :v1
+# Capture original encryption config so an abort mid-example does not leave
+# the process running under a rotated keyring.
+original_encryption_keys = Familia.config.encryption_keys
+original_current_key_version = Familia.config.current_key_version
 
-RotationTest.new(
-  test_id: 'rotation_test',
-  sensitive_data: 'Original sensitive data encrypted with v1 key'
-).save
+begin
+  # Start with only v1 available so the initial save uses v1 as current.
+  Familia.config.encryption_keys = {
+    v1: 'dGVzdGtleWZvcmV4YW1wbGVzMTIzNDU2Nzg5MA==',
+  }
+  Familia.config.current_key_version = :v1
 
-# Inspect raw storage to confirm encryption under v1.
-# e.g. redis-cli HGET rotationtest:rotation_test:object sensitive_data
-#   => {"algorithm":"...","key_version":"v1","nonce":"...","ciphertext":"..."}
+  RotationTest.new(
+    test_id: 'rotation_test',
+    sensitive_data: 'Original sensitive data encrypted with v1 key'
+  ).save
 
-# Rotate: add v2, promote v2 to current. v1 stays in the keyring so existing
-# ciphertext remains decryptable until it is re-encrypted.
-Familia.config.encryption_keys = {
-  v1: 'dGVzdGtleWZvcmV4YW1wbGVzMTIzNDU2Nzg5MA==',
-  v2: 'bmV3ZXJrZXlmb3JleGFtcGxlczEyMzQ1Njc4OTA=',
-}
-Familia.config.current_key_version = :v2
+  # Inspect raw storage to confirm encryption under v1.
+  # e.g. redis-cli HGET rotationtest:rotation_test:object sensitive_data
+  #   => {"algorithm":"...","key_version":"v1","nonce":"...","ciphertext":"..."}
 
-# Load a fresh copy -- do NOT touch plaintext. The field holds a
-# ConcealedString wrapping v1 ciphertext.
-reloaded = RotationTest.find_by_id('rotation_test')
-puts "Loaded record, current key version: #{Familia.config.current_key_version}"
+  # Rotate: add v2, promote v2 to current. v1 stays in the keyring so existing
+  # ciphertext remains decryptable until it is re-encrypted.
+  Familia.config.encryption_keys = {
+    v1: 'dGVzdGtleWZvcmV4YW1wbGVzMTIzNDU2Nzg5MA==',
+    v2: 'bmV3ZXJrZXlmb3JleGFtcGxlczEyMzQ1Njc4OTA=',
+  }
+  Familia.config.current_key_version = :v2
 
-# re_encrypt_fields! decrypts (using v1 from the keyring) and re-assigns
-# plaintext through the setter, which re-encrypts under v2. It only mutates
-# in-memory state; save is required to persist.
-reloaded.re_encrypt_fields!
-reloaded.save
+  # Load a fresh copy -- do NOT touch plaintext. The field holds a
+  # ConcealedString wrapping v1 ciphertext.
+  reloaded = RotationTest.find_by_id('rotation_test')
+  puts "Loaded record, current key version: #{Familia.config.current_key_version}"
 
-# Verify by loading again and inspecting. The stored ciphertext now has
-# key_version: "v2". Use debug_fields or inspect raw Redis to confirm:
-#   redis-cli HGET rotationtest:rotation_test:object sensitive_data
-verify = RotationTest.find_by_id('rotation_test')
-puts "After re-encrypt, status: #{verify.encrypted_fields_status}"
+  # re_encrypt_fields! decrypts (using v1 from the keyring) and re-assigns
+  # plaintext through the setter, which re-encrypts under v2. It only mutates
+  # in-memory state; save is required to persist.
+  reloaded.re_encrypt_fields!
+  reloaded.save
 
-# Restore the original key configuration for subsequent examples.
-Familia.config.encryption_keys = {
-  v1: 'dGVzdGtleWZvcmV4YW1wbGVzMTIzNDU2Nzg5MA==',
-  v2: 'bmV3ZXJrZXlmb3JleGFtcGxlczEyMzQ1Njc4OTA=',
-}
-Familia.config.current_key_version = :v2
+  # Verify by loading again and inspecting. The stored ciphertext now has
+  # key_version: "v2". Use debug_fields or inspect raw Redis to confirm:
+  #   redis-cli HGET rotationtest:rotation_test:object sensitive_data
+  verify = RotationTest.find_by_id('rotation_test')
+  puts "After re-encrypt, status: #{verify.encrypted_fields_status}"
+ensure
+  # Restore the original key configuration for subsequent examples, even if
+  # anything above raised.
+  Familia.config.encryption_keys = original_encryption_keys
+  Familia.config.current_key_version = original_current_key_version
+end
 puts
 
 # Example 5: Memory safety and cleanup

--- a/lib/familia/features/encrypted_fields.rb
+++ b/lib/familia/features/encrypted_fields.rb
@@ -385,7 +385,11 @@ module Familia
       #
       # This method is useful for key rotation or algorithm upgrades.
       # It decrypts all encrypted fields and re-encrypts them with the
-      # current encryption configuration.
+      # current encryption configuration (current key version and algorithm).
+      #
+      # This method mutates in-memory state only. The caller MUST call
+      # {#save} (or equivalent) afterward to persist the re-encrypted
+      # values to Redis.
       #
       # @return [Boolean] true if re-encryption succeeded
       #
@@ -398,12 +402,17 @@ module Familia
           current_value = send(field_name)
           next if current_value.nil?
 
-          # Force re-encryption by setting the value again
-          if current_value.respond_to?(:value)
-            send("#{field_name}=", current_value.value)
-          else
-            send("#{field_name}=", current_value)
+          # Extract plaintext from ConcealedString and re-assign. Re-assigning
+          # plaintext through the setter forces encryption under the current
+          # key version and algorithm. Passing the ConcealedString back to the
+          # setter is a no-op (the setter preserves existing ConcealedStrings
+          # for rehydration), so we must reveal first.
+          unless current_value.is_a?(ConcealedString)
+            raise Familia::EncryptionError,
+                  "re_encrypt_fields!: unexpected value type #{current_value.class} for encrypted field #{field_name} -- expected ConcealedString"
           end
+
+          current_value.reveal { |plaintext| send("#{field_name}=", plaintext) }
         end
         true
       end

--- a/try/features/encrypted_fields/re_encrypt_fields_try.rb
+++ b/try/features/encrypted_fields/re_encrypt_fields_try.rb
@@ -46,6 +46,17 @@ class ReEncryptTarget < Familia::Horreum
   encrypted_field :token
 end
 
+# Mixed-field model: one encrypted, one plain, one transient.
+class ReEncryptMixed < Familia::Horreum
+  feature :encrypted_fields
+  feature :transient_fields
+  identifier_field :id
+  field :id
+  field :plain_label
+  encrypted_field :secret
+  transient_field :session_token
+end
+
 # Track identifiers so teardown can purge records.
 @created_ids = []
 
@@ -175,10 +186,116 @@ raw_secret_before_save = Familia.dbclient.hget(@contract_fresh.dbkey, 'secret')
 JSON.parse(raw_secret_before_save)['key_version']
 #=> 'v1'
 
+## successive re_encrypt_fields! calls produce fresh nonces
+Familia.config.encryption_keys = @test_keys
+Familia.config.current_key_version = :v2
+
+@nonce_obj = ReEncryptTarget.new(id: 're-enc-nonce', label: 'nonce')
+@nonce_obj.secret = 'nonce-secret'
+@nonce_obj.token  = 'nonce-token'
+@nonce_obj.save
+@created_ids << @nonce_obj.id
+
+@nonce_obj.re_encrypt_fields!
+@nonce_obj.save
+first_envelope = JSON.parse(Familia.dbclient.hget(@nonce_obj.dbkey, 'secret'))
+
+@nonce_reload = ReEncryptTarget.load('re-enc-nonce')
+@nonce_reload.re_encrypt_fields!
+@nonce_reload.save
+second_envelope = JSON.parse(Familia.dbclient.hget(@nonce_reload.dbkey, 'secret'))
+
+[
+  first_envelope['key_version'] == second_envelope['key_version'],
+  first_envelope['nonce'] != second_envelope['nonce'],
+  first_envelope['ciphertext'] != second_envelope['ciphertext'],
+]
+#=> [true, true, true]
+
+## raises when the old key version has been removed from the keyring
+Familia.config.encryption_keys = @test_keys
+Familia.config.current_key_version = :v1
+
+@orphan = ReEncryptTarget.new(id: 're-enc-orphan', label: 'orphan')
+@orphan.secret = 'orphan-secret'
+@orphan.token  = 'orphan-token'
+@orphan.save
+@created_ids << @orphan.id
+
+pre_block_keys = Familia.config.encryption_keys
+pre_block_version = Familia.config.current_key_version
+raised = begin
+  Familia.config.encryption_keys = { v2: @test_keys[:v2] }
+  Familia.config.current_key_version = :v2
+  orphan_fresh = ReEncryptTarget.load('re-enc-orphan')
+  orphan_fresh.re_encrypt_fields!
+  nil
+rescue Familia::EncryptionError => e
+  e.class
+ensure
+  Familia.config.encryption_keys = pre_block_keys
+  Familia.config.current_key_version = pre_block_version
+end
+raised
+#=> Familia::EncryptionError
+
+## raises EncryptionError when ivar holds a non-ConcealedString value
+Familia.config.encryption_keys = @test_keys
+Familia.config.current_key_version = :v2
+
+@bad_ivar = ReEncryptTarget.new(id: 're-enc-bad-ivar', label: 'bad-ivar')
+@bad_ivar.secret = 'bad-ivar-secret'
+@bad_ivar.save
+@created_ids << @bad_ivar.id
+
+@bad_ivar.instance_variable_set(:@secret, 42)
+err = begin
+  @bad_ivar.re_encrypt_fields!
+  nil
+rescue Familia::EncryptionError => e
+  e
+end
+[err.class, err.message.include?('Integer')]
+#=> [Familia::EncryptionError, true]
+
+## mixed-field model only rotates the encrypted field
+Familia.config.encryption_keys = @test_keys
+Familia.config.current_key_version = :v1
+
+@mixed = ReEncryptMixed.new(id: 're-enc-mixed')
+@mixed.plain_label = 'mixed-label'
+@mixed.secret = 'mixed-secret'
+@mixed.session_token = 'mixed-session'
+@mixed.save
+@mixed_created_id = @mixed.id
+
+Familia.config.current_key_version = :v2
+@mixed_fresh = ReEncryptMixed.load('re-enc-mixed')
+@mixed_fresh.session_token = 'mixed-session-reloaded'
+@mixed_fresh.re_encrypt_fields!
+@mixed_fresh.save
+
+raw_secret = JSON.parse(Familia.dbclient.hget(@mixed_fresh.dbkey, 'secret'))
+raw_label = Familia.dbclient.hget(@mixed_fresh.dbkey, 'plain_label')
+[
+  raw_secret['key_version'],
+  JSON.parse(raw_label),
+  ReEncryptMixed.encrypted_fields.include?(:session_token),
+]
+#=> ['v2', 'mixed-label', false]
+
 # Teardown: delete test records and restore original encryption config.
 @created_ids.uniq.each do |id|
   begin
     ReEncryptTarget.destroy!(id)
+  rescue StandardError
+    # best effort cleanup
+  end
+end
+
+if @mixed_created_id
+  begin
+    ReEncryptMixed.destroy!(@mixed_created_id)
   rescue StandardError
     # best effort cleanup
   end

--- a/try/features/encrypted_fields/re_encrypt_fields_try.rb
+++ b/try/features/encrypted_fields/re_encrypt_fields_try.rb
@@ -1,0 +1,188 @@
+# try/features/encrypted_fields/re_encrypt_fields_try.rb
+#
+# frozen_string_literal: true
+#
+# Coverage for issue #235: `re_encrypt_fields!` silently no-ops.
+#
+# These tests are designed to fail BEFORE the fix and pass AFTER.
+#
+# The bug: when `re_encrypt_fields!` iterates encrypted fields it calls the
+# setter with the existing ConcealedString. The setter detects
+# `value.is_a?(ConcealedString)` and stores it as-is without re-encrypting,
+# so the stored ciphertext (and its `key_version`) is unchanged even when
+# the current key version has been rotated.
+#
+# A plaintext round-trip is NOT sufficient to detect this: as long as the
+# original key remains in the keyring during rotation, the original
+# ciphertext still decrypts cleanly. The only way to observe the bug is to
+# inspect the RAW stored JSON and verify `key_version` has moved to the
+# current version.
+
+require 'base64'
+require 'json'
+
+require_relative '../../support/helpers/test_helpers'
+
+# Capture original encryption state so teardown can restore it.
+@original_encryption_keys = Familia.config.encryption_keys
+@original_current_key_version = Familia.config.current_key_version
+
+# Two distinct versioned keys; v1 is current at setup time.
+@test_keys = {
+  v1: Base64.strict_encode64('a' * 32),
+  v2: Base64.strict_encode64('b' * 32),
+}
+
+Familia.config.encryption_keys = @test_keys
+Familia.config.current_key_version = :v1
+
+# Model with two encrypted fields and one plain field.
+class ReEncryptTarget < Familia::Horreum
+  feature :encrypted_fields
+  identifier_field :id
+  field :id
+  field :label
+  encrypted_field :secret
+  encrypted_field :token
+end
+
+# Track identifiers so teardown can purge records.
+@created_ids = []
+
+## re_encrypt_fields! rotates ciphertext to current key version
+# Save a record under v1, rotate current to v2, then re_encrypt_fields! + save.
+# Inspect raw stored JSON and assert key_version is now "v2". This is the
+# canary test for the bug in #235.
+Familia.config.encryption_keys = @test_keys
+Familia.config.current_key_version = :v1
+
+@obj = ReEncryptTarget.new(id: 're-enc-1', label: 'one')
+@obj.secret = 'secret-value-one'
+@obj.token  = 'token-value-one'
+@obj.save
+@created_ids << @obj.id
+
+# Rotate: keep v1 available for decrypt, make v2 the current encrypt target.
+Familia.config.encryption_keys = @test_keys
+Familia.config.current_key_version = :v2
+
+# Reload fresh from the database so the in-memory ConcealedString comes
+# from stored ciphertext, not from the original assignment.
+@fresh = ReEncryptTarget.load('re-enc-1')
+@fresh.re_encrypt_fields!
+@fresh.save
+
+raw_secret = Familia.dbclient.hget(@fresh.dbkey, 'secret')
+parsed = JSON.parse(raw_secret)
+parsed['key_version']
+#=> 'v2'
+
+## plaintext round-trips unchanged after rotation
+# Values must decrypt to their original plaintext under the new key version.
+@reloaded = ReEncryptTarget.load('re-enc-1')
+[
+  @reloaded.secret.reveal { |v| v },
+  @reloaded.token.reveal { |v| v },
+]
+#=> ['secret-value-one', 'token-value-one']
+
+## all encrypted fields on a multi-field model are rotated
+# Both `secret` and `token` must have key_version == v2 in storage.
+raw_secret = Familia.dbclient.hget(@fresh.dbkey, 'secret')
+raw_token  = Familia.dbclient.hget(@fresh.dbkey, 'token')
+[
+  JSON.parse(raw_secret)['key_version'],
+  JSON.parse(raw_token)['key_version'],
+]
+#=> ['v2', 'v2']
+
+## nil-valued encrypted fields are skipped, not errored
+# Record with one encrypted field nil and one populated. re_encrypt_fields!
+# must return true without raising and must not introduce ciphertext for the
+# nil field.
+Familia.config.encryption_keys = @test_keys
+Familia.config.current_key_version = :v1
+
+@partial = ReEncryptTarget.new(id: 're-enc-partial', label: 'partial')
+@partial.secret = 'only-secret-set'
+# @partial.token intentionally left nil
+@partial.save
+@created_ids << @partial.id
+
+Familia.config.current_key_version = :v2
+@partial_fresh = ReEncryptTarget.load('re-enc-partial')
+result = @partial_fresh.re_encrypt_fields!
+@partial_fresh.save
+
+raw_token = Familia.dbclient.hget(@partial_fresh.dbkey, 'token')
+raw_secret = Familia.dbclient.hget(@partial_fresh.dbkey, 'secret')
+# Nil encrypted fields are stored as the JSON literal "null" by Familia's
+# scalar serializer -- not as an encrypted envelope. The contract we care
+# about here is: re_encrypt_fields! must not turn a nil field into
+# ciphertext. Parsing "null" yields nil, so we assert that directly.
+token_parsed = JSON.parse(raw_token) rescue :unparseable
+[result, token_parsed, JSON.parse(raw_secret)['key_version']]
+#=> [true, nil, 'v2']
+
+## is idempotent when current key is unchanged
+# Calling re_encrypt_fields! twice without rotating must succeed both times
+# and plaintext must still round-trip. Ciphertext bytes may differ each call
+# (fresh nonces) but the key_version remains the current version.
+Familia.config.encryption_keys = @test_keys
+Familia.config.current_key_version = :v2
+
+@idem = ReEncryptTarget.new(id: 're-enc-idem', label: 'idem')
+@idem.secret = 'idem-secret'
+@idem.token  = 'idem-token'
+@idem.save
+@created_ids << @idem.id
+
+r1 = @idem.re_encrypt_fields!
+@idem.save
+r2 = @idem.re_encrypt_fields!
+@idem.save
+
+@idem_fresh = ReEncryptTarget.load('re-enc-idem')
+raw_secret = Familia.dbclient.hget(@idem_fresh.dbkey, 'secret')
+[
+  r1,
+  r2,
+  JSON.parse(raw_secret)['key_version'],
+  @idem_fresh.secret.reveal { |v| v },
+  @idem_fresh.token.reveal  { |v| v },
+]
+#=> [true, true, 'v2', 'idem-secret', 'idem-token']
+
+## caller must save to persist re-encrypted values
+# re_encrypt_fields! mutates in-memory state only. Until `save` is called,
+# the stored ciphertext still carries the previous key_version. This
+# documents the contract that the caller drives persistence.
+Familia.config.encryption_keys = @test_keys
+Familia.config.current_key_version = :v1
+
+@contract = ReEncryptTarget.new(id: 're-enc-contract', label: 'contract')
+@contract.secret = 'contract-secret'
+@contract.token  = 'contract-token'
+@contract.save
+@created_ids << @contract.id
+
+Familia.config.current_key_version = :v2
+@contract_fresh = ReEncryptTarget.load('re-enc-contract')
+@contract_fresh.re_encrypt_fields!
+# NOTE: deliberately NOT calling save.
+
+raw_secret_before_save = Familia.dbclient.hget(@contract_fresh.dbkey, 'secret')
+JSON.parse(raw_secret_before_save)['key_version']
+#=> 'v1'
+
+# Teardown: delete test records and restore original encryption config.
+@created_ids.uniq.each do |id|
+  begin
+    ReEncryptTarget.destroy!(id)
+  rescue StandardError
+    # best effort cleanup
+  end
+end
+
+Familia.config.encryption_keys = @original_encryption_keys
+Familia.config.current_key_version = @original_current_key_version


### PR DESCRIPTION
`re_encrypt_fields!` was a silent no-op: it read each encrypted field's `ConcealedString` and passed it back to the setter, which stored it unchanged (the setter's passthrough branch exists for object rehydration). Key rotation workflows silently failed — stored ciphertext kept its original `key_version` even after `save`.

Fix uses `ConcealedString#reveal` to extract plaintext before re-assigning through the setter, which forces encryption under the current key version. The unreachable non-`ConcealedString` fallback is replaced with a `Familia::EncryptionError` raise. Adds six tryouts testcases; the canary inspects raw stored JSON for `key_version` changes (round-trip tests would pass even with the bug).

Closes #235