### PR TITLE
[#247] Fix atomic_swap race: rely on native RENAME atomicity

### DIFF
--- a/changelog.d/20260417_160530_delano_247_fix_atomic_swap_race.rst
+++ b/changelog.d/20260417_160530_delano_247_fix_atomic_swap_race.rst
@@ -1,0 +1,14 @@
+Fixed
+-----
+
+- Eliminated a transient read window during index rebuilds where concurrent
+  ``HGET`` on an index key could return ``nil``. ``RebuildStrategies.atomic_swap``
+  previously ran ``DEL`` followed by ``RENAME`` as two separate commands, leaving
+  the final key absent in between. It now relies on ``RENAME``'s native atomic
+  replacement, so readers never observe a missing index during rebuild. Issue #247
+
+AI Assistance
+-------------
+
+- Issue triage, fix, and race-detection test authored with Claude Code
+  assistance. Issue #247

--- a/lib/familia/features/relationships/indexing/rebuild_strategies.rb
+++ b/lib/familia/features/relationships/indexing/rebuild_strategies.rb
@@ -9,7 +9,7 @@ module Familia
         # All rebuild strategies follow a consistent pattern:
         # 1. Build index in temporary key
         # 2. Batch processing with transactions per batch (not entire rebuild)
-        # 3. Atomic swap via Lua script at completion
+        # 3. Atomic swap via Redis RENAME at completion
         # 4. Progress callbacks throughout
         #
         # This ensures:
@@ -434,28 +434,38 @@ module Familia
 
           # Performs atomic swap of temp key to final key.
           #
-          # Uses Redis RENAME (>= 2.6), which atomically replaces final_key if
-          # it exists. Readers observe either the old index or the new one;
-          # there is no window in which final_key is absent. This avoids the
-          # partial-update, race-condition, and stale-visibility problems of
-          # a two-step DEL+RENAME sequence.
+          # Non-empty rebuilds use Redis RENAME (>= 2.6), which atomically
+          # replaces final_key if it exists. Readers observe either the old
+          # index or the new one; there is no window in which final_key is
+          # absent. This avoids the partial-update, race-condition, and
+          # stale-visibility problems of a two-step DEL+RENAME sequence.
+          #
+          # Empty rebuilds (no temp key) intentionally DEL final_key so the
+          # live index reflects the empty result set. In that branch readers
+          # can observe final_key as absent -- this is the correct outcome for
+          # an index with zero members, not a transient gap.
           #
           # @param temp_key [String] The temporary key containing rebuilt index
           # @param final_key [String] The live index key
           # @param redis [Redis] The Redis connection
           #
           def atomic_swap(temp_key, final_key, redis)
-            # Check if temp key exists first - RENAME fails on non-existent keys
+            # Check if temp key exists first - RENAME fails on non-existent keys.
+            # redis.exists returns Integer across all supported redis-rb versions;
+            # using > 0 also tolerates a future boolean return without breaking.
             unless redis.exists(temp_key) > 0
               Familia.info "[Rebuild] No temp key to swap (empty result set)"
-              # Just ensure final key is cleared
+              # Empty rebuild: remove the live index so reads reflect zero members.
+              # This is the one path where readers can legitimately see final_key
+              # as absent -- the index genuinely has no entries.
               redis.del(final_key)
               return
             end
 
             # RENAME atomically replaces final_key if it exists (Redis >= 2.6),
-            # so readers never observe a missing final_key. A preceding DEL would
-            # open a gap where concurrent HGETs return nil.
+            # so readers never observe a missing final_key during a non-empty
+            # swap. A preceding DEL would open a gap where concurrent HGETs
+            # return nil.
             redis.rename(temp_key, final_key)
             Familia.info "[Rebuild] Atomic swap completed: #{temp_key} -> #{final_key}"
           rescue Redis::CommandError => e

--- a/lib/familia/features/relationships/indexing/rebuild_strategies.rb
+++ b/lib/familia/features/relationships/indexing/rebuild_strategies.rb
@@ -434,14 +434,11 @@ module Familia
 
           # Performs atomic swap of temp key to final key.
           #
-          # This ensures zero downtime during rebuild:
-          # 1. DEL final_key (remove old index)
-          # 2. RENAME temp_key final_key (atomically replace)
-          #
-          # RENAME is atomic, so the old index remains queryable until replaced:
-          # - Partial updates
-          # - Race conditions
-          # - Stale data visibility
+          # Uses Redis RENAME (>= 2.6), which atomically replaces final_key if
+          # it exists. Readers observe either the old index or the new one;
+          # there is no window in which final_key is absent. This avoids the
+          # partial-update, race-condition, and stale-visibility problems of
+          # a two-step DEL+RENAME sequence.
           #
           # @param temp_key [String] The temporary key containing rebuilt index
           # @param final_key [String] The live index key
@@ -456,9 +453,9 @@ module Familia
               return
             end
 
-            # Atomic swap: DEL final key, then RENAME temp -> final
-            # RENAME is already atomic, so we just need to clear the final key first
-            redis.del(final_key)
+            # RENAME atomically replaces final_key if it exists (Redis >= 2.6),
+            # so readers never observe a missing final_key. A preceding DEL would
+            # open a gap where concurrent HGETs return nil.
             redis.rename(temp_key, final_key)
             Familia.info "[Rebuild] Atomic swap completed: #{temp_key} -> #{final_key}"
           rescue Redis::CommandError => e

--- a/try/features/relationships/indexing_rebuild_try.rb
+++ b/try/features/relationships/indexing_rebuild_try.rb
@@ -628,14 +628,27 @@ raise "reader shares client with dbclient (coupling regression)" if reader_redis
 missing_observations = Concurrent::AtomicFixnum.new(0)
 stop_flag = Concurrent::AtomicBoolean.new(false)
 reader = Thread.new do
+  iterations = 0
   until stop_flag.true?
     missing_observations.increment if reader_redis.exists(final_key) == 0
+    iterations += 1
+    # Yield periodically so the tight EXISTS loop doesn't starve the
+    # rebuild thread or burn a full CPU core during CI runs. The race
+    # window we're probing is created by the rebuild, not by the reader,
+    # so sampling at this rate is plenty sensitive.
+    Thread.pass if (iterations % 100).zero?
   end
 end
-200.times { RebuildTestUser.rebuild_email_lookup }
-stop_flag.make_true
-reader.join
-reader_redis.close
+begin
+  200.times { RebuildTestUser.rebuild_email_lookup }
+ensure
+  # Always stop/join the reader and release its socket, even if the rebuild
+  # loop raises. Otherwise a failure mid-rebuild leaves the reader spinning
+  # and the try run hangs on process exit.
+  stop_flag.make_true
+  reader.join
+  reader_redis.close
+end
 missing_observations.value
 #=> 0
 

--- a/try/features/relationships/indexing_rebuild_try.rb
+++ b/try/features/relationships/indexing_rebuild_try.rb
@@ -592,6 +592,53 @@ rescue ArgumentError
 end
 #=> "no error"
 
+# =============================================
+# 12. Atomic Swap Race Condition (#247)
+# =============================================
+
+## Seed a clean state for the race test
+RebuildTestUser.instances.clear
+RebuildTestUser.instances.add("user_1")
+RebuildTestUser.instances.add("user_2")
+RebuildTestUser.instances.add("user_3")
+RebuildTestUser.email_lookup.clear
+RebuildTestUser.rebuild_email_lookup
+RebuildTestUser.email_lookup.size > 0
+#=> true
+
+## final_key is never observed missing during repeated rebuilds
+# Before the fix, atomic_swap did DEL+RENAME as two commands, creating
+# a window where EXISTS final_key returned 0. After the fix, RENAME
+# atomically replaces final_key, so the key is always present.
+#
+# The reader thread uses Familia.create_dbclient to get a bare, isolated
+# Redis connection. This is deliberate: it decouples the test from the
+# semantics of Familia.dbclient (which could grow pooling / thread-local
+# caching later and silently cause the reader to share a socket with the
+# rebuild thread, producing protocol-framing errors instead of the race
+# signal we want to observe). create_dbclient always returns a fresh
+# Redis.new(uri.conf), so the reader's socket is guaranteed independent.
+# Atomic primitives keep the shared counter/flag correct on non-MRI Ruby.
+final_key = RebuildTestUser.email_lookup.dbkey
+reader_redis = Familia.create_dbclient
+# Guard against future regressions: reader must not share a client object
+# with whatever the rebuild path fetches from dbclient. If create_dbclient
+# is ever aliased back to dbclient with caching, this assertion fires.
+raise "reader shares client with dbclient (coupling regression)" if reader_redis.equal?(Familia.dbclient)
+missing_observations = Concurrent::AtomicFixnum.new(0)
+stop_flag = Concurrent::AtomicBoolean.new(false)
+reader = Thread.new do
+  until stop_flag.true?
+    missing_observations.increment if reader_redis.exists(final_key) == 0
+  end
+end
+200.times { RebuildTestUser.rebuild_email_lookup }
+stop_flag.make_true
+reader.join
+reader_redis.close
+missing_observations.value
+#=> 0
+
 # Teardown
 RebuildTestUser.email_lookup.clear
 RebuildTestUser.username_lookup.clear


### PR DESCRIPTION
## Summary

Closes #247. `RebuildStrategies.atomic_swap` ran `DEL final_key` then `RENAME temp_key final_key` as two separate Redis commands, briefly leaving `final_key` absent. Concurrent `HGET` against that key during an index rebuild returned nil. Redis `RENAME` (≥ 2.6) atomically replaces the destination, so the preceding `DEL` was both redundant and the sole source of the gap.

The fix removes the `DEL`. All three `atomic_swap` call sites (`rebuild_via_instances`, `rebuild_via_participation`, `rebuild_via_scan`) benefit; no caller changes needed.

## Changes

- **`lib/familia/features/relationships/indexing/rebuild_strategies.rb`** — Drop `redis.del(final_key)` before the rename. Rewrite the YARD docstring and inline comment to describe the single-command atomic replacement.
- **`try/features/relationships/indexing_rebuild_try.rb`** — New section *12. Atomic Swap Race Condition (#247)*. A reader thread polls `EXISTS final_key` in a tight loop while the main thread runs 200 rebuilds; asserts zero missing observations. Reader uses `Familia.create_dbclient` (fresh connection) with an `equal?` guard against `Familia.dbclient` to prevent silent coupling if the client factory ever caches.
- **`changelog.d/20260417_160530_delano_247_fix_atomic_swap_race.rst`** — Fixed + AI Assistance fragment.

## Verification

- Race test verified against both states: with the pre-fix `DEL` reinserted, observed ~200 missing observations per run (deterministic). With the fix, zero.
- `bundle exec try --agent try/features/relationships/` — 778/778 pass.

## Test plan

- [ ] CI green
- [ ] Review test's atomic-primitive and connection-isolation choices
- [ ] Confirm no downstream consumers rely on the transient `DEL` visibility (unlikely — the gap was a bug, not a contract)