### PR TITLE
[#252] ci: add Ruby 4.0 to CI matrix as experimental

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,11 +18,16 @@ jobs:
 
     runs-on: ubuntu-24.04
 
+    continue-on-error: ${{ matrix.continue-on-error }}
+
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         ruby: ["3.4", "3.5"]
         continue-on-error: [false]
+        include:
+          - ruby: "4.0"
+            continue-on-error: true
 
     services:
       redis:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -187,7 +187,7 @@ GEM
     tty-screen (0.8.2)
     unicode-display_width (3.2.0)
       unicode-emoji (~> 4.1)
-    unicode-emoji (4.1.0)
+    unicode-emoji (4.2.0)
     uri-valkey (1.4.0)
     yard (0.9.37)
     zeitwerk (2.7.3)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -80,7 +80,7 @@ GEM
     logger (1.7.0)
     mcp (0.8.0)
       json-schema (>= 4.1)
-    minitest (5.26.0)
+    minitest (5.27.0)
     oj (3.16.13)
       bigdecimal (>= 3.0)
       ostruct (>= 0.2)


### PR DESCRIPTION
## Summary

- Adds Ruby 4.0 to the CI matrix via `include` with `continue-on-error: true`, so failures don't block merges while we validate compatibility
- Switches `fail-fast` to `false` so a Ruby 4 failure doesn't cancel the 3.4/3.5 jobs
- Wires job-level `continue-on-error: ${{ matrix.continue-on-error }}` to the matrix value

Closes #252

## Test plan

- [x] Full tryouts suite on Ruby 4.0.2 locally: 4496/4496 passing in 226 files (16.74s)
- [ ] First CI run confirms `ruby/setup-ruby@v1` accepts `"4.0"` on ubuntu-24.04
- [ ] Ruby 3.4 and 3.5 jobs still run and gate merges; Ruby 4.0 job visible but non-blocking