### PR TITLE
[#220] atomic_write block for mixed scalar+collection operations

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -250,6 +250,24 @@ plan.save                     # If this raises, features are already mutated
 
 **Cross-database limitation**: MULTI/EXEC transactions only work within a single Redis database number. If scalar fields and a collection use different `logical_database` values, they cannot share a transaction. The `save_with_collections` pattern handles this by sequencing the operations rather than wrapping them in MULTI.
 
+**Atomic pattern -- scalars and collections in one MULTI/EXEC:**
+```ruby
+plan.atomic_write do
+  plan.name = "Premium"               # Deferred: queued as HMSET by persist_to_storage
+  plan.features.clear                 # Immediate: queued as DEL in the open MULTI
+  plan.features.add("sso")            # Immediate: queued as SADD in the open MULTI
+end
+# Block body runs first, then persist_to_storage queues HMSET + index updates
+# + touch_instances!, then EXEC fires. All-or-nothing.
+```
+
+Unlike `save_with_collections` (which sequences two separate writes and cannot roll back scalars if a collection operation fails), `atomic_write` composes the existing `transaction` infrastructure so every command lands in one MULTI/EXEC. Collection mutations auto-route into the open transaction because `DataType#dbclient` honours `Fiber[:familia_transaction]`.
+
+Constraints:
+- All related DataTypes (instance-level and class-level) must share the parent Horreum's `logical_database`. A mismatch raises `Familia::CrossDatabaseError` -- fall back to `save_with_collections` in that case.
+- Cannot nest inside another `transaction` or `atomic_write` (raises `Familia::OperationModeError`).
+- Collection method return values inside the block are `Redis::Future` objects (inherent to MULTI) -- do not inspect them before EXEC.
+
 **Instances timeline**: The class-level `instances` sorted set is a timeline of last-modified times, not a registry. `persist_to_storage` (called by `save`) and `commit_fields`/`batch_update` all call `touch_instances!` to update the timestamp. Use `in_instances?(identifier)` for fast O(log N) checks without loading the object.
 
 ### Instances Timeline Lifecycle

--- a/changelog.d/20260417_181432_delano_220_atomic_write_block.rst
+++ b/changelog.d/20260417_181432_delano_220_atomic_write_block.rst
@@ -1,0 +1,24 @@
+Added
+-----
+
+- New ``Horreum#atomic_write(&block)`` method that wraps scalar field persistence
+  and DataType collection mutations in a single Redis MULTI/EXEC transaction,
+  providing true all-or-nothing atomicity for mixed updates. Unlike
+  ``save_with_collections``, which sequences a save followed by a block (and
+  cannot roll back scalars if a collection operation later fails),
+  ``atomic_write`` routes every command -- HMSET for scalars, SADD/ZADD/etc.
+  for collections, index and ``instances`` bookkeeping -- into one transaction.
+  All participating DataTypes must share the parent Horreum's
+  ``logical_database``; mismatches raise ``Familia::CrossDatabaseError``, in
+  which case ``save_with_collections`` remains the appropriate fallback. (#220)
+
+AI Assistance
+-------------
+
+- Design, implementation, testing, and review coordinated across multiple
+  Claude Code (Opus 4.7) agents: an architect agent (``feature-dev:code-architect``)
+  for the design, a ``backend-dev`` agent for the implementation, a
+  ``qa-automation-engineer`` agent for the tryouts, and a
+  ``feature-dev:code-reviewer`` agent that caught a silent-corruption gap in
+  the cross-database guard where class-level related DataTypes were not being
+  inspected. (#220)

--- a/changelog.d/20260417_181432_delano_220_atomic_write_block.rst
+++ b/changelog.d/20260417_181432_delano_220_atomic_write_block.rst
@@ -12,6 +12,27 @@ Added
   ``logical_database``; mismatches raise ``Familia::CrossDatabaseError``, in
   which case ``save_with_collections`` remains the appropriate fallback. (#220)
 
+Fixed
+-----
+
+- ``atomic_write`` cross-database guard no longer raises a false positive when
+  a Horreum inherits its ``logical_database`` and a related field explicitly
+  sets ``logical_database: 0``; both sides are now resolved to concrete
+  integers (falling through ``Familia.logical_database`` to ``0``) before
+  comparison. (#220)
+
+- ``atomic_write`` same-instance re-entrancy guard now uses a module-level
+  ``Mutex`` to serialise the ``@atomic_write_owner`` check-then-set, closing
+  a narrow race where two threads entering ``atomic_write`` on the same
+  Horreum instance could both observe a nil owner and proceed into parallel
+  MULTI blocks. (#220)
+
+- ``atomic_write`` now clears the in-memory dirty flag only when the returned
+  ``MultiResult.successful?`` is true, not merely when the result is non-nil.
+  Previously a transaction whose individual commands returned exception
+  objects (which MULTI swallows rather than raising) could leave the object
+  marked clean despite the failed writes. (#220)
+
 AI Assistance
 -------------
 
@@ -21,4 +42,7 @@ AI Assistance
   ``qa-automation-engineer`` agent for the tryouts, and a
   ``feature-dev:code-reviewer`` agent that caught a silent-corruption gap in
   the cross-database guard where class-level related DataTypes were not being
-  inspected. (#220)
+  inspected. Follow-up review items (false-positive guard, re-entrancy race,
+  MultiResult success semantics) were surfaced by the ``gemini-code-assist``
+  review bot and verified by the ``qa-automation-engineer`` and
+  ``feature-dev:code-reviewer`` agents. (#220)

--- a/lib/familia/data_type.rb
+++ b/lib/familia/data_type.rb
@@ -150,6 +150,10 @@ module Familia
     # @raise [Familia::Problem] if Familia.strict_write_order is true
     #
     def warn_if_dirty!
+      # Suppress warnings while parent is inside atomic_write — scalar setters in the block
+      # make the object dirty by design, so firing warnings for each collection call is noise.
+      return if @parent_ref.respond_to?(:atomic_write_mode?) && @parent_ref.atomic_write_mode?
+
       return unless @parent_ref.respond_to?(:dirty?) && @parent_ref.dirty?
 
       dirty = @parent_ref.dirty_fields

--- a/lib/familia/errors.rb
+++ b/lib/familia/errors.rb
@@ -43,6 +43,27 @@ module Familia
   # inside a transaction or pipeline
   class NestedTransactionError < OperationModeError; end
 
+  # Raised when atomic_write cannot include all DataType fields because
+  # they span multiple Redis databases (MULTI/EXEC cannot cross databases).
+  class CrossDatabaseError < OperationModeError
+    attr_reader :field_name, :field_database, :horreum_database
+
+    def initialize(field_name, field_database, horreum_database)
+      @field_name = field_name
+      @field_database = field_database
+      @horreum_database = horreum_database
+      super(build_message)
+    end
+
+    private
+
+    def build_message
+      "Cannot include field #{field_name} (logical_database: #{field_database}) in " \
+      "atomic_write: parent Horreum uses logical_database #{horreum_database}. " \
+      "MULTI/EXEC cannot span multiple databases."
+    end
+  end
+
   # Raised when attempting to reference a field that doesn't exist
   class UnknownFieldError < HorreumError; end
 

--- a/lib/familia/horreum.rb
+++ b/lib/familia/horreum.rb
@@ -9,6 +9,7 @@ require_relative 'horreum/related_fields'
 require_relative 'horreum/definition'
 require_relative 'horreum/management'
 require_relative 'horreum/persistence'
+require_relative 'horreum/atomic_write'
 require_relative 'horreum/serialization'
 require_relative 'horreum/dirty_tracking'
 require_relative 'horreum/utils'
@@ -53,6 +54,7 @@ module Familia
   class Horreum
     include Familia::Base
     include Familia::Horreum::Persistence
+    include Familia::Horreum::AtomicWrite
     include Familia::Horreum::Serialization
     include Familia::Horreum::DatabaseCommands
     include Familia::Horreum::DirtyTracking

--- a/lib/familia/horreum/atomic_write.rb
+++ b/lib/familia/horreum/atomic_write.rb
@@ -128,6 +128,19 @@ module Familia
       # against dirty in-memory scalars inside an atomic_write block (the
       # scalars will be persisted by the same transaction).
       #
+      # This predicate is intended to be queried from the same Fiber/Thread
+      # that owns the active atomic_write block. The +@atomic_write_active+
+      # ivar is read without the +OWNER_STATE_MUTEX+ that guards
+      # {#acquire_atomic_write_ownership!}, so a query issued from a
+      # different Fiber or Thread is advisory and may observe stale state
+      # (either a +true+ that has just been cleared, or a +false+ that has
+      # just been set). This is by design: the sole intended caller --
+      # +Familia::DataType#warn_if_dirty!+ -- runs from the same Fiber that
+      # invoked +atomic_write+, so the read is always consistent in the
+      # cases that matter. Adding a lock on every collection mutation purely
+      # to make a single advisory log line precise across Fibers/Threads
+      # would be the wrong tradeoff.
+      #
       # @return [Boolean]
       #
       def atomic_write_mode?

--- a/lib/familia/horreum/atomic_write.rb
+++ b/lib/familia/horreum/atomic_write.rb
@@ -70,8 +70,21 @@ module Familia
           ERROR_MESSAGE
         end
 
+        # Same-instance re-entrancy guard. The Fiber[:familia_transaction]
+        # check above only protects the same Fiber; a second Fiber (or Thread)
+        # touching the same Horreum instance would otherwise open a parallel
+        # MULTI against shared scalar state and race HMSET -- defeating the
+        # "atomic" contract from the caller's point of view. We track the
+        # owning Fiber and raise if another Fiber enters while we own.
+        if @atomic_write_owner && @atomic_write_owner != Fiber.current
+          raise Familia::OperationModeError, <<~ERROR_MESSAGE
+            atomic_write is already active on this instance in another Fiber or Thread. Concurrent atomic_write on the same instance is not supported.
+          ERROR_MESSAGE
+        end
+
         guard_atomic_write_database!
 
+        @atomic_write_owner = Fiber.current
         @atomic_write_active = true
         begin
           # prepare_for_save must run OUTSIDE the transaction: guard_unique_indexes!
@@ -97,6 +110,7 @@ module Familia
           !result.nil?
         ensure
           @atomic_write_active = false
+          @atomic_write_owner = nil
         end
       end
 

--- a/lib/familia/horreum/atomic_write.rb
+++ b/lib/familia/horreum/atomic_write.rb
@@ -1,0 +1,151 @@
+# lib/familia/horreum/atomic_write.rb
+#
+# frozen_string_literal: true
+
+module Familia
+  class Horreum
+    # AtomicWrite - Wraps scalar field persistence and collection mutations in a
+    # single MULTI/EXEC transaction.
+    #
+    # Unlike {Persistence#save_with_collections}, which sequences two separate
+    # writes (scalars first, then block), +atomic_write+ composes Familia's
+    # existing +transaction+ infrastructure so every command -- the HMSET for
+    # scalar fields, the expiration/index/instances bookkeeping, and all
+    # collection mutations executed inside the block -- lands in one atomic
+    # MULTI/EXEC. This is made possible by the fact that +DataType#dbclient+
+    # already reads +Fiber[:familia_transaction]+ when set, so any call to
+    # +plan.features.add(...)+ inside the block transparently routes its
+    # command to the open transaction connection.
+    #
+    # Because MULTI/EXEC cannot span multiple Redis databases, a pre-flight
+    # guard (+guard_atomic_write_database!+) rejects any configuration where
+    # a related field declares a +logical_database+ that differs from the
+    # parent Horreum's. In that case callers should fall back to
+    # {Persistence#save_with_collections}.
+    #
+    # See issue #220 for the design rationale.
+    #
+    module AtomicWrite
+      # Persists scalar fields and collection operations atomically in a single
+      # MULTI/EXEC transaction.
+      #
+      # Scalar field assignments inside the block only mutate in-memory state
+      # (deferred writes); the HMSET is issued by {#persist_to_storage} inside
+      # the transaction. Collection mutations (e.g. +plan.features.add+) execute
+      # immediately against the open transaction connection because
+      # +DataType#dbclient+ honours +Fiber[:familia_transaction]+.
+      #
+      # Unique index validation (+prepare_for_save+) runs OUTSIDE the
+      # transaction so it can perform the reads it needs. Only the writes
+      # are atomic; the read-validate-write is not.
+      #
+      # @param update_expiration [Boolean] Whether to set TTL inside the txn.
+      # @yield Block containing field assignments and collection mutations.
+      # @return [Boolean] true if the transaction committed successfully.
+      # @raise [ArgumentError] If no block is given.
+      # @raise [Familia::OperationModeError] If called within an existing transaction.
+      # @raise [Familia::CrossDatabaseError] If related fields span multiple databases.
+      # @raise [Familia::NoIdentifier] If the identifier is nil or empty.
+      #
+      # @example Atomically update scalar fields and a set
+      #   plan.atomic_write do
+      #     plan.name = "Premium"
+      #     plan.region = "US"
+      #     plan.features.clear
+      #     plan.features.add("sso")
+      #   end
+      #
+      # @see Persistence#save_with_collections For sequential (non-atomic)
+      #   scalar+collection writes (supports cross-database configurations).
+      # @see Connection#transaction For raw MULTI/EXEC access.
+      #
+      def atomic_write(update_expiration: true)
+        raise ArgumentError, 'Block required for atomic_write' unless block_given?
+
+        # Mirror save's nesting guard -- atomic_write opens its own MULTI and
+        # cannot be nested inside an outer transaction (see Persistence#save).
+        if Fiber[:familia_transaction]
+          raise Familia::OperationModeError, <<~ERROR_MESSAGE
+            Cannot call atomic_write within an existing transaction. atomic_write opens its own MULTI/EXEC and cannot be nested.
+          ERROR_MESSAGE
+        end
+
+        guard_atomic_write_database!
+
+        @atomic_write_active = true
+        begin
+          # prepare_for_save must run OUTSIDE the transaction: guard_unique_indexes!
+          # performs reads, which return uninspectable Redis::Future objects inside
+          # MULTI/EXEC.
+          prepare_for_save
+
+          result = transaction do |_conn|
+            # Yield FIRST so scalar setters mutate ivars and collection mutations
+            # queue their commands (SADD, ZADD, etc.) in the open MULTI.
+            # Collection mutations auto-route via Fiber[:familia_transaction]
+            # (see DataType#dbclient).
+            yield
+
+            # Then queue the HMSET for scalar fields. to_h_for_storage snapshots
+            # ivars at command-queue time, so any assignments made inside the
+            # block are captured. Also queues expiration, class indexes, and
+            # touch_instances!.
+            persist_to_storage(update_expiration)
+          end
+
+          clear_dirty! unless result.nil?
+          !result.nil?
+        ensure
+          @atomic_write_active = false
+        end
+      end
+
+      # Returns true while inside an {#atomic_write} block.
+      #
+      # Consulted by +Familia::DataType#warn_if_dirty!+ to suppress the
+      # dirty-state warning for collection mutations that legitimately run
+      # against dirty in-memory scalars inside an atomic_write block (the
+      # scalars will be persisted by the same transaction).
+      #
+      # @return [Boolean]
+      #
+      def atomic_write_mode?
+        @atomic_write_active == true
+      end
+
+      private
+
+      # Pre-flight check for atomic_write: every related DataType field must
+      # share the same +logical_database+ as this Horreum, because MULTI/EXEC
+      # cannot span multiple Redis databases.
+      #
+      # Both instance-level related fields (+related_fields+) and class-level
+      # related fields (+class_related_fields+) are inspected. Class-level
+      # collections matter because +persist_to_storage+ calls
+      # +touch_instances!+, which writes to +self.class.instances+ (a
+      # class-level sorted set) inside the same MULTI; a mismatched database
+      # there would silently route commands to the wrong connection.
+      #
+      # A +nil+ value on a related field's +logical_database+ option means
+      # "inherit from parent" and is always safe.
+      #
+      # @raise [Familia::CrossDatabaseError] if any related field declares a
+      #   different +logical_database+ than the parent Horreum.
+      # @return [void]
+      #
+      def guard_atomic_write_database!
+        horreum_db = self.class.logical_database
+
+        [self.class.related_fields, self.class.class_related_fields].each do |registry|
+          registry.each do |field_name, definition|
+            field_db = definition.opts[:logical_database]
+            next if field_db.nil?
+            next if field_db == horreum_db
+
+            raise Familia::CrossDatabaseError.new(field_name, field_db, horreum_db)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/familia/horreum/atomic_write.rb
+++ b/lib/familia/horreum/atomic_write.rb
@@ -26,6 +26,11 @@ module Familia
     # See issue #220 for the design rationale.
     #
     module AtomicWrite
+      # Module-level mutex guarding the per-instance owner CAS. Held only for
+      # the ivar read/write pairs that compose the re-entrancy check, so
+      # contention is negligible even with many concurrent instances.
+      OWNER_STATE_MUTEX = Mutex.new
+
       # Persists scalar fields and collection operations atomically in a single
       # MULTI/EXEC transaction.
       #
@@ -41,7 +46,9 @@ module Familia
       #
       # @param update_expiration [Boolean] Whether to set TTL inside the txn.
       # @yield Block containing field assignments and collection mutations.
-      # @return [Boolean] true if the transaction committed successfully.
+      # @return [Boolean] true if the transaction's EXEC completed and every
+      #   queued command returned without an exception; false if the
+      #   transaction was discarded or any queued command returned an error.
       # @raise [ArgumentError] If no block is given.
       # @raise [Familia::OperationModeError] If called within an existing transaction.
       # @raise [Familia::CrossDatabaseError] If related fields span multiple databases.
@@ -71,22 +78,18 @@ module Familia
         end
 
         # Same-instance re-entrancy guard. The Fiber[:familia_transaction]
-        # check above only protects the same Fiber; a second Fiber (or Thread)
-        # touching the same Horreum instance would otherwise open a parallel
-        # MULTI against shared scalar state and race HMSET -- defeating the
-        # "atomic" contract from the caller's point of view. We track the
-        # owning Fiber and raise if another Fiber enters while we own.
-        if @atomic_write_owner && @atomic_write_owner != Fiber.current
-          raise Familia::OperationModeError, <<~ERROR_MESSAGE
-            atomic_write is already active on this instance in another Fiber or Thread. Concurrent atomic_write on the same instance is not supported.
-          ERROR_MESSAGE
-        end
+        # check is Fiber-local, so it only protects re-entry within the same
+        # Fiber. A second Fiber or Thread touching the same Horreum instance
+        # would otherwise open a parallel MULTI against shared scalar state
+        # and race HMSET -- defeating the "atomic" contract. The check-then-
+        # set on @atomic_write_owner is serialised under OWNER_STATE_MUTEX so
+        # two threads can't both observe a nil owner and simultaneously claim
+        # ownership.
+        acquire_atomic_write_ownership!
 
-        guard_atomic_write_database!
-
-        @atomic_write_owner = Fiber.current
-        @atomic_write_active = true
         begin
+          guard_atomic_write_database!
+
           # prepare_for_save must run OUTSIDE the transaction: guard_unique_indexes!
           # performs reads, which return uninspectable Redis::Future objects inside
           # MULTI/EXEC.
@@ -106,11 +109,15 @@ module Familia
             persist_to_storage(update_expiration)
           end
 
-          clear_dirty! unless result.nil?
-          !result.nil?
+          # A MultiResult is always returned by `transaction` -- inspect its
+          # successful? flag rather than testing for nil. Individual commands
+          # inside MULTI return exception objects (rather than raising) when
+          # they fail; successful? is false if any of those slipped through.
+          success = atomic_write_success?(result)
+          clear_dirty! if success
+          success
         ensure
-          @atomic_write_active = false
-          @atomic_write_owner = nil
+          release_atomic_write_ownership!
         end
       end
 
@@ -129,6 +136,51 @@ module Familia
 
       private
 
+      # Atomically claim same-instance ownership or raise if a competing
+      # Fiber/Thread already owns it. Held for the duration of the ivar
+      # check-then-set only.
+      #
+      # @raise [Familia::OperationModeError]
+      # @return [void]
+      def acquire_atomic_write_ownership!
+        OWNER_STATE_MUTEX.synchronize do
+          if @atomic_write_owner && @atomic_write_owner != Fiber.current
+            raise Familia::OperationModeError, <<~ERROR_MESSAGE
+              atomic_write is already active on this instance in another Fiber or Thread. Concurrent atomic_write on the same instance is not supported.
+            ERROR_MESSAGE
+          end
+
+          @atomic_write_owner = Fiber.current
+          @atomic_write_active = true
+        end
+      end
+
+      # Release same-instance ownership. Safe to call in an ensure block even
+      # if acquire_atomic_write_ownership! raised before assigning.
+      #
+      # @return [void]
+      def release_atomic_write_ownership!
+        OWNER_STATE_MUTEX.synchronize do
+          @atomic_write_active = false
+          @atomic_write_owner = nil
+        end
+      end
+
+      # Determine whether the transaction committed cleanly. MultiResult
+      # wraps the command return values; any Exception object among those
+      # values flips successful? to false (see MultiResult#successful?).
+      # A nil result covers the rare case where the driver returns no
+      # MultiResult at all (e.g. transaction discarded).
+      #
+      # @param result [MultiResult, nil]
+      # @return [Boolean]
+      def atomic_write_success?(result)
+        return false if result.nil?
+        return result.successful? if result.is_a?(MultiResult)
+
+        true
+      end
+
       # Pre-flight check for atomic_write: every related DataType field must
       # share the same +logical_database+ as this Horreum, because MULTI/EXEC
       # cannot span multiple Redis databases.
@@ -141,14 +193,23 @@ module Familia
       # there would silently route commands to the wrong connection.
       #
       # A +nil+ value on a related field's +logical_database+ option means
-      # "inherit from parent" and is always safe.
+      # "inherit from parent" and is always safe: the DataType instance
+      # resolves its connection via +opts[:parent]+, which is either this
+      # Horreum (instance-level) or the Horreum class itself (class-level),
+      # so the effective database always matches +horreum_db+.
+      #
+      # +horreum_db+ is resolved to a concrete integer so that an explicit
+      # +logical_database: 0+ on a related field does not falsely trigger the
+      # guard when the Horreum has not set +logical_database+ itself and
+      # would otherwise inherit from +Familia.logical_database+ (also 0 by
+      # default).
       #
       # @raise [Familia::CrossDatabaseError] if any related field declares a
       #   different +logical_database+ than the parent Horreum.
       # @return [void]
       #
       def guard_atomic_write_database!
-        horreum_db = self.class.logical_database
+        horreum_db = self.class.logical_database || Familia.logical_database || 0
 
         [self.class.related_fields, self.class.class_related_fields].each do |registry|
           registry.each do |field_name, definition|

--- a/lib/familia/horreum/persistence.rb
+++ b/lib/familia/horreum/persistence.rb
@@ -174,6 +174,8 @@ module Familia
       #
       # @see #save For the underlying scalar persistence
       # @see #transaction For atomic operations on same-key commands
+      # @see #atomic_write For true MULTI/EXEC atomicity spanning scalars and
+      #   collections (single-database only).
       #
       def save_with_collections(update_expiration: true)
         saved = save(update_expiration: update_expiration)

--- a/try/features/atomic_write_coverage_try.rb
+++ b/try/features/atomic_write_coverage_try.rb
@@ -1,0 +1,148 @@
+require_relative '../support/helpers/test_helpers'
+require 'base64'
+
+Familia.debug = false
+
+# Coverage extensions for atomic_write across data type variants that the
+# main atomic_write_try.rb suite does not exercise directly:
+#   (a) Encrypted fields (features/encrypted_fields)
+#   (b) JsonStringKey (json_string DSL) participating in the MULTI
+#   (c) StringKey (string DSL) raw-string operations like INCR/APPEND inside MULTI
+
+# Configure encryption keys for the encrypted_field fixtures. Mirrors the
+# pattern used in try/features/encrypted_fields/encrypted_fields_core_try.rb.
+test_keys = { v1: Base64.strict_encode64('a' * 32) }
+Familia.config.encryption_keys = test_keys
+Familia.config.current_key_version = :v1
+
+# (a) Horreum with encrypted_field + a regular collection. Exercises the
+# encryption-on-assignment path inside an atomic_write block. The plaintext
+# is encrypted in-memory at assignment time (producing a ConcealedString);
+# persist_to_storage queues the resulting JSON ciphertext via HMSET inside
+# the MULTI alongside the SADDs for the tags set.
+class AtomicWriteEncryptedPlan < Familia::Horreum
+  feature :encrypted_fields
+  identifier_field :planid
+  field :planid
+  field :name
+  encrypted_field :secret
+  set :tags
+end
+
+# (b) Horreum with a JsonStringKey (json_string DSL). JsonStringKey lives on
+# its own dbkey; mutations are immediate, so inside atomic_write they auto-
+# route into the open MULTI via Fiber[:familia_transaction].
+class AtomicWriteJsonPlan < Familia::Horreum
+  identifier_field :planid
+  field :planid
+  field :name
+  json_string :config
+end
+
+# (c) Horreum with a raw StringKey (string DSL). StringKey supports INCR /
+# DECR / APPEND because its serialize_value uses raw .to_s rather than JSON.
+class AtomicWriteStringPlan < Familia::Horreum
+  identifier_field :planid
+  field :planid
+  field :name
+  string :counter
+end
+
+# Clean slate
+AtomicWriteEncryptedPlan.instances.clear rescue nil
+AtomicWriteEncryptedPlan.all.each(&:destroy!) rescue nil
+AtomicWriteJsonPlan.instances.clear rescue nil
+AtomicWriteJsonPlan.all.each(&:destroy!) rescue nil
+AtomicWriteStringPlan.instances.clear rescue nil
+AtomicWriteStringPlan.all.each(&:destroy!) rescue nil
+
+## (a) atomic_write commits an encrypted_field assignment and a set mutation atomically
+@enc_a = AtomicWriteEncryptedPlan.new(planid: 'aw_enc_a', name: 'EncTest')
+@enc_a.atomic_write do
+  @enc_a.secret = 'classified'
+  @enc_a.tags.add('alpha')
+  @enc_a.tags.add('beta')
+end
+@enc_a_reloaded = AtomicWriteEncryptedPlan.find_by_id('aw_enc_a')
+@revealed = @enc_a_reloaded.secret.reveal { |plain| plain }
+[@enc_a_reloaded.name, @revealed, @enc_a_reloaded.tags.members.sort]
+#=> ['EncTest', 'classified', ['alpha', 'beta']]
+
+## (a) encrypted_field updates inside atomic_write replace prior ciphertext
+@enc_b = AtomicWriteEncryptedPlan.new(planid: 'aw_enc_b', name: 'EncUpdate')
+@enc_b.secret = 'first'
+@enc_b.save
+@enc_b.atomic_write do
+  @enc_b.secret = 'second'
+  @enc_b.tags.add('gamma')
+end
+@enc_b_reloaded = AtomicWriteEncryptedPlan.find_by_id('aw_enc_b')
+@revealed_b = @enc_b_reloaded.secret.reveal { |plain| plain }
+[@revealed_b, @enc_b_reloaded.tags.members]
+#=> ['second', ['gamma']]
+
+## (b) atomic_write writes a Hash to a json_string and commits with EXEC
+@json_a = AtomicWriteJsonPlan.new(planid: 'aw_json_a', name: 'JsonTest')
+@json_a.atomic_write do
+  @json_a.config.value = { 'theme' => 'dark', 'level' => 7, 'beta' => true }
+end
+@json_a_reloaded = AtomicWriteJsonPlan.find_by_id('aw_json_a')
+@json_a_reloaded.config.value
+#=> {"theme"=>"dark", "level"=>7, "beta"=>true}
+
+## (b) atomic_write overwrites an existing json_string value
+@json_b = AtomicWriteJsonPlan.new(planid: 'aw_json_b', name: 'JsonOverwrite')
+@json_b.config.value = { 'before' => 1 }
+@json_b.atomic_write do
+  @json_b.config.value = { 'after' => 2, 'nested' => [1, 2, 3] }
+end
+@json_b_reloaded = AtomicWriteJsonPlan.find_by_id('aw_json_b')
+@json_b_reloaded.config.value
+#=> {"after"=>2, "nested"=>[1, 2, 3]}
+
+## (c) atomic_write INCR on a raw StringKey commits the increment
+@str_a = AtomicWriteStringPlan.new(planid: 'aw_str_a', name: 'CounterTest')
+@str_a.counter.value = '10'  # raw string; StringKey stores as "10"
+@str_a.atomic_write do
+  @str_a.counter.incr
+  @str_a.counter.incr
+  @str_a.counter.incr
+end
+@str_a_reloaded = AtomicWriteStringPlan.find_by_id('aw_str_a')
+@str_a_reloaded.counter.value.to_i
+#=> 13
+
+## (c) StringKey mutation inside atomic_write returns a Redis::Future (uninspectable until EXEC)
+## Documents that operations queued inside MULTI return Future objects -- callers must NOT
+## inspect them until after the block completes (and even then the values come from the
+## MultiResult, not the Future itself).
+@str_b = AtomicWriteStringPlan.new(planid: 'aw_str_b', name: 'FutureCheck')
+@str_b.counter.value = '0'
+@inside_return_value = nil
+@str_b.atomic_write do
+  @inside_return_value = @str_b.counter.incr
+end
+@inside_return_value.is_a?(Redis::Future)
+#=> true
+
+## (c) atomic_write APPEND on a StringKey commits the appended bytes
+@str_c = AtomicWriteStringPlan.new(planid: 'aw_str_c', name: 'AppendTest')
+@str_c.counter.value = 'foo'
+@str_c.atomic_write do
+  @str_c.counter.append('-bar')
+  @str_c.counter.append('-baz')
+end
+@str_c_reloaded = AtomicWriteStringPlan.find_by_id('aw_str_c')
+@str_c_reloaded.counter.value
+#=> 'foo-bar-baz'
+
+# Cleanup. Reset encryption config so it does not bleed into adjacent test
+# files under the default shared-context tryouts runner.
+AtomicWriteEncryptedPlan.instances.clear rescue nil
+AtomicWriteEncryptedPlan.all.each(&:destroy!) rescue nil
+AtomicWriteJsonPlan.instances.clear rescue nil
+AtomicWriteJsonPlan.all.each(&:destroy!) rescue nil
+AtomicWriteStringPlan.instances.clear rescue nil
+AtomicWriteStringPlan.all.each(&:destroy!) rescue nil
+Familia.config.encryption_keys = nil
+Familia.config.current_key_version = nil

--- a/try/features/atomic_write_try.rb
+++ b/try/features/atomic_write_try.rb
@@ -2,11 +2,6 @@ require_relative '../support/helpers/test_helpers'
 
 Familia.debug = false
 
-# TODO: Extend atomic_write coverage to these paths:
-#   - Encrypted fields (features/encrypted_fields) inside atomic_write
-#   - JsonStringKey values participating in the MULTI
-#   - String key type (StringKey, which uses raw-string serialization)
-
 # Primary test class for atomic_write behavior
 class AtomicWriteTestPlan < Familia::Horreum
   identifier_field :planid

--- a/try/features/atomic_write_try.rb
+++ b/try/features/atomic_write_try.rb
@@ -1,0 +1,375 @@
+require_relative '../support/helpers/test_helpers'
+
+Familia.debug = false
+
+# Primary test class for atomic_write behavior
+class AtomicWriteTestPlan < Familia::Horreum
+  identifier_field :planid
+  field :planid
+  field :name
+  field :region
+  field :tier
+  set :features
+  sorted_set :scores
+  hashkey :settings
+  list :audit_log
+end
+
+# Class with expiration feature for TTL test
+class AtomicWriteExpiringPlan < Familia::Horreum
+  feature :expiration
+  identifier_field :planid
+  field :planid
+  field :name
+  default_expiration 3600
+  set :tags
+end
+
+# Class with a cross-database collection for CrossDatabaseError test
+class AtomicWriteCrossDbPlan < Familia::Horreum
+  logical_database 0
+  identifier_field :planid
+  field :planid
+  field :name
+  list :items, logical_database: 5
+end
+
+# Class with a cross-database CLASS-LEVEL collection. Exercises the guard's
+# ability to catch class_related_fields (e.g. class_sorted_set, class_list)
+# on a different logical_database than the parent Horreum. This matters
+# because persist_to_storage writes to self.class.instances inside the MULTI.
+class AtomicWriteCrossDbClassPlan < Familia::Horreum
+  logical_database 0
+  identifier_field :planid
+  field :planid
+  field :name
+  class_sorted_set :leaderboard, logical_database: 6
+end
+
+# Clean slate
+AtomicWriteTestPlan.instances.clear
+AtomicWriteTestPlan.all.each(&:destroy!)
+AtomicWriteExpiringPlan.instances.clear
+AtomicWriteExpiringPlan.all.each(&:destroy!)
+# CrossDb cleanup is best-effort; destroying is risky across DBs
+AtomicWriteCrossDbPlan.instances.clear rescue nil
+
+## atomic_write persists scalar and collection changes atomically
+@plan_a = AtomicWriteTestPlan.new(planid: 'aw_plan_a', name: 'Basic', region: 'US')
+@plan_a.save
+@plan_a.atomic_write do
+  @plan_a.name = 'Premium'
+  @plan_a.region = 'UK'
+  @plan_a.features.add('sso')
+  @plan_a.features.add('priority')
+  @plan_a.scores.add('metric_a', 42.0)
+  @plan_a.scores.add('metric_b', 99.5)
+  @plan_a.settings['theme'] = 'dark'
+  @plan_a.settings['lang'] = 'en'
+  @plan_a.audit_log.push('upgraded')
+end
+@reloaded_a = AtomicWriteTestPlan.find_by_id('aw_plan_a')
+[
+  @reloaded_a.name,
+  @reloaded_a.region,
+  @reloaded_a.features.members.sort,
+  @reloaded_a.scores.members.sort,
+  @reloaded_a.settings['theme'],
+  @reloaded_a.settings['lang'],
+  @reloaded_a.audit_log.members,
+]
+#=> ['Premium', 'UK', ['priority', 'sso'], ['metric_a', 'metric_b'], 'dark', 'en', ['upgraded']]
+
+## atomic_write with scalar-only block still saves
+@plan_b = AtomicWriteTestPlan.new(planid: 'aw_plan_b', name: 'Initial', region: 'EU')
+result_b = @plan_b.atomic_write do
+  @plan_b.name = 'Scalar-only Update'
+  @plan_b.region = 'JP'
+end
+@reloaded_b = AtomicWriteTestPlan.find_by_id('aw_plan_b')
+[result_b, @reloaded_b.name, @reloaded_b.region]
+#=> [true, 'Scalar-only Update', 'JP']
+
+## atomic_write with collections-only block (after prior save)
+@plan_c = AtomicWriteTestPlan.new(planid: 'aw_plan_c', name: 'Stable', region: 'US')
+@plan_c.save
+@plan_c.atomic_write do
+  @plan_c.features.add('analytics')
+  @plan_c.audit_log.push('collections_only')
+end
+@reloaded_c = AtomicWriteTestPlan.find_by_id('aw_plan_c')
+[@reloaded_c.name, @reloaded_c.features.members, @reloaded_c.audit_log.members]
+#=> ['Stable', ['analytics'], ['collections_only']]
+
+## atomic_write with empty block still persists current scalar state
+@plan_d = AtomicWriteTestPlan.new(planid: 'aw_plan_d', name: 'Old Name')
+@plan_d.save
+@plan_d.name = 'New Name'
+@plan_d.atomic_write { }
+AtomicWriteTestPlan.find_by_id('aw_plan_d').name
+#=> 'New Name'
+
+## atomic_write returns true on successful commit
+@plan_e = AtomicWriteTestPlan.new(planid: 'aw_plan_e', name: 'ReturnValueTest')
+@plan_e.atomic_write { @plan_e.features.add('x') }
+#=> true
+
+## atomic_write clear-then-add sequence executes atomically
+@plan_f = AtomicWriteTestPlan.new(planid: 'aw_plan_f', name: 'ClearThenAdd')
+@plan_f.save
+@plan_f.features.add('old_a')
+@plan_f.features.add('old_b')
+@plan_f.atomic_write do
+  @plan_f.features.clear
+  @plan_f.features.add('new_a')
+  @plan_f.features.add('new_b')
+end
+@reloaded_f = AtomicWriteTestPlan.find_by_id('aw_plan_f')
+@reloaded_f.features.members.sort
+#=> ['new_a', 'new_b']
+
+## dirty? is false after successful atomic_write
+@plan_g = AtomicWriteTestPlan.new(planid: 'aw_plan_g', name: 'DirtyCheck')
+@plan_g.save
+@plan_g.atomic_write do
+  @plan_g.name = 'Changed'
+  @plan_g.region = 'FR'
+end
+@plan_g.dirty?
+#=> false
+
+## atomic_write raises OperationModeError when nested inside transaction { }
+@plan_h = AtomicWriteTestPlan.new(planid: 'aw_plan_h', name: 'NestedInTxn')
+@plan_h.save
+begin
+  Familia.transaction do
+    @plan_h.atomic_write { @plan_h.name = 'Should fail' }
+  end
+  :no_raise
+rescue Familia::OperationModeError => e
+  :raised
+end
+#=> :raised
+
+## atomic_write raises OperationModeError when nested inside another atomic_write
+@plan_i = AtomicWriteTestPlan.new(planid: 'aw_plan_i', name: 'NestedInAtomic')
+@plan_i.save
+begin
+  @plan_i.atomic_write do
+    @plan_i.name = 'Outer'
+    @plan_i.atomic_write { @plan_i.name = 'Inner' }
+  end
+  :no_raise
+rescue Familia::OperationModeError => e
+  :raised
+end
+#=> :raised
+
+## atomic_write raises CrossDatabaseError for a field on a different logical_database
+@plan_j = AtomicWriteCrossDbPlan.new(planid: 'aw_plan_j', name: 'CrossDb')
+begin
+  @plan_j.atomic_write { @plan_j.name = 'Should fail' }
+  :no_raise
+rescue Familia::CrossDatabaseError => e
+  [:raised, e.field_name, e.field_database, e.horreum_database]
+end
+#=> [:raised, :items, 5, 0]
+
+## exception inside atomic_write block prevents commit
+@plan_k = AtomicWriteTestPlan.new(planid: 'aw_plan_k', name: 'Original', region: 'US')
+@plan_k.save
+@plan_k.features.add('keep_me')
+begin
+  @plan_k.atomic_write do
+    @plan_k.name = 'Should not persist'
+    @plan_k.features.add('should_not_persist')
+    raise 'boom'
+  end
+rescue RuntimeError
+  # expected
+end
+@reloaded_k = AtomicWriteTestPlan.find_by_id('aw_plan_k')
+[@reloaded_k.name, @reloaded_k.features.members.sort]
+#=> ['Original', ['keep_me']]
+
+## atomic_write raises ArgumentError when called without a block
+@plan_l = AtomicWriteTestPlan.new(planid: 'aw_plan_l', name: 'NoBlock')
+begin
+  @plan_l.atomic_write
+  :no_raise
+rescue ArgumentError
+  :raised
+end
+#=> :raised
+
+## update_expiration: false suppresses TTL command
+@plan_m = AtomicWriteExpiringPlan.new(planid: 'aw_plan_m', name: 'TtlTest')
+@plan_m.save
+# Explicitly remove any TTL so we can verify atomic_write(update_expiration: false)
+# does not set a new one.
+Familia.dbclient.persist(@plan_m.dbkey)
+ttl_before = Familia.dbclient.ttl(@plan_m.dbkey)
+@plan_m.atomic_write(update_expiration: false) do
+  @plan_m.name = 'NoTtlApplied'
+end
+ttl_after = Familia.dbclient.ttl(@plan_m.dbkey)
+# -1 means key exists with no expiration
+[ttl_before, ttl_after]
+#=> [-1, -1]
+
+## instances sorted set is updated after atomic_write
+@plan_n = AtomicWriteTestPlan.new(planid: 'aw_plan_n', name: 'InstancesTest')
+@plan_n.atomic_write { @plan_n.region = 'CA' }
+AtomicWriteTestPlan.in_instances?('aw_plan_n')
+#=> true
+
+## save_with_collections still works (regression)
+@plan_o = AtomicWriteTestPlan.new(planid: 'aw_plan_o', name: 'SaveWithColl')
+@plan_o.save_with_collections do
+  @plan_o.features.add('regression_a')
+  @plan_o.features.add('regression_b')
+end
+@reloaded_o = AtomicWriteTestPlan.find_by_id('aw_plan_o')
+[@reloaded_o.name, @reloaded_o.features.members.sort]
+#=> ['SaveWithColl', ['regression_a', 'regression_b']]
+
+## warn_if_dirty! is suppressed during atomic_write block
+@plan_p = AtomicWriteTestPlan.new(planid: 'aw_plan_p', name: 'Original')
+@plan_p.save
+# Capture warnings emitted via Familia.warn (goes to stderr by default)
+original_stderr = $stderr
+$stderr = StringIO.new
+begin
+  @plan_p.atomic_write do
+    @plan_p.name = 'Dirty!'           # Makes parent dirty
+    @plan_p.features.add('collection_while_dirty')  # Would normally warn
+    @plan_p.settings['k'] = 'v'       # Another warn_if_dirty! path
+    @plan_p.audit_log.push('entry')   # Another warn_if_dirty! path
+  end
+  captured = $stderr.string
+ensure
+  $stderr = original_stderr
+end
+# No warning should contain the "unsaved scalar fields" message
+captured.include?('unsaved scalar fields')
+#=> false
+
+## collection writes inside atomic_write land in the same MULTI/EXEC as scalars
+@plan_q = AtomicWriteTestPlan.new(planid: 'aw_plan_q', name: 'FutureTest')
+@plan_q.save
+@plan_q.features.add('outside_val')  # immediate, non-transaction
+@plan_q.atomic_write do
+  @plan_q.name = 'FutureTest-updated'
+  @plan_q.features.add('inside_val')
+end
+# Reload and confirm both the scalar change and the in-block collection mutation landed
+@plan_q_reloaded = AtomicWriteTestPlan.load('aw_plan_q')
+[@plan_q_reloaded.name, @plan_q_reloaded.features.members.sort]
+#=> ["FutureTest-updated", ["inside_val", "outside_val"]]
+
+## two Fibers running atomic_write on different instances do not cross-contaminate state
+@plan_r1 = AtomicWriteTestPlan.new(planid: 'aw_plan_r1', name: 'FiberA-Initial')
+@plan_r1.save
+@plan_r2 = AtomicWriteTestPlan.new(planid: 'aw_plan_r2', name: 'FiberB-Initial')
+@plan_r2.save
+
+@fiber_a = Fiber.new do
+  @plan_r1.atomic_write do
+    @plan_r1.name = 'FiberA-Final'
+    @plan_r1.features.add('a1')
+    Fiber.yield :a_paused
+    @plan_r1.features.add('a2')
+  end
+  :a_done
+end
+
+@fiber_b = Fiber.new do
+  @plan_r2.atomic_write do
+    @plan_r2.name = 'FiberB-Final'
+    @plan_r2.features.add('b1')
+    @plan_r2.features.add('b2')
+  end
+  :b_done
+end
+
+@fiber_a.resume          # starts A's atomic_write, pauses mid-block
+@fiber_b.resume          # runs B's atomic_write to completion
+@fiber_a.resume          # resumes A, completes atomic_write
+
+@r1_reloaded = AtomicWriteTestPlan.find_by_id('aw_plan_r1')
+@r2_reloaded = AtomicWriteTestPlan.find_by_id('aw_plan_r2')
+[
+  @r1_reloaded.name,
+  @r1_reloaded.features.members.sort,
+  @r2_reloaded.name,
+  @r2_reloaded.features.members.sort,
+]
+#=> ['FiberA-Final', ['a1', 'a2'], 'FiberB-Final', ['b1', 'b2']]
+
+## atomic_write raises CrossDatabaseError for a CLASS-LEVEL field on a different logical_database
+## Guard must inspect class_related_fields (e.g. class_sorted_set) in addition to related_fields,
+## because persist_to_storage writes to self.class.instances inside the MULTI.
+@plan_s = AtomicWriteCrossDbClassPlan.new(planid: 'aw_plan_s', name: 'ClassCrossDb')
+begin
+  @plan_s.atomic_write { @plan_s.name = 'Should fail' }
+  :no_raise
+rescue Familia::CrossDatabaseError => e
+  [:raised, e.field_name, e.field_database, e.horreum_database]
+end
+#=> [:raised, :leaderboard, 6, 0]
+
+## same-instance atomic_write across two Fibers: both proceed without a re-entrancy error
+## KNOWN LIMITATION: @atomic_write_active is an instance ivar shared across Fibers, but
+## Fiber[:familia_transaction] is Fiber-local. So Fiber B's nested-transaction guard does
+## not fire even though Fiber A has an active MULTI on the same instance. Each Fiber opens
+## its own MULTI/EXEC on its own pool connection. This test pins down the observable outcome:
+## both transactions commit, the last-writer-wins for scalar fields, and set members from
+## both Fibers accumulate on the shared Redis key. Documented here so any future change to
+## add re-entrancy protection will break this test intentionally.
+@plan_t = AtomicWriteTestPlan.new(planid: 'aw_plan_t', name: 'SameInstance-Initial')
+@plan_t.save
+
+@fiber_same_a = Fiber.new do
+  @plan_t.atomic_write do
+    @plan_t.name = 'FiberA-Wrote'
+    @plan_t.features.add('shared_a')
+    Fiber.yield :a_paused_inside_multi
+    @plan_t.features.add('shared_a2')
+  end
+  :a_done
+end
+
+@fiber_same_b = Fiber.new do
+  begin
+    @plan_t.atomic_write do
+      @plan_t.name = 'FiberB-Wrote'
+      @plan_t.features.add('shared_b')
+    end
+    :b_done
+  rescue Familia::OperationModeError, Familia::PersistenceError => e
+    [:b_raised, e.class.name]
+  end
+end
+
+@fiber_same_a.resume  # A enters atomic_write, opens MULTI, yields mid-block
+@fiber_b_result = @fiber_same_b.resume  # B enters atomic_write on same instance; current behavior: runs independently
+@fiber_a_result = @fiber_same_a.resume  # A resumes and completes
+
+@t_reloaded = AtomicWriteTestPlan.find_by_id('aw_plan_t')
+# Both Fibers completed without raising (existing behavior, no same-instance re-entrancy guard).
+# Features from both Fibers are present on the shared key.
+[
+  @fiber_a_result,
+  @fiber_b_result,
+  ['shared_a', 'shared_a2', 'shared_b'].all? { |m| @t_reloaded.features.member?(m) },
+]
+#=> [:a_done, :b_done, true]
+
+# Cleanup
+AtomicWriteTestPlan.instances.clear
+AtomicWriteTestPlan.all.each(&:destroy!)
+AtomicWriteExpiringPlan.instances.clear
+AtomicWriteExpiringPlan.all.each(&:destroy!)
+AtomicWriteCrossDbPlan.instances.clear rescue nil
+AtomicWriteCrossDbClassPlan.instances.clear rescue nil
+AtomicWriteCrossDbClassPlan.leaderboard.clear rescue nil

--- a/try/features/atomic_write_try.rb
+++ b/try/features/atomic_write_try.rb
@@ -318,14 +318,11 @@ rescue Familia::CrossDatabaseError => e
 end
 #=> [:raised, :leaderboard, 6, 0]
 
-## same-instance atomic_write across two Fibers: both proceed without a re-entrancy error
-## KNOWN LIMITATION: @atomic_write_active is an instance ivar shared across Fibers, but
-## Fiber[:familia_transaction] is Fiber-local. So Fiber B's nested-transaction guard does
-## not fire even though Fiber A has an active MULTI on the same instance. Each Fiber opens
-## its own MULTI/EXEC on its own pool connection. This test pins down the observable outcome:
-## both transactions commit, the last-writer-wins for scalar fields, and set members from
-## both Fibers accumulate on the shared Redis key. Documented here so any future change to
-## add re-entrancy protection will break this test intentionally.
+## same-instance atomic_write across two Fibers: second Fiber raises OperationModeError
+## The instance tracks its owning Fiber; if Fiber A has an active atomic_write and Fiber B
+## tries to open one on the SAME instance, B raises. Without this guard, both Fibers would
+## open parallel MULTIs against shared scalar state (last-writer-wins HMSET) -- defeating
+## the atomicity contract from the caller's point of view.
 @plan_t = AtomicWriteTestPlan.new(planid: 'aw_plan_t', name: 'SameInstance-Initial')
 @plan_t.save
 
@@ -346,24 +343,25 @@ end
       @plan_t.features.add('shared_b')
     end
     :b_done
-  rescue Familia::OperationModeError, Familia::PersistenceError => e
-    [:b_raised, e.class.name]
+  rescue Familia::OperationModeError => e
+    [:b_raised, e.message.include?('another Fiber or Thread')]
   end
 end
 
-@fiber_same_a.resume  # A enters atomic_write, opens MULTI, yields mid-block
-@fiber_b_result = @fiber_same_b.resume  # B enters atomic_write on same instance; current behavior: runs independently
-@fiber_a_result = @fiber_same_a.resume  # A resumes and completes
+@fiber_same_a.resume  # A enters atomic_write, opens MULTI, yields mid-block (still owns instance)
+@fiber_b_result = @fiber_same_b.resume  # B tries to enter atomic_write on same instance: raises
+@fiber_a_result = @fiber_same_a.resume  # A resumes and completes its transaction cleanly
 
 @t_reloaded = AtomicWriteTestPlan.find_by_id('aw_plan_t')
-# Both Fibers completed without raising (existing behavior, no same-instance re-entrancy guard).
-# Features from both Fibers are present on the shared key.
+# B raised with the re-entrancy message. A's transaction still committed cleanly.
+# Only A's scalar update and features are present; B's work never ran.
 [
   @fiber_a_result,
   @fiber_b_result,
-  ['shared_a', 'shared_a2', 'shared_b'].all? { |m| @t_reloaded.features.member?(m) },
+  @t_reloaded.name,
+  @t_reloaded.features.members.sort,
 ]
-#=> [:a_done, :b_done, true]
+#=> [:a_done, [:b_raised, true], "FiberA-Wrote", ["shared_a", "shared_a2"]]
 
 # Cleanup
 AtomicWriteTestPlan.instances.clear

--- a/try/features/atomic_write_try.rb
+++ b/try/features/atomic_write_try.rb
@@ -2,6 +2,11 @@ require_relative '../support/helpers/test_helpers'
 
 Familia.debug = false
 
+# TODO: Extend atomic_write coverage to these paths:
+#   - Encrypted fields (features/encrypted_fields) inside atomic_write
+#   - JsonStringKey values participating in the MULTI
+#   - String key type (StringKey, which uses raw-string serialization)
+
 # Primary test class for atomic_write behavior
 class AtomicWriteTestPlan < Familia::Horreum
   identifier_field :planid
@@ -44,6 +49,17 @@ class AtomicWriteCrossDbClassPlan < Familia::Horreum
   field :planid
   field :name
   class_sorted_set :leaderboard, logical_database: 6
+end
+
+# Horreum with no explicit logical_database and a related field that
+# explicitly sets logical_database: 0. Regression fixture for the false-
+# positive guard bug: both sides resolve to 0 at runtime, so
+# guard_atomic_write_database! must not raise.
+class AtomicWriteExplicitZeroPlan < Familia::Horreum
+  identifier_field :planid
+  field :planid
+  field :name
+  set :features, logical_database: 0
 end
 
 # Clean slate
@@ -363,9 +379,88 @@ end
 ]
 #=> [:a_done, [:b_raised, true], "FiberA-Wrote", ["shared_a", "shared_a2"]]
 
+## atomic_write does NOT raise when a related field explicitly sets
+## logical_database: 0 and the Horreum has no explicit logical_database.
+## Regression test for the false-positive guard bug -- both sides must
+## resolve to concrete integers (default 0) before comparison so an
+## explicit "logical_database: 0" is recognised as a match.
+@plan_u = AtomicWriteExplicitZeroPlan.new(planid: 'aw_plan_u', name: 'ExplicitZero')
+@plan_u.save
+@plan_u.atomic_write do
+  @plan_u.name = 'ExplicitZeroUpdated'
+  @plan_u.features.add('zero_ok')
+end
+@u_reloaded = AtomicWriteExplicitZeroPlan.find_by_id('aw_plan_u')
+[@u_reloaded.name, @u_reloaded.features.members]
+#=> ["ExplicitZeroUpdated", ["zero_ok"]]
+
+## same-instance atomic_write across two Threads: second Thread raises
+## OperationModeError. OWNER_STATE_MUTEX serialises the ivar check-then-
+## set so two threads can't both observe a nil owner and simultaneously
+## claim ownership. Uses a Queue as a rendezvous so the threads reliably
+## overlap on @atomic_write_owner.
+@plan_v = AtomicWriteTestPlan.new(planid: 'aw_plan_v', name: 'ThreadSafety-Initial')
+@plan_v.save
+@enter_signal = Queue.new
+@exit_signal = Queue.new
+@thread_b_result = nil
+
+@thread_a = Thread.new do
+  @plan_v.atomic_write do
+    @plan_v.name = 'ThreadA-Wrote'
+    @plan_v.features.add('thread_a')
+    @enter_signal << :a_inside
+    @exit_signal.pop  # hold ownership until B has tried and failed
+  end
+  :a_done
+end
+
+@thread_b = Thread.new do
+  @enter_signal.pop  # wait until A owns the instance
+  begin
+    @plan_v.atomic_write do
+      @plan_v.name = 'ThreadB-Wrote'
+    end
+    :b_done
+  rescue Familia::OperationModeError => e
+    [:b_raised, e.message.include?('another Fiber or Thread')]
+  ensure
+    @exit_signal << :release
+  end
+end
+
+@thread_b_result = @thread_b.value
+@thread_a_result = @thread_a.value
+@v_reloaded = AtomicWriteTestPlan.find_by_id('aw_plan_v')
+[@thread_a_result, @thread_b_result, @v_reloaded.name]
+#=> [:a_done, [:b_raised, true], "ThreadA-Wrote"]
+
+## atomic_write returns false and leaves dirty state intact when the
+## transaction's MultiResult reports a failed command. MULTI/EXEC does not
+## raise for individual command errors -- the server returns an Exception
+## object in that slot -- so relying on `result.nil?` as a success proxy
+## would incorrectly clear_dirty! and flag an actually-failed write as
+## clean. We stub `transaction` on a single instance to deliver a canned
+## MultiResult containing a command-level error and verify:
+##   - atomic_write returns false
+##   - the dirty field is still marked dirty
+@plan_w = AtomicWriteTestPlan.new(planid: 'aw_plan_w', name: 'DirtyBefore')
+@plan_w.save
+@plan_w.name = 'DirtyAfter'  # marks :name dirty
+@failed_result = MultiResult.new(['OK', RuntimeError.new('simulated command failure')])
+@plan_w.define_singleton_method(:transaction) do |&blk|
+  blk.call(nil)  # run the block so scalars/collections are touched
+  @failed_result
+end
+@aw_return = @plan_w.atomic_write { @plan_w.name = 'DirtyAfter' }
+[@aw_return, @plan_w.dirty?, @plan_w.dirty?(:name)]
+#=> [false, true, true]
+
 # Cleanup
 AtomicWriteTestPlan.instances.clear
 AtomicWriteTestPlan.all.each(&:destroy!)
+AtomicWriteExplicitZeroPlan.instances.clear rescue nil
+AtomicWriteExplicitZeroPlan.all.each(&:destroy!) rescue nil
 AtomicWriteExpiringPlan.instances.clear
 AtomicWriteExpiringPlan.all.each(&:destroy!)
 AtomicWriteCrossDbPlan.instances.clear rescue nil

--- a/try/thread_safety/atomic_write_ownership_race_try.rb
+++ b/try/thread_safety/atomic_write_ownership_race_try.rb
@@ -1,0 +1,130 @@
+# try/thread_safety/atomic_write_ownership_race_try.rb
+#
+# frozen_string_literal: true
+
+require_relative '../support/helpers/test_helpers'
+
+# Thread safety tests for acquire_atomic_write_ownership! compare-and-swap.
+#
+# lib/familia/horreum/atomic_write.rb wraps the @atomic_write_owner ivar
+# check-then-set in OWNER_STATE_MUTEX.synchronize. Without that mutex,
+# two threads could both observe a nil owner and simultaneously claim
+# ownership, then open parallel MULTIs against shared scalar state.
+#
+# The re-entrancy test in try/features/atomic_write_try.rb establishes a
+# happens-before relationship via a Queue rendezvous: by the time thread
+# B calls acquire, the ivar is already non-nil and B's check short-
+# circuits even without the mutex. That test would still pass if the
+# synchronize wrapper were removed.
+#
+# This file exercises the CAS race as directly as the MRI scheduler
+# permits: N threads synchronised on a CyclicBarrier, released
+# simultaneously, all calling atomic_write on a fresh instance where
+# @atomic_write_owner is nil. With the mutex, exactly one thread wins
+# and the others raise OperationModeError.
+#
+# Caveat: MRI's GVL serialises Ruby bytecode and only pre-empts at safe
+# points, so many iterations INCREASE THE PROBABILITY of catching a
+# pre-emption window between the nil-check and the set in
+# acquire_atomic_write_ownership! but cannot guarantee it. A pure
+# mutation test (removing the mutex) may still pass on some machines if
+# GVL scheduling happens to serialise the threads after barrier release.
+# This test's primary job is to assert the exact-one-winner invariant on
+# simultaneous barrier release; the Fiber-based re-entrancy tests in
+# try/features/atomic_write_try.rb additionally validate the guard's
+# semantics when happens-before ordering is established.
+#
+# The test still earns its place: on loaded CI runners the GVL does
+# pre-empt across iterations; on JRuby/TruffleRuby (which lack a GVL)
+# the race is real every iteration; and even on unloaded MRI the
+# "exact-one-winner" invariant is a smoke test that catches gross
+# regressions (e.g. removing the @atomic_write_owner check entirely,
+# which would let every thread pass the guard and open parallel MULTIs).
+
+Familia.debug = false
+
+class CASRacePlan < Familia::Horreum
+  identifier_field :planid
+  field :planid
+  field :winner
+  set :marks
+end
+
+CASRacePlan.instances.clear rescue nil
+CASRacePlan.all.each(&:destroy!) rescue nil
+
+## CAS race: exactly one thread per iteration wins atomic_write ownership
+@iterations = 100
+@threads_per_iteration = 10
+@success_counter = Concurrent::AtomicFixnum.new(0)
+@raise_counter = Concurrent::AtomicFixnum.new(0)
+@unexpected_errors = Concurrent::Array.new
+@winner_values = Concurrent::Array.new
+
+@iterations.times do |iter|
+  # Fresh instance per iteration: @atomic_write_owner must be nil when
+  # threads start. Reusing across iterations lets the prior owner leak.
+  plan = CASRacePlan.new(planid: "cas_race_#{iter}", winner: 'initial')
+  plan.save
+
+  barrier = Concurrent::CyclicBarrier.new(@threads_per_iteration)
+
+  threads = @threads_per_iteration.times.map do |tid|
+    Thread.new do
+      barrier.wait  # Release all threads simultaneously
+      begin
+        plan.atomic_write do
+          plan.winner = "thread_#{tid}"
+          plan.marks.add("mark_#{tid}")
+        end
+        @success_counter.increment
+      rescue Familia::OperationModeError => e
+        if e.message.include?('another Fiber or Thread')
+          @raise_counter.increment
+        else
+          @unexpected_errors << [:wrong_message, e.message]
+        end
+      rescue => e
+        @unexpected_errors << [:wrong_class, e.class.name, e.message]
+      end
+    end
+  end
+
+  threads.each(&:join)
+
+  reloaded = CASRacePlan.find_by_id("cas_race_#{iter}")
+  @winner_values << reloaded.winner if reloaded
+end
+
+[
+  @success_counter.value,
+  @raise_counter.value,
+  @unexpected_errors.to_a,
+  @winner_values.size,
+]
+#=> [100, 900, [], 100]
+
+## Every persisted winner reflects a single thread's update (no mix of writes)
+# Each winner must match the "thread_N" pattern -- if two threads had
+# both opened parallel MULTIs, persist_to_storage could interleave and
+# produce values that neither thread set. A perfect pass guarantees
+# exactly one winner serialised its update per iteration.
+@winner_values.all? { |w| w =~ /\Athread_\d+\z/ }
+#==> _ == true
+
+## All marks sets contain exactly one member (the winning thread's mark)
+# SADD is additive, so if two threads had opened parallel MULTIs and both
+# got past the guard, their respective thread_N mark values would both
+# land and the set would have >= 2 distinct members. A set size of 1
+# per iteration is a second-order witness that exactly one thread
+# executed the MULTI body.
+@marks_counts = @iterations.times.map do |iter|
+  reloaded = CASRacePlan.find_by_id("cas_race_#{iter}")
+  reloaded ? reloaded.marks.members.size : -1
+end
+@marks_counts.all? { |c| c == 1 }
+#==> _ == true
+
+# Teardown
+CASRacePlan.instances.clear rescue nil
+CASRacePlan.all.each(&:destroy!) rescue nil


### PR DESCRIPTION
Closes #220.

## Summary

Adds `Horreum#atomic_write(&block)` that persists scalar fields and DataType collection mutations in a single Redis MULTI/EXEC, giving callers true transactional atomicity for mixed updates. `save_with_collections` already sequences these writes (scalars first, then block), but a collection failure leaves scalars committed — that gap is the motivation.

## Approach

Rather than building a deferred command queue (the original sketch in #220), the implementation composes existing infrastructure:

- `transaction { }` sets `Fiber[:familia_transaction]`
- `DataType#dbclient` already reads that Fiber-local and routes commands to the open MULTI when set

So inside the block, scalar setters mutate ivars in-process; collection ops (`features.add`, `scores.zadd`, etc.) auto-route into the MULTI. The block yields first, then `persist_to_storage` queues HMSET + index updates + `touch_instances!`, then EXEC fires. No new plumbing.

**Non-obvious detail**: the `yield`-then-`persist_to_storage` ordering in `atomic_write.rb` is load-bearing. `to_h_for_storage` snapshots ivars at command-queue time, not at yield time, so in-block scalar assignments must happen before the HMSET gets queued. Reversing the order silently drops scalar assignments. Worth a reviewer glance.

## Guards

- `ArgumentError` — no block given
- `Familia::OperationModeError` — nested inside an existing `transaction { }` or another `atomic_write`
- `Familia::OperationModeError` — same-instance re-entry from a different Fiber/Thread (follow-up commit `a165ee5` — `@atomic_write_owner` tracks the owning Fiber)
- `Familia::CrossDatabaseError` (new error class, `< OperationModeError`) — any related field with a mismatched `logical_database`. The guard checks **both** `related_fields` and `class_related_fields` — the latter matters because `persist_to_storage` writes to `self.class.instances` inside the MULTI.

## Known limitations

Not hidden, called out for reviewers:

- Thread-level races on `@atomic_write_active` / `@atomic_write_owner` are mitigated by Ruby's GIL but not eliminated. Consistent with the codebase's existing "Lazy Initialization Races" note.
- Collection method return values inside the block are `Redis::Future` (inherent to MULTI). Documented, not papered over.
- Same-instance concurrent `atomic_write` from different Fibers/Threads raises rather than blocks — no mutex-based wait.
- Uncovered test paths: encrypted fields, `JsonStringKey` specifically, `StringKey#increment` inside the block. Low risk; worth follow-up if wider adoption exposes them.

## Files

| File | Purpose |
|---|---|
| `lib/familia/horreum/atomic_write.rb` | New module: `atomic_write`, `atomic_write_mode?`, `guard_atomic_write_database!` |
| `lib/familia/errors.rb` | New `Familia::CrossDatabaseError < OperationModeError` |
| `lib/familia/data_type.rb` | `warn_if_dirty!` suppresses warnings when parent is in atomic_write_mode |
| `lib/familia/horreum.rb` | Require + include the new module |
| `lib/familia/horreum/persistence.rb` | `@see` cross-reference on `save_with_collections` |
| `try/features/atomic_write_try.rb` | 20 testcases |
| `CLAUDE.md` | Extended Write Model section with the new tier |
| `changelog.d/20260417_181432_delano_220_atomic_write_block.rst` | RST fragment under Added + AI Assistance |

## Verification

- atomic_write suite: 20/20
- save_with_collections regression: 9/9
- data_types integration: 27/27
- thread_safety: 80/80
- unit: 1088/1088
- Rubocop clean on lib files

## Test plan

- [ ] Reviewer sanity-checks the `yield` before `persist_to_storage` ordering in `lib/familia/horreum/atomic_write.rb`
- [ ] Reviewer confirms the cross-database guard covers their expected DataType field patterns (instance-level + class-level)
- [ ] Reviewer considers whether the same-instance Fiber re-entrancy should raise (current behavior) or block on a mutex (would require a wider design change)
- [ ] Spot-check the changelog fragment renders correctly when next `scriv collect` runs