### PR TITLE
Implement instance-scoped multi-index audit and repair

### DIFF
--- a/changelog.d/20260514_034522_claude_review_familia_issue_217.rst
+++ b/changelog.d/20260514_034522_claude_review_familia_issue_217.rst
@@ -1,0 +1,46 @@
+Added
+~~~~~
+
+- Instance-scoped ``audit_multi_indexes`` is now fully implemented.
+  Discovers per-scope bucket keys via SCAN, partitions them by scope
+  instance, and reports stale members, orphaned buckets, and missing
+  entries in the same shape as the class-level audit. Orphan entries
+  carry a ``:reason`` (``:scope_missing`` or ``:field_value_unheld``)
+  and a ``:scope_id``. Missing entries are detected via the indexed
+  class's ``participates_in`` relationship to the scope class; when
+  absent, the result carries ``missing_status: :not_audited``.
+  Resolves the ``:not_implemented`` follow-up from #217.
+
+- ``repair_multi_indexes!`` class method that invokes the existing
+  ``rebuild_<index_name>`` methods for both class-level (one call on
+  the indexed class) and instance-scoped (one call per scope
+  instance) multi-indexes. Indexes whose audit status is ``:ok`` are
+  skipped; rebuild methods that don't exist or scope classes
+  without an ``instances`` collection are recorded in ``:skipped``
+  with a reason.
+
+Changed
+~~~~~~~
+
+- ``repair_all!`` now runs each repair stage inside its own rescue
+  boundary; a failure in one dimension no longer prevents the others
+  from running. The return hash gains ``:status`` (``:ok`` or
+  ``:partial_failure``), ``:errors`` (per-stage exception details
+  when raised), and ``:multi_indexes`` (results from the new
+  ``repair_multi_indexes!``). An opt-in ``verify: true`` kwarg
+  re-runs ``health_check`` after repair and exposes the result as
+  ``:post_audit`` / ``:verified`` so callers can confirm the run
+  actually drove the model back to a healthy state.
+
+- ``AuditReport#complete?`` is no longer false-positive due to
+  ``:not_implemented`` stubs in ``multi_indexes`` -- instance-scoped
+  indexes return ``:ok`` or ``:issues_found`` like class-level ones.
+
+AI Assistance
+~~~~~~~~~~~~~
+
+- Instance-scoped multi-index audit algorithm (bucket discovery,
+  scope existence batching, participation-driven missing detection),
+  ``repair_multi_indexes!``, the ``repair_all!`` robustness
+  refactor, and the accompanying tryouts coverage were authored
+  with Claude Code assistance against the #217 review branch.

--- a/lib/familia/horreum/management/audit.rb
+++ b/lib/familia/horreum/management/audit.rb
@@ -423,10 +423,13 @@ module Familia
 
       # Audit a single multi index.
       #
-      # Class-level multi-indexes (within: nil or within: :class) are fully
-      # audited. Instance-scoped multi-indexes (within: SomeClass) require
-      # enumerating every scope instance to discover per-value set keys; that
-      # path is not implemented yet and returns status: :not_implemented.
+      # Class-level multi-indexes (within: nil or within: :class) and
+      # instance-scoped multi-indexes (within: SomeClass) are both fully
+      # audited. The class-level path SCANs a single bucket namespace and
+      # cross-checks it against live objects on this class. The
+      # instance-scoped path SCANs across all scope instances, partitions
+      # the discovered bucket keys by scope id, and uses the participation
+      # relationship (if present) to detect missing entries.
       #
       # @param rel [IndexingRelationship]
       # @param scanned_identifiers [Array<String>, nil] Optional cached SCAN result.
@@ -434,26 +437,15 @@ module Familia
       # @return [Hash] {index_name:, stale_members: [], missing: [], orphaned_keys: [], status:}
       #
       def audit_single_multi_index(rel, scanned_identifiers: nil, loaded_objects: nil)
-        index_name = rel.index_name
-
-        unless rel.class_level?
-          Familia.debug "[audit_multi_indexes] #{name}##{index_name}: " \
-                        "instance-scoped audit (within: #{rel.within.inspect}) not implemented; " \
-                        'requires enumerating every scope instance to discover per-value set keys'
-          return {
-            index_name: index_name,
-            stale_members: [],
-            missing: [],
-            orphaned_keys: [],
-            status: :not_implemented,
-          }
+        if rel.class_level?
+          audit_class_level_multi_index(
+            rel,
+            scanned_identifiers: scanned_identifiers,
+            loaded_objects: loaded_objects,
+          )
+        else
+          audit_instance_scoped_multi_index(rel)
         end
-
-        audit_class_level_multi_index(
-          rel,
-          scanned_identifiers: scanned_identifiers,
-          loaded_objects: loaded_objects,
-        )
       end
 
       # Audit a class-level multi index.
@@ -629,6 +621,367 @@ module Familia
         end
 
         orphaned
+      end
+
+      # Audit an instance-scoped multi-index across every scope instance.
+      #
+      # Key layout: "{scope_prefix}:{scope_id}:{index_name}:{field_value}"
+      # SCAN pattern: "{scope_prefix}:*:{index_name}:*"
+      #
+      # Three failure modes are detected:
+      #   - stale_members: bucket member object missing or field value drifted
+      #   - orphaned_keys: scope instance no longer exists, or bucket field
+      #     value is not held by any live participant for that scope
+      #   - missing: live participant has a field value but no bucket entry
+      #     in the scope it belongs to (requires participation relationship)
+      #
+      # Detecting "missing" requires walking each scope instance's
+      # participation collection to discover which indexed objects belong
+      # to which scope. When the indexed class does not declare a
+      # `participates_in scope_class, :collection_name` relationship, the
+      # missing dimension is set to `:not_audited` and a debug message
+      # explains why.
+      #
+      # @param rel [IndexingRelationship]
+      # @return [Hash] {index_name:, stale_members:, missing:, orphaned_keys:, status:}
+      #
+      def audit_instance_scoped_multi_index(rel)
+        scope_class = Familia.resolve_class(rel.scope_class)
+
+        bucket_entries = discover_instance_scoped_buckets(rel, scope_class)
+        scope_ids = bucket_entries.values.map { |e| e[:scope_id] }.uniq
+        scope_exists_flags = batch_check_scope_existence(scope_class, scope_ids)
+
+        stale_members, orphaned_from_scope = inspect_instance_scoped_buckets(
+          rel, bucket_entries, scope_exists_flags
+        )
+
+        missing, missing_status = detect_instance_scoped_missing(
+          rel, scope_class, bucket_entries, scope_exists_flags
+        )
+
+        orphaned_from_field_value = detect_instance_scoped_orphaned_buckets(
+          rel, scope_class, bucket_entries, scope_exists_flags
+        )
+
+        orphaned_keys = orphaned_from_scope + orphaned_from_field_value
+
+        status = if stale_members.empty? && missing.empty? && orphaned_keys.empty?
+          :ok
+        else
+          :issues_found
+        end
+
+        result = {
+          index_name: rel.index_name,
+          stale_members: stale_members,
+          missing: missing,
+          orphaned_keys: orphaned_keys,
+          status: status,
+        }
+        # Surface a sub-status when the "missing" dimension could not be
+        # audited so callers can distinguish "checked and clean" from
+        # "not checked due to missing participation".
+        result[:missing_status] = missing_status if missing_status != :ok
+        result
+      end
+
+      # SCAN for instance-scoped bucket keys and load their members.
+      #
+      # @param rel [IndexingRelationship]
+      # @param scope_class [Class]
+      # @return [Hash{String => Hash}] full_key => {key:, scope_id:, field_value:, identifiers:}
+      #
+      def discover_instance_scoped_buckets(rel, scope_class)
+        scope_prefix = "#{scope_class.prefix}#{Familia.delim}"
+        marker = "#{Familia.delim}#{rel.index_name}#{Familia.delim}"
+        pattern = "#{scope_prefix}*#{marker}*"
+        bucket_entries = {}
+
+        # Use the scope class's dbclient so multi-database setups address
+        # the right Redis instance for the scope namespace.
+        client = scope_class.dbclient
+
+        # Batch SCAN results and pipeline SMEMBERS to collapse a round trip
+        # per bucket key into a round trip per slice of 100 keys.
+        client.scan_each(match: pattern).each_slice(100) do |keys|
+          parsed = keys.filter_map do |key|
+            scope_id, field_value = parse_instance_scoped_bucket_key(key, scope_prefix, marker)
+            next nil if scope_id.nil? || scope_id.empty? || field_value.nil? || field_value.empty?
+
+            [key, scope_id, field_value]
+          end
+          next if parsed.empty?
+
+          members_batch = client.pipelined do |pipe|
+            parsed.each { |(key, _sid, _fv)| pipe.smembers(key) }
+          end
+
+          parsed.each_with_index do |(key, scope_id, field_value), idx|
+            bucket_entries[key] = {
+              key: key,
+              scope_id: scope_id,
+              field_value: field_value,
+              identifiers: deserialize_index_members(members_batch[idx]),
+            }
+          end
+        end
+
+        bucket_entries
+      end
+
+      # Splits a bucket key into (scope_id, field_value).
+      #
+      # The key is structured as "{scope_prefix}{scope_id}{marker}{field_value}"
+      # where marker is "{delim}{index_name}{delim}". The first occurrence of
+      # the marker is used to support identifiers and field values that
+      # themselves contain the delimiter character.
+      #
+      # @param key [String]
+      # @param scope_prefix [String]
+      # @param marker [String]
+      # @return [Array(String, String), Array(nil, nil)]
+      #
+      def parse_instance_scoped_bucket_key(key, scope_prefix, marker)
+        return [nil, nil] unless key.start_with?(scope_prefix)
+
+        rest = key[scope_prefix.length..]
+        marker_pos = rest.index(marker)
+        return [nil, nil] unless marker_pos
+
+        scope_id = rest[0...marker_pos]
+        field_value = rest[(marker_pos + marker.length)..]
+        [scope_id, field_value]
+      end
+
+      # Batch-checks scope instance existence via pipelined EXISTS.
+      #
+      # @param scope_class [Class]
+      # @param scope_ids [Array<String>]
+      # @return [Hash{String => Boolean}]
+      #
+      def batch_check_scope_existence(scope_class, scope_ids)
+        flags = {}
+        return flags if scope_ids.empty?
+
+        scope_ids.each_slice(100) do |slice|
+          results = scope_class.dbclient.pipelined do |pipe|
+            slice.each { |id| pipe.exists(scope_class.dbkey(id)) }
+          end
+          slice.each_with_index do |id, idx|
+            flags[id] = results[idx].to_i.positive?
+          end
+        end
+
+        flags
+      end
+
+      # Inspects each instance-scoped bucket's members for staleness.
+      #
+      # For buckets whose scope still exists, classify members via
+      # classify_multi_index_entry. For buckets whose scope is missing,
+      # mark the entire bucket as orphaned with reason :scope_missing.
+      #
+      # @return [Array(Array<Hash>, Array<Hash>)] (stale_members, orphaned_from_scope)
+      #
+      def inspect_instance_scoped_buckets(rel, bucket_entries, scope_exists_flags)
+        stale_members = []
+        orphaned = []
+
+        bucket_entries.each_value do |entry|
+          unless scope_exists_flags[entry[:scope_id]]
+            orphaned << {
+              field_value: entry[:field_value],
+              key: entry[:key],
+              scope_id: entry[:scope_id],
+              reason: :scope_missing,
+            }
+            next
+          end
+
+          identifiers = entry[:identifiers].map(&:to_s)
+          next if identifiers.empty?
+
+          objects = load_multi(identifiers)
+          identifiers.each_with_index do |identifier, idx|
+            classification = classify_multi_index_entry(rel, entry[:field_value], identifier, objects[idx])
+            next unless classification
+
+            classification[:scope_id] = entry[:scope_id]
+            stale_members << classification
+          end
+        end
+
+        [stale_members, orphaned]
+      end
+
+      # Detects buckets whose field_value is no longer held by any live
+      # participant in that scope.
+      #
+      # Without a participation relationship from this class to the scope
+      # class, we cannot determine which participants belong to which scope,
+      # so this dimension is skipped (the prior :scope_missing check still
+      # surfaces fully orphaned buckets).
+      #
+      # @return [Array<Hash>]
+      #
+      def detect_instance_scoped_orphaned_buckets(rel, scope_class, bucket_entries, scope_exists_flags)
+        participation = find_participation_to_scope(scope_class)
+        return [] unless participation
+
+        # field_values_per_scope: { scope_id => Set<String> } observed on live participants
+        field_values_per_scope = collect_field_values_per_scope(rel, scope_class, participation)
+
+        orphaned = []
+        bucket_entries.each_value do |entry|
+          # Already counted by inspect_instance_scoped_buckets when scope is missing.
+          next unless scope_exists_flags[entry[:scope_id]]
+
+          observed = field_values_per_scope[entry[:scope_id]] || Set.new
+          next if observed.include?(entry[:field_value])
+
+          orphaned << {
+            field_value: entry[:field_value],
+            key: entry[:key],
+            scope_id: entry[:scope_id],
+            reason: :field_value_unheld,
+          }
+        end
+
+        orphaned
+      end
+
+      # Detects live participants whose bucket entry is absent.
+      #
+      # @return [Array(Array<Hash>, Symbol)] (missing, sub_status)
+      #
+      def detect_instance_scoped_missing(rel, scope_class, bucket_entries, scope_exists_flags)
+        participation = find_participation_to_scope(scope_class)
+        return [[], :not_audited] unless participation
+
+        unless scope_class.respond_to?(:instances)
+          Familia.debug "[audit_instance_scoped_multi_index] #{name}##{rel.index_name}: " \
+                        "scope class #{scope_class.name} has no instances collection; " \
+                        "missing detection requires enumerating scope instances"
+          return [[], :no_scope_instances]
+        end
+
+        missing = []
+        scope_ids = enumerate_scope_ids(scope_class, scope_exists_flags)
+
+        scope_ids.each do |scope_id|
+          scope_instance = scope_class.find_by_id(scope_id)
+          next unless scope_instance
+
+          collection = scope_instance.send(participation.collection_name)
+          member_ids = participation_collection_members(collection)
+          next if member_ids.empty?
+
+          member_objects = load_multi(member_ids)
+          member_ids.each_with_index do |identifier, idx|
+            obj = member_objects[idx]
+            next unless obj
+
+            value = obj.send(rel.field)
+            next if value.nil? || value.to_s.strip.empty?
+
+            expected_field_value = value.to_s
+            expected_key = build_instance_scoped_bucket_key(scope_class, scope_id, rel.index_name, expected_field_value)
+            bucket = bucket_entries[expected_key]
+            next if bucket && bucket[:identifiers].any? { |m| m.to_s == identifier.to_s }
+
+            missing << {
+              identifier: identifier,
+              field_value: expected_field_value,
+              scope_class: scope_class.name,
+              scope_id: scope_id,
+            }
+          end
+        end
+
+        [missing, :ok]
+      end
+
+      # Aggregates the field values present per scope instance via the
+      # participation collection. Used to decide which buckets are orphaned
+      # by virtue of no live participant holding their field_value.
+      #
+      # @return [Hash{String => Set<String>}]
+      #
+      def collect_field_values_per_scope(rel, scope_class, participation)
+        result = Hash.new { |h, k| h[k] = Set.new }
+        return result unless scope_class.respond_to?(:instances)
+
+        scope_class.instances.members.each do |scope_id|
+          scope_instance = scope_class.find_by_id(scope_id)
+          next unless scope_instance
+
+          collection = scope_instance.send(participation.collection_name)
+          member_ids = participation_collection_members(collection)
+          next if member_ids.empty?
+
+          load_multi(member_ids).each do |obj|
+            next unless obj
+
+            value = obj.send(rel.field)
+            next if value.nil? || value.to_s.strip.empty?
+
+            result[scope_id] << value.to_s
+          end
+        end
+
+        result
+      end
+
+      # Looks up the indexed-class participation pointing at the scope class.
+      #
+      # Returns nil when the indexed class does not declare a
+      # `participates_in scope_class, :collection_name` relationship,
+      # which makes per-scope membership inference impossible.
+      #
+      # @return [ParticipationRelationship, nil]
+      #
+      def find_participation_to_scope(scope_class)
+        return nil unless respond_to?(:participation_relationships)
+
+        participation_relationships.find { |rel| rel.target_class == scope_class }
+      end
+
+      # Enumerate the set of scope ids worth inspecting for "missing"
+      # detection. Includes:
+      #   - every scope id we already saw a bucket for
+      #   - every scope id in the scope class's instances timeline
+      #
+      # @return [Array<String>]
+      #
+      def enumerate_scope_ids(scope_class, scope_exists_flags)
+        from_buckets = scope_exists_flags.select { |_, v| v }.keys
+        from_instances = scope_class.instances.members.to_a
+        (from_buckets + from_instances).uniq
+      end
+
+      # Returns members of a participation collection in a type-agnostic
+      # way. Falls back to to_a when the DataType does not expose members.
+      #
+      # @return [Array<String>]
+      #
+      def participation_collection_members(collection)
+        if collection.respond_to?(:members)
+          Array(collection.members)
+        elsif collection.respond_to?(:to_a)
+          Array(collection.to_a)
+        else
+          []
+        end
+      end
+
+      # Rebuilds the expected bucket key for a (scope_id, field_value) pair.
+      #
+      # @return [String]
+      #
+      def build_instance_scoped_bucket_key(scope_class, scope_id, index_name, field_value)
+        d = Familia.delim
+        "#{scope_class.prefix}#{d}#{scope_id}#{d}#{index_name}#{d}#{field_value}"
       end
 
       # Audit a class-level participation collection (from class_participates_in).

--- a/lib/familia/horreum/management/repair.rb
+++ b/lib/familia/horreum/management/repair.rb
@@ -222,10 +222,27 @@ module Familia
 
       # Runs health_check then all repair methods.
       #
-      # By default this repairs the three always-on dimensions
-      # (instances, unique indexes, participations). The related_fields
-      # and cross_references dimensions are opt-in and must be enabled
-      # on the audit side for repair to consider them.
+      # By default this repairs four always-on dimensions (instances,
+      # unique indexes, multi indexes, and participations). The
+      # related_fields dimension is opt-in via +audit_collections:+;
+      # cross_references drift is reported but not auto-repaired.
+      #
+      # Each repair stage runs inside its own rescue boundary so a
+      # failure in one dimension does not prevent the others from
+      # running. The returned hash includes:
+      #   - +:report+ -- the AuditReport produced by health_check
+      #   - one entry per stage that ran (e.g. +:instances+, +:indexes+,
+      #     +:multi_indexes+, +:participations+, optionally +:related_fields+)
+      #   - +:errors+ -- map of stage name to exception details for any
+      #     stage that raised
+      #   - +:status+ -- +:ok+ when every stage finished cleanly,
+      #     +:partial_failure+ when one or more stages errored
+      #
+      # When +verify:+ is true, a second health_check runs after repair
+      # and the resulting report is exposed as +:post_audit+, with
+      # +:verified+ set to +post_audit.healthy?+. This lets callers
+      # confirm that the repair actually drove the model back to a
+      # healthy state.
       #
       # @param batch_size [Integer] SCAN batch size passed to health_check
       # @param audit_collections [Boolean] When true, health_check runs
@@ -239,10 +256,13 @@ module Familia
       #   resolve the drift manually. The flag is accepted here for symmetry
       #   with the audit side and so repair_all! can surface the dimension
       #   through its returned report.
+      # @param verify [Boolean] When true, re-run health_check after
+      #   repair and expose the result as +:post_audit+ / +:verified+.
       # @yield [Hash] Progress callbacks
       # @return [Hash] Combined repair results plus the AuditReport
       #
-      def repair_all!(batch_size: 100, audit_collections: false, check_cross_refs: false, &progress)
+      def repair_all!(batch_size: 100, audit_collections: false, check_cross_refs: false,
+                      verify: false, &progress)
         report = health_check(
           batch_size: batch_size,
           audit_collections: audit_collections,
@@ -250,25 +270,100 @@ module Familia
           &progress
         )
 
-        instances_result = repair_instances!(report.instances)
-        indexes_result = repair_indexes!(report.unique_indexes)
-        participations_result = repair_participations!(report.participations)
+        stages = {}
+        errors = {}
 
-        result = {
-          report: report,
-          instances: instances_result,
-          indexes: indexes_result,
-          participations: participations_result,
-        }
+        # Run each repair stage with exception isolation. A failure in
+        # one stage should not prevent later stages from running, so the
+        # operator gets the broadest possible view of what was repaired.
+        run_repair_stage(stages, errors, :instances) { repair_instances!(report.instances) }
+        run_repair_stage(stages, errors, :indexes) { repair_indexes!(report.unique_indexes) }
+        run_repair_stage(stages, errors, :multi_indexes) { repair_multi_indexes!(report.multi_indexes) }
+        run_repair_stage(stages, errors, :participations) { repair_participations!(report.participations) }
 
         # Only repair related fields when the audit actually checked them.
         # Nil means the caller did not pass audit_collections: true to
         # health_check, so repair has nothing to act on.
         unless report.related_fields.nil?
-          result[:related_fields] = repair_related_fields!(report.related_fields, &progress)
+          run_repair_stage(stages, errors, :related_fields) {
+            repair_related_fields!(report.related_fields, &progress)
+          }
+        end
+
+        result = stages.merge(
+          report: report,
+          errors: errors,
+          status: errors.empty? ? :ok : :partial_failure,
+        )
+
+        if verify
+          post = health_check(
+            batch_size: batch_size,
+            audit_collections: audit_collections,
+            check_cross_refs: check_cross_refs,
+            &progress
+          )
+          result[:post_audit] = post
+          result[:verified] = post.healthy?
         end
 
         result
+      end
+
+      # Repairs multi-indexes by invoking the existing rebuild_<index_name>
+      # methods. Handles both class-level and instance-scoped indexes.
+      #
+      # For class-level multi-indexes the rebuild method lives on the
+      # indexed class (e.g. +Customer.rebuild_role_index+). For
+      # instance-scoped multi-indexes the rebuild method lives on each
+      # scope instance (e.g. +company.rebuild_dept_index+); we iterate
+      # the scope class's instances timeline and rebuild per scope.
+      #
+      # Indexes whose audit status is :ok are skipped. Indexes for
+      # which a rebuild method is unavailable or a scope class has no
+      # instances collection are recorded in +:skipped+ with a reason.
+      #
+      # @param audit_results [Array<Hash>, nil] Results from audit_multi_indexes
+      # @return [Hash] {rebuilt:, rebuilt_per_scope:, skipped:}
+      #
+      def repair_multi_indexes!(audit_results = nil)
+        audit_results ||= audit_multi_indexes
+
+        rebuilt = []
+        rebuilt_per_scope = []
+        skipped = []
+
+        unless respond_to?(:indexing_relationships)
+          return { rebuilt: rebuilt, rebuilt_per_scope: rebuilt_per_scope, skipped: skipped }
+        end
+
+        multi_rels = indexing_relationships.select { |r| r.cardinality == :multi }
+
+        audit_results.each do |idx_result|
+          next if idx_result[:status] == :ok
+
+          index_name = idx_result[:index_name]
+          rel = multi_rels.find { |r| r.index_name == index_name }
+          unless rel
+            skipped << { index_name: index_name, reason: :relationship_missing }
+            next
+          end
+
+          if rel.class_level?
+            method = :"rebuild_#{index_name}"
+            if respond_to?(method)
+              send(method)
+              rebuilt << index_name
+            else
+              skipped << { index_name: index_name, reason: :rebuild_method_missing }
+            end
+          else
+            scopes_rebuilt = rebuild_instance_scoped_multi_index(rel, skipped)
+            rebuilt_per_scope << { index_name: index_name, scopes_rebuilt: scopes_rebuilt } if scopes_rebuilt
+          end
+        end
+
+        { rebuilt: rebuilt, rebuilt_per_scope: rebuilt_per_scope, skipped: skipped }
       end
 
       # SCAN helper for enumerating keys matching a pattern.
@@ -291,6 +386,63 @@ module Familia
       end
 
       private
+
+      # Runs a repair stage with exception isolation.
+      #
+      # On success, the stage's return value is stored under +name+ in
+      # +stages+. On failure, the exception is logged and recorded
+      # under +name+ in +errors+ so repair_all! can surface the
+      # partial-failure status without losing the rest of the run.
+      #
+      # @param stages [Hash] Accumulator for successful stage results
+      # @param errors [Hash] Accumulator for stage failures
+      # @param name [Symbol] Stage identifier (:instances, :indexes, ...)
+      # @yield Stage body returning the per-stage result hash
+      #
+      def run_repair_stage(stages, errors, name)
+        stages[name] = yield
+      rescue StandardError => e
+        errors[name] = {
+          class: e.class.name,
+          message: e.message,
+          backtrace: Array(e.backtrace).first(5),
+        }
+        Familia.warn "[repair_all!] #{name} stage failed: #{e.class}: #{e.message}"
+      end
+
+      # Rebuilds an instance-scoped multi-index across every scope
+      # instance. Returns the number of scope instances successfully
+      # rebuilt, or nil when the scope class lacks an instances
+      # collection (in which case +skipped+ is appended to).
+      #
+      # @param rel [IndexingRelationship]
+      # @param skipped [Array<Hash>] Mutated when no scope path is available
+      # @return [Integer, nil]
+      #
+      def rebuild_instance_scoped_multi_index(rel, skipped)
+        scope_class = Familia.resolve_class(rel.scope_class)
+        method = :"rebuild_#{rel.index_name}"
+
+        unless scope_class.respond_to?(:instances)
+          skipped << {
+            index_name: rel.index_name,
+            reason: :no_scope_instances_collection,
+            scope_class: scope_class.name,
+          }
+          return nil
+        end
+
+        count = 0
+        scope_class.instances.members.each do |scope_id|
+          scope = scope_class.find_by_id(scope_id)
+          next unless scope
+          next unless scope.respond_to?(method)
+
+          scope.send(method)
+          count += 1
+        end
+        count
+      end
 
       # Process a batch of key/identifier pairs for rebuild_instances.
       #

--- a/try/audit/audit_instance_scoped_multi_index_try.rb
+++ b/try/audit/audit_instance_scoped_multi_index_try.rb
@@ -1,0 +1,198 @@
+# try/audit/audit_instance_scoped_multi_index_try.rb
+#
+# frozen_string_literal: true
+
+# Instance-scoped multi-index audit
+#
+# Covers the previously-stubbed path. Validates discovery of buckets
+# across scope instances, detection of stale members (object_missing
+# and value_mismatch), orphaned buckets (scope_missing and
+# field_value_unheld), and missing entries detected via the
+# participation relationship from the indexed class to the scope class.
+
+require_relative '../support/helpers/test_helpers'
+
+class ::ISMICompany < Familia::Horreum
+  feature :relationships
+
+  identifier_field :company_id
+  field :company_id
+  field :name
+
+  class_sorted_set :instances, reference: true
+end
+
+class ::ISMIEmployee < Familia::Horreum
+  feature :relationships
+
+  identifier_field :emp_id
+  field :emp_id
+  field :department
+  field :name
+
+  multi_index :department, :dept_index, within: ISMICompany
+  participates_in ISMICompany, :employees, score: :emp_id
+
+  class_sorted_set :instances, reference: true
+end
+
+def ismi_reset!
+  [ISMICompany, ISMIEmployee].each do |klass|
+    existing = Familia.dbclient.keys("#{klass.prefix}:*")
+    Familia.dbclient.del(*existing) if existing.any?
+    klass.instances.clear if klass.respond_to?(:instances)
+  end
+end
+
+def ismi_seed!
+  ismi_reset!
+  @c1 = ISMICompany.new(company_id: 'c-1', name: 'Acme')
+  @c1.save
+  @c2 = ISMICompany.new(company_id: 'c-2', name: 'Globex')
+  @c2.save
+
+  @e1 = ISMIEmployee.new(emp_id: 'e-1', department: 'engineering', name: 'Alice')
+  @e1.save
+  @e1.add_to_ismi_company_employees(@c1)
+  @e1.add_to_ismi_company_dept_index(@c1)
+
+  @e2 = ISMIEmployee.new(emp_id: 'e-2', department: 'engineering', name: 'Bob')
+  @e2.save
+  @e2.add_to_ismi_company_employees(@c1)
+  @e2.add_to_ismi_company_dept_index(@c1)
+
+  @e3 = ISMIEmployee.new(emp_id: 'e-3', department: 'sales', name: 'Carla')
+  @e3.save
+  @e3.add_to_ismi_company_employees(@c2)
+  @e3.add_to_ismi_company_dept_index(@c2)
+end
+
+ismi_reset!
+
+## Empty state: audit returns a single result for the declared index
+@empty = ISMIEmployee.audit_multi_indexes
+@empty.size
+#=> 1
+
+## Empty state: status is :ok
+@empty.first[:status]
+#=> :ok
+
+## Empty state: stale_members, missing, orphaned_keys all empty
+[@empty.first[:stale_members], @empty.first[:missing], @empty.first[:orphaned_keys]]
+#=> [[], [], []]
+
+## Healthy baseline: status :ok
+ismi_seed!
+ISMIEmployee.audit_multi_indexes.first[:status]
+#=> :ok
+
+## Healthy baseline: no stale members
+ismi_seed!
+ISMIEmployee.audit_multi_indexes.first[:stale_members]
+#=> []
+
+## Healthy baseline: no missing
+ismi_seed!
+ISMIEmployee.audit_multi_indexes.first[:missing]
+#=> []
+
+## Healthy baseline: no orphaned keys
+ismi_seed!
+ISMIEmployee.audit_multi_indexes.first[:orphaned_keys]
+#=> []
+
+## Stale (object_missing): delete employee hash key directly
+ismi_seed!
+ISMIEmployee.dbclient.del(ISMIEmployee.dbkey('e-1'))
+@result = ISMIEmployee.audit_multi_indexes.first
+@result[:stale_members].any? { |m| m[:indexed_id] == 'e-1' && m[:reason] == :object_missing }
+#=> true
+
+## Stale (object_missing): scope_id is reported on the stale entry
+ismi_seed!
+ISMIEmployee.dbclient.del(ISMIEmployee.dbkey('e-1'))
+@result = ISMIEmployee.audit_multi_indexes.first
+@result[:stale_members].find { |m| m[:indexed_id] == 'e-1' }[:scope_id]
+#=> "c-1"
+
+## Stale (object_missing): status transitions to :issues_found
+ismi_seed!
+ISMIEmployee.dbclient.del(ISMIEmployee.dbkey('e-1'))
+ISMIEmployee.audit_multi_indexes.first[:status]
+#=> :issues_found
+
+## Stale (value_mismatch): mutate field via direct HSET
+ismi_seed!
+ISMIEmployee.dbclient.hset(ISMIEmployee.dbkey('e-1'), 'department', '"marketing"')
+@result = ISMIEmployee.audit_multi_indexes.first
+@mm = @result[:stale_members].find { |m| m[:indexed_id] == 'e-1' }
+[@mm[:reason], @mm[:field_value], @mm[:current_value]]
+#=> [:value_mismatch, "engineering", "marketing"]
+
+## Stale (value_mismatch): missing entry added for the new bucket
+ismi_seed!
+ISMIEmployee.dbclient.hset(ISMIEmployee.dbkey('e-1'), 'department', '"marketing"')
+@result = ISMIEmployee.audit_multi_indexes.first
+@result[:missing].any? { |m| m[:identifier] == 'e-1' && m[:field_value] == 'marketing' }
+#=> true
+
+## Missing: object exists in participation but not in the bucket
+ismi_seed!
+# Inject an employee via direct HSET so the index-update mutation path is bypassed
+ISMIEmployee.dbclient.hset(
+  ISMIEmployee.dbkey('e-raw'),
+  'emp_id', '"e-raw"',
+  'department', '"finance"',
+  'name', '"Raw"',
+)
+# Participate raw employee with company c1 (bypassing the index path on save).
+# Use the instance dbkey directly (suffix=:employees) so the collection key
+# is "ismi_company:c-1:employees" rather than "...:object:employees".
+ISMIEmployee.dbclient.zadd(
+  ISMICompany.dbkey('c-1', :employees),
+  Familia.now,
+  'e-raw',
+)
+@result = ISMIEmployee.audit_multi_indexes.first
+@hit = @result[:missing].find { |m| m[:identifier] == 'e-raw' }
+[@hit && @hit[:field_value], @hit && @hit[:scope_id]]
+#=> ["finance", "c-1"]
+
+## Orphaned: scope instance destroyed but bucket key lingers
+ismi_seed!
+# Drop the company hash directly; bucket key under that company is now orphaned
+ISMICompany.dbclient.del(ISMICompany.dbkey('c-1'))
+@result = ISMIEmployee.audit_multi_indexes.first
+@orphans = @result[:orphaned_keys].select { |o| o[:scope_id] == 'c-1' && o[:reason] == :scope_missing }
+@orphans.size >= 1
+#=> true
+
+## Orphaned: scope_missing reason on the orphan entry
+ismi_seed!
+ISMICompany.dbclient.del(ISMICompany.dbkey('c-1'))
+@result = ISMIEmployee.audit_multi_indexes.first
+@result[:orphaned_keys].first[:reason]
+#=> :scope_missing
+
+## Orphaned (field_value_unheld): bucket whose field_value no live participant holds
+ismi_seed!
+# Manually create a bucket under c-1 for a department no employee has.
+# Use the instance dbkey directly so the key is
+# "ismi_company:c-1:dept_index:legal" with no :object segment.
+ISMIEmployee.dbclient.sadd(
+  ISMICompany.dbkey('c-1', 'dept_index:legal'),
+  '"e-1"',
+)
+@result = ISMIEmployee.audit_multi_indexes.first
+@unheld = @result[:orphaned_keys].find { |o| o[:field_value] == 'legal' && o[:scope_id] == 'c-1' }
+@unheld[:reason]
+#=> :field_value_unheld
+
+## Healthy baseline: missing_status is :ok when participation exists
+ismi_seed!
+ISMIEmployee.audit_multi_indexes.first[:missing_status]
+#=> nil
+
+# Teardown
+ismi_reset!

--- a/try/audit/m3_multi_index_stub_try.rb
+++ b/try/audit/m3_multi_index_stub_try.rb
@@ -4,11 +4,11 @@
 
 # M3: audit_multi_indexes behavior
 #
-# Covers the real class-level multi-index audit implementation plus the
-# still-stubbed instance-scoped path. Class-level indexes are audited in
-# three phases (stale members, missing objects, orphaned buckets) while
-# instance-scoped indexes return status: :not_implemented with a clearer
-# diagnostic message.
+# Covers both class-level and instance-scoped multi-index audit paths.
+# Both are audited in three phases (stale members, missing objects,
+# orphaned buckets). Instance-scoped audits depend on a participation
+# relationship to detect "missing" entries; when absent the result
+# carries missing_status: :not_audited.
 
 require_relative '../support/helpers/test_helpers'
 
@@ -112,9 +112,9 @@ M3PlainModel.audit_multi_indexes.is_a?(Array)
 @results.first[:index_name]
 #=> :category_index
 
-## Instance-scoped multi-index result includes status: :not_implemented
+## Instance-scoped multi-index returns :ok when no objects exist
 @results.first[:status]
-#=> :not_implemented
+#=> :ok
 
 ## Instance-scoped multi-index result has empty stale_members
 @results.first[:stale_members]
@@ -128,20 +128,27 @@ M3PlainModel.audit_multi_indexes.is_a?(Array)
 @results.first[:missing]
 #=> []
 
+## Instance-scoped audit without participation surfaces missing_status
+# M3ScopedModel has multi_index ... within: M3ScopeTarget but no
+# participates_in M3ScopeTarget, so per-scope membership cannot be
+# inferred and the missing dimension is marked :not_audited.
+@results.first[:missing_status]
+#=> :not_audited
+
 ## health_check with instance-scoped multi-index returns AuditReport
 @scoped_report = M3ScopedModel.health_check
 @scoped_report.class.name
 #=> "Familia::Horreum::AuditReport"
 
-## health_check includes multi_indexes with status marker
-@scoped_report.multi_indexes.any? { |idx| idx[:status] == :not_implemented }
+## health_check no longer reports :not_implemented for instance-scoped
+@scoped_report.multi_indexes.none? { |idx| idx[:status] == :not_implemented }
 #=> true
 
-## health_check is still healthy with not_implemented stub (empty collections)
+## health_check is healthy when no buckets exist
 @scoped_report.healthy?
 #=> true
 
-## health_check complete? is false when a stubbed index exists
+## health_check complete? remains false until related_fields/cross_refs are opted in
 @scoped_report.complete?
 #=> false
 

--- a/try/audit/repair_all_robustness_try.rb
+++ b/try/audit/repair_all_robustness_try.rb
@@ -1,0 +1,149 @@
+# try/audit/repair_all_robustness_try.rb
+#
+# frozen_string_literal: true
+
+# repair_all! robustness:
+#  - per-stage exception isolation
+#  - aggregate :status / :errors return shape
+#  - opt-in :verify post-audit
+#  - multi-index repair coverage (class-level and instance-scoped)
+
+require_relative '../support/helpers/test_helpers'
+
+class RARoleModel < Familia::Horreum
+  feature :relationships
+
+  identifier_field :rid
+  field :rid
+  field :role
+  field :name
+
+  multi_index :role, :role_index
+
+  class_sorted_set :instances, reference: true
+end
+
+class RARoleCompany < Familia::Horreum
+  feature :relationships
+
+  identifier_field :company_id
+  field :company_id
+  field :name
+
+  class_sorted_set :instances, reference: true
+end
+
+class RARoleEmployee < Familia::Horreum
+  feature :relationships
+
+  identifier_field :emp_id
+  field :emp_id
+  field :department
+  field :name
+
+  multi_index :department, :dept_index, within: RARoleCompany
+  participates_in RARoleCompany, :employees, score: :emp_id
+
+  class_sorted_set :instances, reference: true
+end
+
+def rar_reset!
+  [RARoleModel, RARoleCompany, RARoleEmployee].each do |klass|
+    existing = Familia.dbclient.keys("#{klass.prefix}:*")
+    Familia.dbclient.del(*existing) if existing.any?
+    klass.instances.clear if klass.respond_to?(:instances)
+  end
+end
+
+rar_reset!
+
+## repair_all! returns :status => :ok on a clean model
+@r1 = RARoleModel.new(rid: 'r-1', role: 'admin', name: 'One')
+@r1.save
+@result_clean = RARoleModel.repair_all!
+@result_clean[:status]
+#=> :ok
+
+## repair_all! returns an empty :errors hash on a clean model
+@result_clean[:errors]
+#=> {}
+
+## repair_all! has a :multi_indexes stage entry
+@result_clean[:multi_indexes].is_a?(Hash)
+#=> true
+
+## repair_all! :verify => true exposes :post_audit and :verified
+@result_verified = RARoleModel.repair_all!(verify: true)
+[@result_verified[:verified], @result_verified[:post_audit].class.name]
+#=> [true, "Familia::Horreum::AuditReport"]
+
+## Class-level multi-index rebuild: drift in role_index is fixed by repair_all!
+# Inject a raw object so the index-update path is bypassed
+RARoleModel.dbclient.hset(
+  RARoleModel.dbkey('r-raw'),
+  'rid', '"r-raw"',
+  'role', '"observer"',
+  'name', '"Raw"',
+)
+@pre_audit = RARoleModel.audit_multi_indexes.first
+@result_fixed = RARoleModel.repair_all!(verify: true)
+[@pre_audit[:missing].any? { |m| m[:identifier] == 'r-raw' },
+ @result_fixed[:multi_indexes][:rebuilt].include?(:role_index),
+ @result_fixed[:verified]]
+#=> [true, true, true]
+
+## Instance-scoped multi-index rebuild: drift via raw participation is fixed
+rar_reset!
+@c1 = RARoleCompany.new(company_id: 'c-1', name: 'Acme')
+@c1.save
+@e1 = RARoleEmployee.new(emp_id: 'e-1', department: 'engineering', name: 'Alice')
+@e1.save
+@e1.add_to_ra_role_company_employees(@c1)
+@e1.add_to_ra_role_company_dept_index(@c1)
+# Inject a raw participant whose department bucket does not exist
+RARoleEmployee.dbclient.hset(
+  RARoleEmployee.dbkey('e-raw'),
+  'emp_id', '"e-raw"',
+  'department', '"sales"',
+  'name', '"Raw"',
+)
+RARoleEmployee.dbclient.zadd(
+  RARoleCompany.dbkey('c-1', :employees),
+  Familia.now,
+  'e-raw',
+)
+@pre = RARoleEmployee.audit_multi_indexes.first
+@out = RARoleEmployee.repair_all!(verify: true)
+[@pre[:missing].any? { |m| m[:identifier] == 'e-raw' && m[:scope_id] == 'c-1' },
+ @out[:multi_indexes][:rebuilt_per_scope].any? { |r| r[:index_name] == :dept_index && r[:scopes_rebuilt] >= 1 },
+ @out[:verified]]
+#=> [true, true, true]
+
+## repair_all! isolates per-stage failures into :errors and continues
+rar_reset!
+@r2 = RARoleModel.new(rid: 'r-2', role: 'admin', name: 'Two')
+@r2.save
+
+# Stub repair_indexes! to raise; other stages should still run.
+class << RARoleModel
+  alias_method :_orig_repair_indexes!, :repair_indexes!
+  def repair_indexes!(*)
+    raise StandardError, 'simulated index failure'
+  end
+end
+
+@out = RARoleModel.repair_all!
+[@out[:status],
+ @out[:errors].keys,
+ @out[:instances].is_a?(Hash),
+ @out[:participations].is_a?(Hash)]
+#=> [:partial_failure, [:indexes], true, true]
+
+# Restore
+class << RARoleModel
+  alias_method :repair_indexes!, :_orig_repair_indexes!
+  remove_method :_orig_repair_indexes!
+end
+
+# Teardown
+rar_reset!


### PR DESCRIPTION
## Summary

Completes the implementation of instance-scoped multi-index auditing, which was previously stubbed with a `:not_implemented` status. Adds comprehensive audit and repair support for multi-indexes scoped to class instances (e.g., `multi_index :field, :index_name, within: SomeClass`).

## Key Changes

**Audit Implementation** (`lib/familia/horreum/management/audit.rb`):
- Replaced `:not_implemented` stub in `audit_single_multi_index` with full instance-scoped audit path
- Added `audit_instance_scoped_multi_index` to discover and validate buckets across all scope instances
- Implemented bucket discovery via SCAN with scope-aware key parsing (`discover_instance_scoped_buckets`, `parse_instance_scoped_bucket_key`)
- Added scope existence batching (`batch_check_scope_existence`) to efficiently check if scope instances still exist
- Implemented stale member detection (`inspect_instance_scoped_buckets`) with scope_id tracking
- Added orphaned bucket detection via two mechanisms:
  - `:scope_missing` — scope instance no longer exists
  - `:field_value_unheld` — no live participant holds the bucket's field value
- Implemented missing entry detection (`detect_instance_scoped_missing`) using the indexed class's `participates_in` relationship to the scope class
- When participation relationship is absent, audit surfaces `missing_status: :not_audited` to distinguish "checked and clean" from "not checked"
- Added helper methods for participation relationship lookup, scope enumeration, and field value aggregation per scope

**Repair Implementation** (`lib/familia/horreum/management/repair.rb`):
- Added `repair_multi_indexes!` class method that rebuilds both class-level and instance-scoped multi-indexes
- For class-level indexes: invokes `rebuild_<index_name>` on the indexed class
- For instance-scoped indexes: invokes `rebuild_<index_name>` on each scope instance via `rebuild_instance_scoped_multi_index`
- Skips indexes with `:ok` audit status; records unavailable rebuild methods or missing scope instances collections in `:skipped` with reason
- Refactored `repair_all!` to run each repair stage (instances, indexes, multi_indexes, participations, related_fields) inside its own rescue boundary
- Added per-stage exception isolation so failures in one dimension don't prevent others from running
- Enhanced `repair_all!` return shape with `:status` (`:ok` or `:partial_failure`), `:errors` (per-stage exception details), and `:multi_indexes` results
- Added opt-in `verify: true` kwarg to `repair_all!` that re-runs `health_check` after repair and exposes result as `:post_audit` / `:verified`

**Documentation & Testing**:
- Updated docstrings in `audit_single_multi_index` to reflect full implementation
- Added comprehensive tryout coverage in `try/audit/audit_instance_scoped_multi_index_try.rb` covering:
  - Empty state and healthy baseline scenarios
  - Stale member detection (object_missing, value_mismatch)
  - Orphaned bucket detection (scope_missing, field_value_unheld)
  - Missing entry detection via participation relationship
- Added `try/audit/repair_all_robustness_try.rb` covering:
  - Per-stage exception isolation
  - Class-level and instance-scoped multi-index repair
  - Post-audit verification
- Updated `try/audit/m3_multi_index_stub_try.rb` to reflect instance-scoped implementation (no longer returns `:not_implemented`)
- Added changelog fragment documenting the feature completion and repair_all! robustness improvements

## Notable Implementation Details

- **Bucket Key Structure**: Instance-scoped buckets follow pattern `{scope_prefix}:{scope_id}:{index_name}:{field_value}`, parsed to support identifiers and field values containing delimiters
- **Participation-Driven Missing Detection**: Requires indexed class to declare `participates_in scope_class, :collection_name`; when absent

https://claude.ai/code/session_01W2KvrjEqvqXZfWtLvwjk3w