### PR TITLE
Add FiberPipelineHandler and guard fast writers in transaction/pipeline contexts

### DIFF
--- a/changelog.d/20260514_232240_claude_housekeeping_chore_methods.rst
+++ b/changelog.d/20260514_232240_claude_housekeeping_chore_methods.rst
@@ -1,3 +1,17 @@
+Added
+~~~~~
+
+- ``housekeeping`` feature gains a class-level bulk runner,
+  ``Klass.run_chores!(chore_name:, limit:, batch_size:)``. It iterates
+  the class's ``instances`` collection in pipelined batches via
+  ``load_multi``, runs all registered chores (or one named chore)
+  against each record, and returns a stats hash:
+  ``{ model:, scanned:, chores: { name => { modified:, errors: } } }``.
+  Truthy chore returns increment ``modified``; raised exceptions are
+  isolated per-record, logged via ``Familia.warn``, and counted as
+  ``errors`` so a single failure doesn't halt the run. Lifted from the
+  shape proven out in OneTime Secret's ``HousekeepingJob``.
+
 Changed
 ~~~~~~~
 
@@ -7,10 +21,12 @@ Changed
   in a ``{name => result}`` hash). ``do_chores!`` runs every
   registered chore and returns the ``{name => result}`` hash.
   ``tidy!`` is preserved as an alias of ``do_chores!`` for backwards
-  compatibility with the 2.7.0 API.
+  compatibility with the 2.7.0 no-arg call site; the single-arg form
+  ``tidy!(:name)`` now raises ``ArgumentError``.
 
 AI Assistance
 ~~~~~~~~~~~~~
 
-- Method split, alias wiring, doc updates and expanded tryouts
-  coverage authored with Claude Code.
+- Method split, alias wiring, bulk runner port from OTS, doc updates,
+  and expanded tryouts coverage (25 → 48 testcases) authored with
+  Claude Code.

--- a/changelog.d/20260514_232240_claude_housekeeping_chore_methods.rst
+++ b/changelog.d/20260514_232240_claude_housekeeping_chore_methods.rst
@@ -1,0 +1,16 @@
+Changed
+~~~~~~~
+
+- ``housekeeping`` feature: split the dual-purpose ``tidy!`` into two
+  explicit instance methods. ``do_chore!(name)`` runs a single named
+  chore and returns the block's raw return value (no longer wrapped
+  in a ``{name => result}`` hash). ``do_chores!`` runs every
+  registered chore and returns the ``{name => result}`` hash.
+  ``tidy!`` is preserved as an alias of ``do_chores!`` for backwards
+  compatibility with the 2.7.0 API.
+
+AI Assistance
+~~~~~~~~~~~~~
+
+- Method split, alias wiring, doc updates and expanded tryouts
+  coverage authored with Claude Code.

--- a/changelog.d/20260515_060502_claude_pr263_feedback.rst
+++ b/changelog.d/20260515_060502_claude_pr263_feedback.rst
@@ -1,0 +1,20 @@
+Added
+~~~~~
+
+- Trace events for connection-mode conflicts. ``Familia.trace`` now
+  emits ``CONFLICTING_CONTEXT`` when pipeline and transaction
+  contexts collide (in both ``FiberPipelineHandler``/
+  ``FiberTransactionHandler`` and the
+  ``execute_transaction``/``execute_pipeline`` entry points), and
+  ``FAST_WRITER_BLOCKED`` when a fast writer (``field!``) is called
+  inside a transaction or pipeline. These fire just before the
+  corresponding ``ConflictingContextError`` /
+  ``OperationModeError`` is raised, so operators can pinpoint where
+  blocked operations originate when ``FAMILIA_TRACE=1``.
+
+AI Assistance
+~~~~~~~~~~~~~
+
+- Added the trace instrumentation in response to PR #263 review
+  feedback (Claude Code review bot) recommending tracing for
+  conflict detection events.

--- a/changelog.d/20260515_170434_delano_tidying_connection_handlers.rst
+++ b/changelog.d/20260515_170434_delano_tidying_connection_handlers.rst
@@ -1,0 +1,20 @@
+Removed
+-------
+
+- ``Familia::DataType#direct_access`` has been removed. The method was a legacy escape hatch for issuing raw Redis commands from inside a DataType wrapper; it predates the chain-based routing of ``Fiber[:familia_transaction]`` and ``Fiber[:familia_pipeline]``. All in-tree call sites now go through the wrapper's own mutating methods (which auto-route through the active transaction or pipeline) or through the wrapper's ``transaction`` / ``pipelined`` blocks. If you were calling ``direct_access do |conn, key| ... end``, replace it with either the DataType's own mutator or the corresponding block API.
+
+Changed
+-------
+
+- The connection handler hierarchy has been refactored from class inheritance (``BaseConnectionHandler``) to module composition. Handlers now ``include Familia::Connection::Handler`` and declare their operation-mode capabilities with a small DSL: ``supports transaction: true, pipelined: false``. The ``BaseConnectionHandler`` constant is gone. This is only relevant if you have custom handlers in application code — the public ``allows_transaction`` / ``allows_pipelined`` class methods continue to work, and the singleton ``.instance`` accessors on ``FiberPipelineHandler`` / ``FiberTransactionHandler`` are unchanged. The previous default of "allow all operations" when capability flags were not set has been removed; every handler is now expected to declare its capabilities explicitly via ``supports``.
+- ``Familia.dbclient`` and ``Familia::DataType#dbclient`` now route through ``FiberPipelineHandler`` before ``FiberTransactionHandler``, matching ``Horreum#dbclient``. With both handlers in the chain, attempting to mix pipeline and transaction contexts raises ``Familia::ConflictingContextError`` uniformly from every call site.
+
+Fixed
+-----
+
+- Restored ``require 'set'`` in ``lib/familia/horreum/management/audit.rb``. ``Set`` is autoloaded as a core class only on Ruby 3.4+; on Ruby 3.2/3.3 (the gem's supported floor) the require is mandatory for the five ``Set.new`` usages in that file.
+
+AI Assistance
+-------------
+
+- The handler refactor, ``direct_access`` removal, and changelog drafting were performed with Claude Code assistance while resolving review feedback on PR #263.

--- a/docs/guides/feature-housekeeping.md
+++ b/docs/guides/feature-housekeeping.md
@@ -95,26 +95,31 @@ user.do_chore!(:downcase_email)
 
 `do_chores!` returns a hash mapping chore name to the block's return value. `do_chore!` returns the block's raw return value (not wrapped in a hash). A truthy result signals "modified"; `nil` or `false` signals "no-op". The feature does not interpret these values -- they are passed through for the caller's stats collection.
 
-### Iteration -- Caller's Responsibility
+### Iteration -- Bulk Runner
 
-The feature operates on a single instance. Bulk runs live in the consumer app:
+For running chores across every record, the feature ships a class-level `run_chores!` that iterates the `instances` collection in pipelined batches (via `load_multi`), executes each chore per record with error isolation, and returns a stats hash:
 
 ```ruby
-# nightly rake task
-namespace :data do
-  task tidy_orgs: :environment do
-    stats = Hash.new(0)
-    Organization.instances.each do |id|
-      org = Organization.find_by_id(id) or next
-      results = org.do_chores!
-      results.each { |name, result| stats[name] += 1 if result }
-    end
-    puts stats.inspect
-  end
-end
+Organization.run_chores!
+# => {
+#      model: "Organization",
+#      scanned: 4200,
+#      chores: {
+#        standardize_planid: { modified: 37, errors: 0 },
+#        uppercase_country:  { modified: 102, errors: 1 },
+#      },
+#    }
+
+Organization.run_chores!(chore_name: :standardize_planid, limit: 500)
+# Filter to one chore and cap records scanned.
+
+Organization.run_chores!(batch_size: 50)
+# Tune the load_multi pipeline batch size (default: 100).
 ```
 
-The feature has no opinion about batching, SCAN vs KEYS, error aggregation, or scheduling -- the consumer app owns all of that.
+A truthy chore return increments `modified`; a raised exception increments `errors` (logged via `Familia.warn`) and iteration continues. The runner requires the class to expose `instances` (Horreum's default class-level sorted set) and `load_multi`.
+
+For scheduling, cross-model orchestration, custom logging, or non-default iteration (e.g. a configured allowlist of model classes), wrap `run_chores!` in your own job. The feature deliberately stays out of cron, multi-model discovery, and project-specific logging layers.
 
 ## Generated Method Reference
 
@@ -124,6 +129,7 @@ The feature has no opinion about batching, SCAN vs KEYS, error aggregation, or s
 |-------|--------|---------|
 | **Class** | `chore(name, &block)` | Register a chore |
 | | `chores` | Hash of registered chores |
+| | `run_chores!(chore_name:, limit:, batch_size:)` | Bulk runner across `instances`; returns stats hash |
 | **Instance** | `do_chore!(name)` | Run a single chore by name; returns the block's raw value |
 | | `do_chores!` | Run every registered chore; returns Hash |
 | | `tidy!` | Alias for `do_chores!` |
@@ -131,10 +137,10 @@ The feature has no opinion about batching, SCAN vs KEYS, error aggregation, or s
 ## Design Constraints
 
 1. **No implicit saves.** The block must call `save` (or `commit_fields`) itself. The feature does not auto-persist.
-2. **No iteration.** Operates on a single instance. There is no class-level `tidy_all!`.
+2. **Bulk via `run_chores!` only.** The feature operates on a single instance (`do_chore!`/`do_chores!`) plus one bulk runner (`run_chores!`) that iterates `instances`. Scheduling, multi-model orchestration, and custom logging stay in the consumer app.
 3. **No ordering.** Chores run in registration order, but should not depend on each other. If order matters, write one chore with sequential steps.
 4. **Idempotent by convention.** Use the conditional pattern (`if canonical && canonical != org.planid`) so a second run is a no-op.
-5. **Errors propagate.** The block can raise; the iteration code in the consumer app decides whether to rescue.
+5. **Errors isolate in `run_chores!`, propagate in `do_chore!`/`do_chores!`.** Single-instance methods let exceptions propagate; the bulk runner rescues per-record and increments the chore's `errors` counter so one failure doesn't halt the run.
 
 ## Common Patterns
 
@@ -185,28 +191,43 @@ chore :reconcile_billing do |account|
 end
 ```
 
-### Tracking Modified Records
+### Tracking Modified Records (Bulk)
+
+`run_chores!` already aggregates `modified` and `errors` counts per chore. Use it directly:
+
+```ruby
+report = Organization.run_chores!
+report[:chores].each do |name, counts|
+  puts "#{name}: #{counts[:modified]} modified, #{counts[:errors]} errors"
+end
+```
+
+### Custom Iteration (e.g. SCAN-Based)
+
+If `instances`-driven iteration isn't suitable (sharded data, custom scoping), drop down to `do_chore!`/`do_chores!`:
 
 ```ruby
 modified = []
 Organization.instances.each do |id|
-  org = Organization.find_by_id(id) or next
+  org = Organization.find_by_identifier(id) or next
   results = org.do_chores!
   modified << id if results.values.any?
 end
 puts "Modified #{modified.size} records: #{modified.inspect}"
 ```
 
-### Error Aggregation
+### Wrapping `run_chores!` for a Job Framework
 
 ```ruby
-errors = {}
-Organization.instances.each do |id|
-  org = Organization.find_by_id(id) or next
-  begin
-    org.do_chores!
-  rescue => e
-    errors[id] = e.message
+class HousekeepingJob
+  def self.perform_for(klass)
+    report = klass.run_chores!(batch_size: 50)
+    StatsD.gauge("housekeeping.#{klass.name}.scanned", report[:scanned])
+    report[:chores].each do |chore, counts|
+      StatsD.increment("housekeeping.#{klass.name}.#{chore}.modified", counts[:modified])
+      StatsD.increment("housekeeping.#{klass.name}.#{chore}.errors",   counts[:errors])
+    end
+    report
   end
 end
 ```

--- a/docs/guides/feature-housekeeping.md
+++ b/docs/guides/feature-housekeeping.md
@@ -3,7 +3,7 @@
 The Housekeeping feature provides a declarative DSL for registering named cleanup chores on Horreum models. It is designed for short-lived, repeated tidying against fields whose values have drifted over time -- not for versioned, one-shot migrations.
 
 > [!TIP]
-> Enable with `feature :housekeeping` and register cleanup blocks with `chore :name do |obj| ... end`. Run them with `obj.tidy!`. Iteration and persistence are the caller's responsibility.
+> Enable with `feature :housekeeping` and register cleanup blocks with `chore :name do |obj| ... end`. Run all of them with `obj.do_chores!` (aliased `tidy!`), or one with `obj.do_chore!(:name)`. Iteration and persistence are the caller's responsibility.
 
 ## Quick Start
 
@@ -27,8 +27,12 @@ class Organization < Familia::Horreum
 end
 
 org = Organization.from_identifier("acme-corp")
-org.tidy!
+org.do_chores!
 # => { standardize_planid: true }
+
+# Or run a single chore by name (returns the block's raw value):
+org.do_chore!(:standardize_planid)
+# => true
 ```
 
 ## When to Use
@@ -79,14 +83,17 @@ Run all registered chores, or one by name:
 ```ruby
 user = User.from_identifier("alice@example.com")
 
-user.tidy!
+user.do_chores!
 # => { downcase_email: true, default_timezone: nil }
 
-user.tidy!(:downcase_email)
-# => { downcase_email: true }
+user.tidy! # alias for do_chores!
+# => { downcase_email: nil, default_timezone: nil }
+
+user.do_chore!(:downcase_email)
+# => true
 ```
 
-The return value is a hash mapping chore name to the block's return value. A truthy result signals "modified"; `nil` or `false` signals "no-op". The feature does not interpret these values -- they are passed through for the caller's stats collection.
+`do_chores!` returns a hash mapping chore name to the block's return value. `do_chore!` returns the block's raw return value (not wrapped in a hash). A truthy result signals "modified"; `nil` or `false` signals "no-op". The feature does not interpret these values -- they are passed through for the caller's stats collection.
 
 ### Iteration -- Caller's Responsibility
 
@@ -99,7 +106,7 @@ namespace :data do
     stats = Hash.new(0)
     Organization.instances.each do |id|
       org = Organization.find_by_id(id) or next
-      results = org.tidy!
+      results = org.do_chores!
       results.each { |name, result| stats[name] += 1 if result }
     end
     puts stats.inspect
@@ -117,7 +124,9 @@ The feature has no opinion about batching, SCAN vs KEYS, error aggregation, or s
 |-------|--------|---------|
 | **Class** | `chore(name, &block)` | Register a chore |
 | | `chores` | Hash of registered chores |
-| **Instance** | `tidy!(name = nil)` | Run all (or one) chore; returns Hash |
+| **Instance** | `do_chore!(name)` | Run a single chore by name; returns the block's raw value |
+| | `do_chores!` | Run every registered chore; returns Hash |
+| | `tidy!` | Alias for `do_chores!` |
 
 ## Design Constraints
 
@@ -150,7 +159,7 @@ class Customer < Familia::Horreum
   end
 end
 
-customer.tidy!
+customer.do_chores!
 # => { trim_whitespace: true, uppercase_country: nil }
 ```
 
@@ -182,7 +191,7 @@ end
 modified = []
 Organization.instances.each do |id|
   org = Organization.find_by_id(id) or next
-  results = org.tidy!
+  results = org.do_chores!
   modified << id if results.values.any?
 end
 puts "Modified #{modified.size} records: #{modified.inspect}"
@@ -195,7 +204,7 @@ errors = {}
 Organization.instances.each do |id|
   org = Organization.find_by_id(id) or next
   begin
-    org.tidy!
+    org.do_chores!
   rescue => e
     errors[id] = e.message
   end

--- a/lib/familia/connection.rb
+++ b/lib/familia/connection.rb
@@ -112,7 +112,8 @@ module Familia
     # Builds the connection chain with handlers in priority order
     def build_connection_chain
       ResponsibilityChain.new
-        .add_handler(Familia::Connection::FiberTransactionHandler.new)
+        .add_handler(Familia::Connection::FiberPipelineHandler.instance)
+        .add_handler(Familia::Connection::FiberTransactionHandler.instance)
         .add_handler(FiberConnectionHandler.new)
         .add_handler(ProviderConnectionHandler.new)
         .add_handler(CreateConnectionHandler.new)

--- a/lib/familia/connection/handlers.rb
+++ b/lib/familia/connection/handlers.rb
@@ -188,6 +188,8 @@ module Familia
         return nil unless Fiber[:familia_pipeline]
 
         if Fiber[:familia_transaction]
+          Familia.trace :CONFLICTING_CONTEXT, nil,
+                       'Pipeline handler detected active transaction context'
           raise Familia::ConflictingContextError,
             'Cannot mix pipeline and transaction contexts. ' \
             'Restructure to use one or the other.'
@@ -227,6 +229,8 @@ module Familia
         return nil unless Fiber[:familia_transaction]
 
         if Fiber[:familia_pipeline]
+          Familia.trace :CONFLICTING_CONTEXT, nil,
+                       'Transaction handler detected active pipeline context'
           raise Familia::ConflictingContextError,
             'Cannot mix pipeline and transaction contexts. ' \
             'Restructure to use one or the other.'

--- a/lib/familia/connection/handlers.rb
+++ b/lib/familia/connection/handlers.rb
@@ -38,38 +38,52 @@ module Familia
       end
     end
 
-    # Connection handler base class for Chain of Responsibility pattern.
-    # When no arguments are passed, all behaviour is based on the top
-    # Familia module itself. e.g. Familia.create_dbclient.
+    # Shared interface for connection handlers in the Chain of Responsibility.
     #
-    # Summary of Behaviors
+    # Including this module gives a handler class:
+    # * an instance-side `handle(uri)` stub that raises NotImplementedError, and
+    # * a small class-level DSL (`supports`) for declaring capability flags
+    #   (`allows_transaction`, `allows_pipelined`) read by the operation
+    #   guards in {Familia::Connection::TransactionCore} and
+    #   {Familia::Connection::PipelinedCore}.
     #
-    #   | Handler | Transaction | Pipeline | Ad-hoc Commands |
-    #   |---------|------------|----------|-----------------|
-    #   | **FiberPipeline** | Error | Reentrant (same conn) | Use pipeline conn |
-    #   | **FiberTransaction** | Reentrant (same conn) | Error | Use transaction conn |
-    #   | **FiberConnection** | Error | Error | ✓ Allowed |
-    #   | **Provider** | ✓ New checkout | ✓ New checkout | ✓ New checkout |
-    #   | **Default** | ✓ With guards | ✓ With guards | ✓ Check mode |
-    #   | **Create** | ✓ Fresh conn | ✓ Fresh conn | ✓ Fresh conn |
+    # Capability flags default to `nil` when `supports` is not called — there
+    # is no implicit "allow all". Every handler is expected to declare its
+    # capabilities explicitly.
     #
-    # NOTE: Every subclass must provide values for the @allows_transaction
-    # and @allows_pipelined attributes.
+    # Summary of behaviours of the in-tree handlers:
     #
-    class BaseConnectionHandler
-      @allows_transaction = true
-      @allows_pipelined = true
-
-      class << self
-        attr_reader :allows_transaction, :allows_pipelined
+    #   | Handler            | Transaction       | Pipeline             | Ad-hoc Commands      |
+    #   |--------------------|-------------------|----------------------|----------------------|
+    #   | FiberPipeline      | Error             | Reentrant (same conn)| Use pipeline conn    |
+    #   | FiberTransaction   | Reentrant         | Error                | Use transaction conn |
+    #   | FiberConnection    | Error             | Error                | Allowed              |
+    #   | Provider           | New checkout      | New checkout         | New checkout         |
+    #   | Cached             | Error             | Error                | Allowed              |
+    #   | Create / Default   | Fresh conn        | Fresh conn           | Fresh conn           |
+    #   | ParentDelegation   | Delegated         | Delegated            | Delegated            |
+    #   | Standalone         | Allowed           | Allowed              | Allowed              |
+    #
+    module Handler
+      def self.included(base)
+        base.extend(ClassMethods)
       end
 
-      def initialize(familia_module = nil)
-        @familia_module = familia_module || Familia
-      end
-
-      def handle(uri)
+      def handle(_uri)
         raise NotImplementedError, 'Subclasses must implement handle'
+      end
+
+      module ClassMethods
+        attr_reader :allows_transaction, :allows_pipelined
+
+        # Declare the operation modes this handler supports.
+        #
+        # @param transaction [Boolean, Symbol] true/false or :reentrant
+        # @param pipelined   [Boolean, Symbol] true/false or :reentrant
+        def supports(transaction: false, pipelined: false)
+          @allows_transaction = transaction
+          @allows_pipelined = pipelined
+        end
       end
     end
 
@@ -80,9 +94,13 @@ module Familia
     # Fresh connection each time - all operations safe (transactions,
     # pipelined, ad-hoc)
     #
-    class CreateConnectionHandler < BaseConnectionHandler
-      @allows_transaction = true
-      @allows_pipelined = true
+    class CreateConnectionHandler
+      include Handler
+      supports transaction: true, pipelined: true
+
+      def initialize(familia_module = nil)
+        @familia_module = familia_module || Familia
+      end
 
       def handle(uri)
         # Create new connection (no module-level caching)
@@ -102,9 +120,13 @@ module Familia
     # and also expected how they are to be used.
     # This is where connection pools live
     #
-    class ProviderConnectionHandler < BaseConnectionHandler
-      @allows_transaction = true
-      @allows_pipelined = true
+    class ProviderConnectionHandler
+      include Handler
+      supports transaction: true, pipelined: true
+
+      def initialize(familia_module = nil)
+        @familia_module = familia_module || Familia
+      end
 
       def handle(uri)
         return nil unless @familia_module.connection_provider
@@ -144,9 +166,13 @@ module Familia
     #       raise "Unknown operation: #{request.operation}"
     #     end
     #
-    class FiberConnectionHandler < BaseConnectionHandler
-      @allows_transaction = false
-      @allows_pipelined = false
+    class FiberConnectionHandler
+      include Handler
+      supports transaction: false, pipelined: false
+
+      def initialize(familia_module = nil)
+        @familia_module = familia_module || Familia
+      end
 
       def handle(uri)
         return nil unless Fiber[:familia_connection]
@@ -173,9 +199,9 @@ module Familia
     # Reentrant pipeline - just yield the existing connection
     # No new pipeline block, just participate in existing pipeline
     #
-    class FiberPipelineHandler < BaseConnectionHandler
-      @allows_transaction = false
-      @allows_pipelined = :reentrant
+    class FiberPipelineHandler
+      include Handler
+      supports transaction: false, pipelined: :reentrant
 
       # Singleton pattern for stateless handler
       @instance = new.freeze
@@ -212,9 +238,9 @@ module Familia
     # Fiber[:familia_transaction_depth] ||= 0
     # Fiber[:familia_transaction_depth] += 1
     #
-    class FiberTransactionHandler < BaseConnectionHandler
-      @allows_transaction = :reentrant
-      @allows_pipelined = false
+    class FiberTransactionHandler
+      include Handler
+      supports transaction: :reentrant, pipelined: false
 
       # Singleton pattern for stateless handler
       @instance = new.freeze
@@ -249,13 +275,12 @@ module Familia
     #
     # CachedConnectionHandler - Single cached connection - block all multi-mode operations
     #
-    class CachedConnectionHandler < BaseConnectionHandler
-      @allows_transaction = false
-      @allows_pipelined = false
+    class CachedConnectionHandler
+      include Handler
+      supports transaction: false, pipelined: false
 
-      # This override makes the module argument required instead of default optional.
-      def initialize(familia_module) # rubocop:disable Lint/UselessMethodDefinition
-        super
+      def initialize(familia_module)
+        @familia_module = familia_module
       end
 
       def handle(_uri)
@@ -285,13 +310,12 @@ module Familia
     # @example Class-level DataType with parent
     #   User.global_users  # DataType that delegates to User.dbclient
     #
-    class ParentDelegationHandler < BaseConnectionHandler
-      @allows_transaction = true
-      @allows_pipelined = true
+    class ParentDelegationHandler
+      include Handler
+      supports transaction: true, pipelined: true
 
       def initialize(data_type)
         @data_type = data_type
-        super
       end
 
       def handle(uri)
@@ -327,13 +351,12 @@ module Familia
     # @example Standalone DataType with logical_database option
     #   cache = Familia::HashKey.new('app:cache', logical_database: 2)
     #
-    class StandaloneConnectionHandler < BaseConnectionHandler
-      @allows_transaction = true
-      @allows_pipelined = true
+    class StandaloneConnectionHandler
+      include Handler
+      supports transaction: true, pipelined: true
 
       def initialize(data_type)
         @data_type = data_type
-        super
       end
 
       def handle(uri)

--- a/lib/familia/connection/handlers.rb
+++ b/lib/familia/connection/handlers.rb
@@ -46,6 +46,7 @@ module Familia
     #
     #   | Handler | Transaction | Pipeline | Ad-hoc Commands |
     #   |---------|------------|----------|-----------------|
+    #   | **FiberPipeline** | Error | Reentrant (same conn) | Use pipeline conn |
     #   | **FiberTransaction** | Reentrant (same conn) | Error | Use transaction conn |
     #   | **FiberConnection** | Error | Error | ✓ Allowed |
     #   | **Provider** | ✓ New checkout | ✓ New checkout | ✓ New checkout |
@@ -163,11 +164,48 @@ module Familia
       end
     end
 
-    # Checks for fiber-local transaction connections (highest priority for Horreum)
+    # Checks for fiber-local pipeline connections
+    #
+    # Returns the fiber-local pipeline connection when inside a pipelined block.
+    # Raises ConflictingContextError if both pipeline and transaction contexts
+    # are active — these are mutually exclusive operations.
+    #
+    # Reentrant pipeline - just yield the existing connection
+    # No new pipeline block, just participate in existing pipeline
+    #
+    class FiberPipelineHandler < BaseConnectionHandler
+      @allows_transaction = false
+      @allows_pipelined = :reentrant
+
+      # Singleton pattern for stateless handler
+      @instance = new.freeze
+
+      class << self
+        attr_reader :instance
+      end
+
+      def handle(_uri)
+        return nil unless Fiber[:familia_pipeline]
+
+        if Fiber[:familia_transaction]
+          raise Familia::ConflictingContextError,
+            'Cannot mix pipeline and transaction contexts. ' \
+            'Restructure to use one or the other.'
+        end
+
+        Familia.trace :DBCLIENT_FIBER_PIPELINE, nil, 'Using fiber-local pipeline connection'
+        Fiber[:familia_pipeline]
+      end
+    end
+
+    # Checks for fiber-local transaction connections
     #
     # Key insight: Mark that we're in reentrant mode and also track of
     # depth. This allows nested transaction calls to be safely reentrant
     # without breaking Redis's single-level MULTI/EXEC.
+    #
+    # Raises ConflictingContextError if both pipeline and transaction contexts
+    # are active — these are mutually exclusive operations.
     #
     # Reentrant transaction - just yield the existing connection
     # No new MULTI/EXEC, just participate in existing transaction
@@ -187,6 +225,12 @@ module Familia
 
       def handle(_uri)
         return nil unless Fiber[:familia_transaction]
+
+        if Fiber[:familia_pipeline]
+          raise Familia::ConflictingContextError,
+            'Cannot mix pipeline and transaction contexts. ' \
+            'Restructure to use one or the other.'
+        end
 
         Familia.trace :DBCLIENT_FIBER_TRANSACTION, nil, 'Using fiber-local transaction connection'
         Fiber[:familia_transaction]

--- a/lib/familia/connection/handlers.rb
+++ b/lib/familia/connection/handlers.rb
@@ -181,8 +181,8 @@ module Familia
       # Singleton pattern for stateless handler
       @instance = new.freeze
 
-      def self.instance
-        @instance
+      class << self
+        attr_reader :instance
       end
 
       def handle(_uri)
@@ -209,8 +209,9 @@ module Familia
       @allows_transaction = false
       @allows_pipelined = false
 
-      def initialize(familia_module)
-        @familia_module = familia_module
+      # This override makes the module argument required instead of default optional.
+      def initialize(familia_module) # rubocop:disable Lint/UselessMethodDefinition
+        super
       end
 
       def handle(_uri)
@@ -246,6 +247,7 @@ module Familia
 
       def initialize(data_type)
         @data_type = data_type
+        super
       end
 
       def handle(uri)
@@ -287,6 +289,7 @@ module Familia
 
       def initialize(data_type)
         @data_type = data_type
+        super
       end
 
       def handle(uri)

--- a/lib/familia/connection/handlers.rb
+++ b/lib/familia/connection/handlers.rb
@@ -73,6 +73,8 @@ module Familia
         raise NotImplementedError, 'Subclasses must implement handle'
       end
 
+      # Class-level DSL injected into every handler class that includes Handler.
+      # Holds the capability flag readers and the `supports` declarator.
       module ClassMethods
         attr_reader :allows_transaction, :allows_pipelined
 
@@ -96,6 +98,7 @@ module Familia
     #
     class CreateConnectionHandler
       include Handler
+
       supports transaction: true, pipelined: true
 
       def initialize(familia_module = nil)
@@ -122,6 +125,7 @@ module Familia
     #
     class ProviderConnectionHandler
       include Handler
+
       supports transaction: true, pipelined: true
 
       def initialize(familia_module = nil)
@@ -168,6 +172,7 @@ module Familia
     #
     class FiberConnectionHandler
       include Handler
+
       supports transaction: false, pipelined: false
 
       def initialize(familia_module = nil)
@@ -201,6 +206,7 @@ module Familia
     #
     class FiberPipelineHandler
       include Handler
+
       supports transaction: false, pipelined: :reentrant
 
       # Singleton pattern for stateless handler
@@ -240,6 +246,7 @@ module Familia
     #
     class FiberTransactionHandler
       include Handler
+
       supports transaction: :reentrant, pipelined: false
 
       # Singleton pattern for stateless handler
@@ -277,6 +284,7 @@ module Familia
     #
     class CachedConnectionHandler
       include Handler
+
       supports transaction: false, pipelined: false
 
       def initialize(familia_module)
@@ -312,6 +320,7 @@ module Familia
     #
     class ParentDelegationHandler
       include Handler
+
       supports transaction: true, pipelined: true
 
       def initialize(data_type)
@@ -353,6 +362,7 @@ module Familia
     #
     class StandaloneConnectionHandler
       include Handler
+
       supports transaction: true, pipelined: true
 
       def initialize(data_type)

--- a/lib/familia/connection/handlers.rb
+++ b/lib/familia/connection/handlers.rb
@@ -188,7 +188,7 @@ module Familia
         return nil unless Fiber[:familia_pipeline]
 
         if Fiber[:familia_transaction]
-          Familia.trace :CONFLICTING_CONTEXT, nil,
+          Familia.trace :CONFLICTING_CONTEXT, _uri,
                        'Pipeline handler detected active transaction context'
           raise Familia::ConflictingContextError,
             'Cannot mix pipeline and transaction contexts. ' \
@@ -229,7 +229,7 @@ module Familia
         return nil unless Fiber[:familia_transaction]
 
         if Fiber[:familia_pipeline]
-          Familia.trace :CONFLICTING_CONTEXT, nil,
+          Familia.trace :CONFLICTING_CONTEXT, _uri,
                        'Transaction handler detected active pipeline context'
           raise Familia::ConflictingContextError,
             'Cannot mix pipeline and transaction contexts. ' \

--- a/lib/familia/connection/operations.rb
+++ b/lib/familia/connection/operations.rb
@@ -218,8 +218,8 @@ module Familia
       # @see MultiResult For details on the return value structure
       # @see Familia.transaction For atomic command execution
       # @see #batch_update For similar MultiResult pattern in Horreum models
-      def pipelined(&block)
-        PipelineCore.execute_pipeline(-> { dbclient }, &block)
+      def pipelined(&)
+        PipelineCore.execute_pipeline(-> { dbclient }, &)
       end
       alias pipeline pipelined
 

--- a/lib/familia/connection/operations.rb
+++ b/lib/familia/connection/operations.rb
@@ -205,6 +205,7 @@ module Familia
       #   - Transaction: Better consistency for related operations
       #
       # @note Connection Handler Compatibility:
+      #   - FiberPipelineHandler: Supports reentrant pipelines
       #   - ProviderConnectionHandler: Full pipeline support
       #   - CreateConnectionHandler: Full pipeline support
       #   - FiberTransactionHandler: Blocked (raises OperationModeError)

--- a/lib/familia/connection/pipelined_core.rb
+++ b/lib/familia/connection/pipelined_core.rb
@@ -39,23 +39,21 @@ module Familia
       #     conn.set('key', 'value')  # Executes individually, no error
       #   end
       #
-      def self.execute_pipeline(dbclient_proc, &block)
+      def self.execute_pipeline(dbclient_proc, &)
         # First, get the connection to populate the handler class
-        connection = dbclient_proc.call
+        dbclient_proc.call
         handler_class = Fiber[:familia_connection_handler_class]
 
         # Check pipeline capability
         pipeline_capability = handler_class&.allows_pipelined
 
         if pipeline_capability == false
-          OperationCore.handle_fallback(:pipeline, dbclient_proc, handler_class, &block)
+          OperationCore.handle_fallback(:pipeline, dbclient_proc, handler_class, &)
         else
           # Normal pipeline flow (includes nil, true, and other values)
-          execute_normal_pipeline(dbclient_proc, &block)
+          execute_normal_pipeline(dbclient_proc, &)
         end
       end
-
-      private
 
       # Executes a normal Redis pipeline
       #
@@ -66,7 +64,7 @@ module Familia
       # @param block [Proc] Block containing Redis commands to execute
       # @return [MultiResult] Result object with pipeline command results
       #
-      def self.execute_normal_pipeline(dbclient_proc, &block)
+      def self.execute_normal_pipeline(dbclient_proc)
         # Check for existing pipeline context
         return yield(Fiber[:familia_pipeline]) if Fiber[:familia_pipeline]
 

--- a/lib/familia/connection/pipelined_core.rb
+++ b/lib/familia/connection/pipelined_core.rb
@@ -42,6 +42,8 @@ module Familia
       def self.execute_pipeline(dbclient_proc, &)
         # Prevent mixing pipeline and transaction contexts
         if Fiber[:familia_transaction]
+          Familia.trace :CONFLICTING_CONTEXT, nil,
+                       'Attempted to start pipeline inside active transaction'
           raise Familia::ConflictingContextError,
             'Cannot start pipeline inside transaction. ' \
             'Restructure to use one or the other.'

--- a/lib/familia/connection/pipelined_core.rb
+++ b/lib/familia/connection/pipelined_core.rb
@@ -40,6 +40,13 @@ module Familia
       #   end
       #
       def self.execute_pipeline(dbclient_proc, &)
+        # Prevent mixing pipeline and transaction contexts
+        if Fiber[:familia_transaction]
+          raise Familia::ConflictingContextError,
+            'Cannot start pipeline inside transaction. ' \
+            'Restructure to use one or the other.'
+        end
+
         # First, get the connection to populate the handler class
         dbclient_proc.call
         handler_class = Fiber[:familia_connection_handler_class]

--- a/lib/familia/connection/transaction_core.rb
+++ b/lib/familia/connection/transaction_core.rb
@@ -95,6 +95,8 @@ module Familia
       def self.execute_transaction(dbclient_proc, &)
         # Prevent mixing pipeline and transaction contexts
         if Fiber[:familia_pipeline]
+          Familia.trace :CONFLICTING_CONTEXT, nil,
+                       'Attempted to start transaction inside active pipeline'
           raise Familia::ConflictingContextError,
             'Cannot start transaction inside pipeline. ' \
             'Restructure to use one or the other.'

--- a/lib/familia/connection/transaction_core.rb
+++ b/lib/familia/connection/transaction_core.rb
@@ -93,6 +93,13 @@ module Familia
       #   result.results     # => ["OK", 1]
       #
       def self.execute_transaction(dbclient_proc, &)
+        # Prevent mixing pipeline and transaction contexts
+        if Fiber[:familia_pipeline]
+          raise Familia::ConflictingContextError,
+            'Cannot start transaction inside pipeline. ' \
+            'Restructure to use one or the other.'
+        end
+
         # First, get the connection to populate the handler class
         dbclient_proc.call
         handler_class = Fiber[:familia_connection_handler_class]

--- a/lib/familia/data_type/connection.rb
+++ b/lib/familia/data_type/connection.rb
@@ -14,18 +14,18 @@ module Familia
     # Key features:
     # * Database connection resolution with Chain of Responsibility pattern
     # * Redis key generation based on parent context
-    # * Direct database access for advanced operations
     # * Transaction support (MULTI/EXEC) for atomic operations
     # * Pipeline support for batched command execution
     # * Parent delegation for owned DataType objects
     # * Standalone connection management for independent DataType objects
     #
     # Connection Chain Priority:
-    # 1. FiberTransactionHandler - Active transaction context
-    # 2. FiberConnectionHandler - Fiber-local connections
-    # 3. ProviderConnectionHandler - User-defined connection provider
-    # 4. ParentDelegationHandler - Delegate to parent object (primary for owned DataTypes)
-    # 5. StandaloneConnectionHandler - Independent DataType connection
+    # 1. FiberPipelineHandler - Active pipeline context
+    # 2. FiberTransactionHandler - Active transaction context
+    # 3. FiberConnectionHandler - Fiber-local connections
+    # 4. ProviderConnectionHandler - User-defined connection provider
+    # 5. ParentDelegationHandler - Delegate to parent object (primary for owned DataTypes)
+    # 6. StandaloneConnectionHandler - Independent DataType connection
     #
     # @example Parent-owned DataType (automatic delegation)
     #   class User < Familia::Horreum
@@ -79,8 +79,8 @@ module Familia
       # Retrieves a Database connection using the Chain of Responsibility pattern
       #
       # Implements connection resolution optimized for DataType usage patterns:
-      # - Fast path check for active transaction context
-      # - Full connection chain for comprehensive resolution
+      # - Full connection chain for comprehensive resolution (pipeline/transaction
+      #   precedence and conflict detection live in the handlers themselves)
       # - Parent delegation as primary behavior for owned DataTypes
       # - Standalone connection handling for independent DataTypes
       #
@@ -100,10 +100,9 @@ module Familia
       #   cache.dbclient  # Uses standalone handler with db 2
       #
       def dbclient(uri = nil)
-        # Fast path for transaction context (highest priority)
-        return Fiber[:familia_transaction] if Fiber[:familia_transaction]
-
-        # Build connection chain (not cached due to frozen objects)
+        # Build connection chain (not cached due to frozen objects).
+        # The chain handles pipeline/transaction precedence and conflict detection
+        # symmetrically with Horreum#dbclient — no fast paths that bypass the chain.
         build_connection_chain.handle(uri)
       end
 
@@ -157,41 +156,6 @@ module Familia
         end
       end
 
-      # Provides a structured way to "gear down" to run db commands that are
-      # not implemented in our DataType classes since we intentionally don't
-      # have a method_missing method.
-      #
-      # Enhanced to work seamlessly with transactions and pipelines. When called
-      # within a transaction or pipeline context, uses that connection automatically.
-      #
-      # @yield [Redis, String] Yields the connection and dbkey to the block
-      # @return The return value of the block
-      #
-      # @example Basic usage
-      #   datatype.direct_access do |conn, key|
-      #     conn.zadd(key, 100, 'member')
-      #   end
-      #
-      # @example Within transaction (automatic context detection)
-      #   datatype.transaction do |trans_conn|
-      #     datatype.direct_access do |conn, key|
-      #       # conn is the same as trans_conn
-      #       conn.zadd(key, 200, 'member')
-      #     end
-      #   end
-      #
-      def direct_access
-        if Fiber[:familia_transaction]
-          # Already in transaction, use that connection
-          yield(Fiber[:familia_transaction], dbkey)
-        elsif Fiber[:familia_pipeline]
-          # Already in pipeline, use that connection
-          yield(Fiber[:familia_pipeline], dbkey)
-        else
-          yield(dbclient, dbkey)
-        end
-      end
-
       private
 
       # Builds the connection chain with handlers in priority order
@@ -199,11 +163,15 @@ module Familia
       # Creates the Chain of Responsibility for connection resolution with
       # DataType-specific handlers. Handlers are checked in order:
       #
-      # 1. FiberTransactionHandler - Return active transaction connection
-      # 2. FiberConnectionHandler - Use fiber-local connection
-      # 3. ProviderConnectionHandler - Delegate to connection provider
-      # 4. ParentDelegationHandler - Delegate to parent's connection (primary for owned DataTypes)
-      # 5. StandaloneConnectionHandler - Handle standalone DataTypes
+      # 1. FiberPipelineHandler  - Return active pipeline connection (raises on transaction conflict)
+      # 2. FiberTransactionHandler - Return active transaction connection (raises on pipeline conflict)
+      # 3. FiberConnectionHandler - Use fiber-local connection
+      # 4. ProviderConnectionHandler - Delegate to connection provider
+      # 5. ParentDelegationHandler - Delegate to parent's connection (primary for owned DataTypes)
+      # 6. StandaloneConnectionHandler - Handle standalone DataTypes
+      #
+      # Order matches Horreum#build_connection_chain so DataType call sites observe
+      # the same pipeline/transaction precedence and conflict semantics.
       #
       # @return [ResponsibilityChain] Configured connection chain
       #
@@ -218,6 +186,7 @@ module Familia
         standalone_connection_handler = Familia::Connection::StandaloneConnectionHandler.new(self)
 
         Familia::Connection::ResponsibilityChain.new
+          .add_handler(Familia::Connection::FiberPipelineHandler.instance)
           .add_handler(Familia::Connection::FiberTransactionHandler.instance)
           .add_handler(fiber_connection_handler)
           .add_handler(provider_connection_handler)

--- a/lib/familia/errors.rb
+++ b/lib/familia/errors.rb
@@ -43,6 +43,10 @@ module Familia
   # inside a transaction or pipeline
   class NestedTransactionError < OperationModeError; end
 
+  # Raised when both pipeline and transaction contexts are active.
+  # These contexts are mutually exclusive — restructure code to use one or the other.
+  class ConflictingContextError < OperationModeError; end
+
   # Raised when atomic_write cannot include all DataType fields because
   # they span multiple Redis databases (MULTI/EXEC cannot cross databases).
   class CrossDatabaseError < OperationModeError

--- a/lib/familia/features/encrypted_fields/encrypted_field_type.rb
+++ b/lib/familia/features/encrypted_fields/encrypted_field_type.rb
@@ -111,11 +111,15 @@ module Familia
           # Prevent fast writer within transaction/pipeline - the return value
           # would be Redis::Future which doesn't support zero?/positive? checks
           if Fiber[:familia_transaction]
+            Familia.trace :FAST_WRITER_BLOCKED, nil,
+                         "#{fast_method_name} blocked by active transaction context"
             raise Familia::OperationModeError, <<~ERROR_MESSAGE.chomp
               Cannot call fast writer #{fast_method_name} within a transaction.
               Use batch_update or commit_fields instead.
             ERROR_MESSAGE
           elsif Fiber[:familia_pipeline]
+            Familia.trace :FAST_WRITER_BLOCKED, nil,
+                         "#{fast_method_name} blocked by active pipeline context"
             raise Familia::OperationModeError, <<~ERROR_MESSAGE.chomp
               Cannot call fast writer #{fast_method_name} within a pipeline.
               Restructure to call fast writers outside the pipeline.

--- a/lib/familia/features/encrypted_fields/encrypted_field_type.rb
+++ b/lib/familia/features/encrypted_fields/encrypted_field_type.rb
@@ -108,6 +108,20 @@ module Familia
         klass.define_method fast_method_name do |val|
           raise ArgumentError, "#{fast_method_name} requires a value" if val.nil?
 
+          # Prevent fast writer within transaction/pipeline - the return value
+          # would be Redis::Future which doesn't support zero?/positive? checks
+          if Fiber[:familia_transaction]
+            raise Familia::OperationModeError, <<~ERROR_MESSAGE.chomp
+              Cannot call fast writer #{fast_method_name} within a transaction.
+              Use batch_update or commit_fields instead.
+            ERROR_MESSAGE
+          elsif Fiber[:familia_pipeline]
+            raise Familia::OperationModeError, <<~ERROR_MESSAGE.chomp
+              Cannot call fast writer #{fast_method_name} within a pipeline.
+              Restructure to call fast writers outside the pipeline.
+            ERROR_MESSAGE
+          end
+
           # UnsortedSet via the setter method to get proper ConcealedString wrapping
           send(:"#{method_name}=", val) if method_name
 

--- a/lib/familia/features/encrypted_fields/encrypted_field_type.rb
+++ b/lib/familia/features/encrypted_fields/encrypted_field_type.rb
@@ -111,14 +111,14 @@ module Familia
           # Prevent fast writer within transaction/pipeline - the return value
           # would be Redis::Future which doesn't support zero?/positive? checks
           if Fiber[:familia_transaction]
-            Familia.trace :FAST_WRITER_BLOCKED, nil,
+            Familia.trace :FAST_WRITER_BLOCKED, dbkey,
                          "#{fast_method_name} blocked by active transaction context"
             raise Familia::OperationModeError, <<~ERROR_MESSAGE.chomp
               Cannot call fast writer #{fast_method_name} within a transaction.
               Use batch_update or commit_fields instead.
             ERROR_MESSAGE
           elsif Fiber[:familia_pipeline]
-            Familia.trace :FAST_WRITER_BLOCKED, nil,
+            Familia.trace :FAST_WRITER_BLOCKED, dbkey,
                          "#{fast_method_name} blocked by active pipeline context"
             raise Familia::OperationModeError, <<~ERROR_MESSAGE.chomp
               Cannot call fast writer #{fast_method_name} within a pipeline.

--- a/lib/familia/features/housekeeping.rb
+++ b/lib/familia/features/housekeeping.rb
@@ -46,6 +46,11 @@ module Familia
     module Housekeeping
       Familia::Base.add_feature self, :housekeeping
 
+      # Default Redis-pipelined batch size for `run_chores!`. Each batch hits
+      # Redis once via `load_multi`, then drives the chore block per record.
+      # 100 trades pipeline efficiency against per-batch latency.
+      DEFAULT_BATCH_SIZE = 100
+
       def self.included(base)
         Familia.trace :LOADED, self, base if Familia.debug?
         base.extend ModelClassMethods
@@ -77,6 +82,82 @@ module Familia
             superclass.chores.dup
           else
             {}
+          end
+        end
+
+        # Run registered chores against every record reachable via the
+        # `instances` class-level sorted set. Records are loaded in pipelined
+        # batches (`load_multi`) and each chore is executed per record with
+        # error isolation -- one failing chore call does not abort the run.
+        #
+        # Stats shape:
+        #
+        #   {
+        #     model: 'User',
+        #     scanned: 4200,
+        #     chores: {
+        #       downcase_email: { modified: 37, errors: 0 },
+        #       default_timezone: { modified: 102, errors: 1 },
+        #     },
+        #   }
+        #
+        # The `modified` counter increments when the chore block returns a
+        # truthy value (the conventional "modified" signal). The `errors`
+        # counter increments when the chore block raises; the exception is
+        # logged via `Familia.warn` and iteration continues.
+        #
+        # Requires the class to expose an `instances` collection (Horreum's
+        # default class-level sorted set) and `load_multi` (Horreum default).
+        #
+        # @param chore_name [Symbol, String, nil] specific chore to run; nil
+        #   runs every registered chore against each record
+        # @param limit [Integer, nil] cap on records scanned; nil iterates all
+        # @param batch_size [Integer] pipeline batch size for `load_multi`
+        # @return [Hash] stats hash (see above)
+        # @raise [ArgumentError] if the class has no chores, the named chore
+        #   is not registered, or `instances`/`load_multi` are unavailable
+        def run_chores!(chore_name: nil, limit: nil, batch_size: DEFAULT_BATCH_SIZE)
+          unless respond_to?(:instances) && respond_to?(:load_multi)
+            raise ArgumentError, "#{name} cannot run_chores! without instances and load_multi"
+          end
+
+          chore_keys = resolve_chore_keys(chore_name)
+          stats      = chore_keys.to_h { |key| [key, { modified: 0, errors: 0 }] }
+          scanned    = 0
+
+          instances.to_a.each_slice(batch_size) do |batch_ids|
+            break if limit && scanned >= limit
+
+            batch_ids = batch_ids.take(limit - scanned) if limit
+            records   = load_multi(batch_ids).compact
+            records.each do |record|
+              scanned += 1
+              chore_keys.each do |key|
+                begin
+                  stats[key][:modified] += 1 if record.do_chore!(key)
+                rescue StandardError => e
+                  stats[key][:errors] += 1
+                  Familia.warn "[run_chores!] #{name}##{record.identifier} chore=#{key} failed: #{e.message}"
+                end
+              end
+            end
+          end
+
+          { model: name, scanned: scanned, chores: stats }
+        end
+
+        private
+
+        def resolve_chore_keys(chore_name)
+          raise ArgumentError, "#{name} has no chores registered" if chores.empty?
+
+          if chore_name
+            key = chore_name.to_sym
+            raise ArgumentError, "unknown chore #{chore_name.inspect}" unless chores.key?(key)
+
+            [key]
+          else
+            chores.keys
           end
         end
       end

--- a/lib/familia/features/housekeeping.rb
+++ b/lib/familia/features/housekeeping.rb
@@ -70,10 +70,10 @@ module Familia
         # @return [Hash{Symbol => Proc}]
         def chores
           @chores ||= if superclass.respond_to?(:chores)
-                        superclass.chores.dup
-                      else
-                        {}
-                      end
+            superclass.chores.dup
+          else
+            {}
+          end
         end
       end
 

--- a/lib/familia/features/housekeeping.rb
+++ b/lib/familia/features/housekeeping.rb
@@ -33,10 +33,13 @@ module Familia
     #   end
     #
     #   org = Organization.from_identifier('acme-corp')
-    #   org.tidy!
+    #   org.do_chores!
     #   # => { standardize_planid: true }
     #
-    #   org.tidy!(:standardize_planid)
+    #   org.do_chore!(:standardize_planid)
+    #   # => true
+    #
+    #   org.tidy! # alias for do_chores!
     #   # => { standardize_planid: true }
     #
     # See docs/guides/feature-housekeeping.md for the full guide.
@@ -46,6 +49,7 @@ module Familia
       def self.included(base)
         Familia.trace :LOADED, self, base if Familia.debug?
         base.extend ModelClassMethods
+        base.include ModelInstanceMethods
       end
 
       # Housekeeping::ModelClassMethods
@@ -53,7 +57,7 @@ module Familia
         # Register a chore by name. The block receives the instance.
         #
         # @param name [Symbol, String] chore identifier
-        # @yield [obj] block invoked with the instance during tidy!
+        # @yield [obj] block invoked with the instance during do_chore!/do_chores!
         # @return [Proc] the registered block
         # @raise [ArgumentError] if name is blank or no block is given
         def chore(name, &block)
@@ -77,24 +81,33 @@ module Familia
         end
       end
 
-      # Run all registered chores, or one chore by name.
-      #
-      # @param name [Symbol, String, nil] chore to run; nil runs all
-      # @return [Hash{Symbol => Object}] chore name => block return value
-      # @raise [ArgumentError] if name is given but not registered
-      def tidy!(name = nil)
-        registered = self.class.chores
+      # Housekeeping::ModelInstanceMethods
+      module ModelInstanceMethods
+        # Run a single registered chore by name.
+        #
+        # @param name [Symbol, String] chore to run
+        # @return [Object] the block's return value
+        # @raise [ArgumentError] if name is blank or not registered
+        def do_chore!(name)
+          raise ArgumentError, 'chore name required' if name.nil? || name.to_s.empty?
 
-        if name
           key = name.to_sym
+          registered = self.class.chores
           raise ArgumentError, "unknown chore #{name.inspect}" unless registered.key?(key)
 
-          { key => registered[key].call(self) }
-        else
-          registered.each_with_object({}) do |(chore_name, block), results|
+          registered[key].call(self)
+        end
+
+        # Run every registered chore against this instance.
+        #
+        # @return [Hash{Symbol => Object}] chore name => block return value
+        def do_chores!
+          self.class.chores.each_with_object({}) do |(chore_name, block), results|
             results[chore_name] = block.call(self)
           end
         end
+
+        alias tidy! do_chores!
       end
     end
   end

--- a/lib/familia/field_type.rb
+++ b/lib/familia/field_type.rb
@@ -157,14 +157,14 @@ module Familia
           # Prevent fast writer within transaction/pipeline - the return value
           # would be Redis::Future which doesn't support zero?/positive? checks
           if Fiber[:familia_transaction]
-            Familia.trace :FAST_WRITER_BLOCKED, nil,
+            Familia.trace :FAST_WRITER_BLOCKED, dbkey,
                          "#{fast_method_name} blocked by active transaction context"
             raise Familia::OperationModeError, <<~ERROR_MESSAGE.chomp
               Cannot call fast writer #{fast_method_name} within a transaction.
               Use batch_update or commit_fields instead.
             ERROR_MESSAGE
           elsif Fiber[:familia_pipeline]
-            Familia.trace :FAST_WRITER_BLOCKED, nil,
+            Familia.trace :FAST_WRITER_BLOCKED, dbkey,
                          "#{fast_method_name} blocked by active pipeline context"
             raise Familia::OperationModeError, <<~ERROR_MESSAGE.chomp
               Cannot call fast writer #{fast_method_name} within a pipeline.

--- a/lib/familia/field_type.rb
+++ b/lib/familia/field_type.rb
@@ -157,11 +157,15 @@ module Familia
           # Prevent fast writer within transaction/pipeline - the return value
           # would be Redis::Future which doesn't support zero?/positive? checks
           if Fiber[:familia_transaction]
+            Familia.trace :FAST_WRITER_BLOCKED, nil,
+                         "#{fast_method_name} blocked by active transaction context"
             raise Familia::OperationModeError, <<~ERROR_MESSAGE.chomp
               Cannot call fast writer #{fast_method_name} within a transaction.
               Use batch_update or commit_fields instead.
             ERROR_MESSAGE
           elsif Fiber[:familia_pipeline]
+            Familia.trace :FAST_WRITER_BLOCKED, nil,
+                         "#{fast_method_name} blocked by active pipeline context"
             raise Familia::OperationModeError, <<~ERROR_MESSAGE.chomp
               Cannot call fast writer #{fast_method_name} within a pipeline.
               Restructure to call fast writers outside the pipeline.

--- a/lib/familia/field_type.rb
+++ b/lib/familia/field_type.rb
@@ -154,6 +154,20 @@ module Familia
           # Handle Redis::Future objects during transactions
           return hget(field_name) if val.nil? || val.is_a?(Redis::Future)
 
+          # Prevent fast writer within transaction/pipeline - the return value
+          # would be Redis::Future which doesn't support zero?/positive? checks
+          if Fiber[:familia_transaction]
+            raise Familia::OperationModeError, <<~ERROR_MESSAGE.chomp
+              Cannot call fast writer #{fast_method_name} within a transaction.
+              Use batch_update or commit_fields instead.
+            ERROR_MESSAGE
+          elsif Fiber[:familia_pipeline]
+            raise Familia::OperationModeError, <<~ERROR_MESSAGE.chomp
+              Cannot call fast writer #{fast_method_name} within a pipeline.
+              Restructure to call fast writers outside the pipeline.
+            ERROR_MESSAGE
+          end
+
           begin
             # Trace the operation if debugging is enabled
             Familia.trace :FAST_WRITER, nil, "#{field_name}: #{val.inspect}" if Familia.debug?

--- a/lib/familia/horreum.rb
+++ b/lib/familia/horreum.rb
@@ -390,10 +390,12 @@ module Familia
     # Returns the Database connection for the instance using Chain of Responsibility pattern.
     #
     # This method uses a chain of handlers to resolve connections in priority order:
-    # 1. FiberTransactionHandler - Fiber[:familia_transaction] (active transaction)
-    # 2. CachedConnectionHandler - Accesses self.dbclient
-    # 3. CachedConnectionHandler - Accesses self.class.dbclient
-    # 4. GlobalFallbackHandler - Familia.dbclient(uri || logical_database) (global fallback)
+    # 1. FiberPipelineHandler - Fiber[:familia_pipeline] (active pipeline)
+    # 2. FiberTransactionHandler - Fiber[:familia_transaction] (active transaction)
+    # 3. FiberConnectionHandler - Fiber[:familia_connection] (middleware-provided)
+    # 4. ProviderConnectionHandler - connection_provider callback
+    # 5. CachedConnectionHandler - @dbclient instance variable
+    # 6. CreateConnectionHandler - creates new connection (fallback)
     #
     # @return [Redis] the Database connection instance.
     #

--- a/lib/familia/horreum.rb
+++ b/lib/familia/horreum.rb
@@ -293,7 +293,8 @@ module Familia
     #
     def initialize_relatives
       # Store initialization flag on singleton class to avoid polluting instance variables
-      return if singleton_class.instance_variable_defined?(:"@relatives_initialized")
+      return if singleton_class.instance_variable_defined?(:@relatives_initialized)
+
       # Generate instances of each DataType. These need to be
       # unique for each instance of this class so they can piggyback
       # on the specifc index of this instance.
@@ -335,7 +336,7 @@ module Familia
       end
 
       # Mark relatives as initialized on singleton class to avoid polluting instance variables
-      singleton_class.instance_variable_set(:"@relatives_initialized", true)
+      singleton_class.instance_variable_set(:@relatives_initialized, true)
     end
 
     def initialize_with_keyword_args_deserialize_value(**fields)

--- a/lib/familia/horreum/connection.rb
+++ b/lib/familia/horreum/connection.rb
@@ -22,9 +22,12 @@ module Familia
       # Returns the Database connection for the class using Chain of Responsibility pattern.
       #
       # This method uses a chain of handlers to resolve connections in priority order:
-      # 1. FiberTransactionHandler - Fiber[:familia_transaction] (active transaction)
-      # 2. DefaultConnectionHandler - Horreum model class-level @dbclient
-      # 3. GlobalFallbackHandler - Familia.dbclient(uri || logical_database) (global fallback)
+      # 1. FiberPipelineHandler - Fiber[:familia_pipeline] (active pipeline)
+      # 2. FiberTransactionHandler - Fiber[:familia_transaction] (active transaction)
+      # 3. FiberConnectionHandler - Fiber[:familia_connection] (middleware connection)
+      # 4. ProviderConnectionHandler - User-defined connection provider
+      # 5. CachedConnectionHandler - Horreum model class-level @dbclient
+      # 6. CreateConnectionHandler - Fresh connection creation (fallback)
       #
       # Thread-safe lazy initialization using double-checked locking to ensure
       # only a single connection chain is built even under high concurrent load.
@@ -278,6 +281,7 @@ module Familia
         @create_connection_handler ||= Familia::Connection::CreateConnectionHandler.new(klass)
 
         Familia::Connection::ResponsibilityChain.new
+          .add_handler(Familia::Connection::FiberPipelineHandler.instance)
           .add_handler(Familia::Connection::FiberTransactionHandler.instance)
           .add_handler(@fiber_connection_handler)
           .add_handler(@provider_connection_handler)

--- a/lib/familia/horreum/connection.rb
+++ b/lib/familia/horreum/connection.rb
@@ -236,6 +236,11 @@ module Familia
       end
       alias pipeline pipelined
 
+      # Thread-safe mutex initialization when module is extended
+      def self.extended(base)
+        base.instance_variable_set(:@class_connection_chain_mutex, Mutex.new)
+      end
+
       private
 
       # Ensures that related fields have been initialized before entering transactions or pipelines.
@@ -250,10 +255,10 @@ module Familia
       def ensure_relatives_initialized!
         return if is_a?(Class)  # Class methods handle their own instances
         return unless self.class.respond_to?(:relations?) && self.class.relations?
-        return if singleton_class.instance_variable_defined?(:"@relatives_initialized")
+        return if singleton_class.instance_variable_defined?(:@relatives_initialized)
 
         raise "#{self.class} has related fields but they haven't been initialized. " \
-              "Did you override initialize without calling super? " \
+              'Did you override initialize without calling super? ' \
               "Related fields: #{self.class.related_fields.keys.join(', ')}"
       end
 
@@ -280,10 +285,6 @@ module Familia
           .add_handler(@create_connection_handler)
       end
 
-      # Thread-safe mutex initialization when module is extended
-      def self.extended(base)
-        base.instance_variable_set(:@class_connection_chain_mutex, Mutex.new)
-      end
     end
   end
 end

--- a/lib/familia/horreum/definition.rb
+++ b/lib/familia/horreum/definition.rb
@@ -483,11 +483,15 @@ module Familia
             # Prevent fast writer within transaction/pipeline - the return value
             # would be Redis::Future which doesn't support zero?/positive? checks
             if Fiber[:familia_transaction]
+              Familia.trace :FAST_WRITER_BLOCKED, nil,
+                           "#{fast_method_name} blocked by active transaction context"
               raise Familia::OperationModeError, <<~ERROR_MESSAGE.chomp
                 Cannot call fast writer #{fast_method_name} within a transaction.
                 Use batch_update or commit_fields instead.
               ERROR_MESSAGE
             elsif Fiber[:familia_pipeline]
+              Familia.trace :FAST_WRITER_BLOCKED, nil,
+                           "#{fast_method_name} blocked by active pipeline context"
               raise Familia::OperationModeError, <<~ERROR_MESSAGE.chomp
                 Cannot call fast writer #{fast_method_name} within a pipeline.
                 Restructure to call fast writers outside the pipeline.

--- a/lib/familia/horreum/definition.rb
+++ b/lib/familia/horreum/definition.rb
@@ -483,14 +483,14 @@ module Familia
             # Prevent fast writer within transaction/pipeline - the return value
             # would be Redis::Future which doesn't support zero?/positive? checks
             if Fiber[:familia_transaction]
-              Familia.trace :FAST_WRITER_BLOCKED, nil,
+              Familia.trace :FAST_WRITER_BLOCKED, dbkey,
                            "#{fast_method_name} blocked by active transaction context"
               raise Familia::OperationModeError, <<~ERROR_MESSAGE.chomp
                 Cannot call fast writer #{fast_method_name} within a transaction.
                 Use batch_update or commit_fields instead.
               ERROR_MESSAGE
             elsif Fiber[:familia_pipeline]
-              Familia.trace :FAST_WRITER_BLOCKED, nil,
+              Familia.trace :FAST_WRITER_BLOCKED, dbkey,
                            "#{fast_method_name} blocked by active pipeline context"
               raise Familia::OperationModeError, <<~ERROR_MESSAGE.chomp
                 Cannot call fast writer #{fast_method_name} within a pipeline.

--- a/lib/familia/horreum/definition.rb
+++ b/lib/familia/horreum/definition.rb
@@ -480,6 +480,20 @@ module Familia
             # Handle Redis::Future objects during transactions
             return hget field_name if val.nil? || val.is_a?(Redis::Future)
 
+            # Prevent fast writer within transaction/pipeline - the return value
+            # would be Redis::Future which doesn't support zero?/positive? checks
+            if Fiber[:familia_transaction]
+              raise Familia::OperationModeError, <<~ERROR_MESSAGE.chomp
+                Cannot call fast writer #{fast_method_name} within a transaction.
+                Use batch_update or commit_fields instead.
+              ERROR_MESSAGE
+            elsif Fiber[:familia_pipeline]
+              raise Familia::OperationModeError, <<~ERROR_MESSAGE.chomp
+                Cannot call fast writer #{fast_method_name} within a pipeline.
+                Restructure to call fast writers outside the pipeline.
+              ERROR_MESSAGE
+            end
+
             begin
               # Trace the operation if debugging is enabled.
               Familia.trace :FAST_WRITER, nil, "#{field_name}: #{val.inspect}" if Familia.debug?

--- a/lib/familia/horreum/management/audit.rb
+++ b/lib/familia/horreum/management/audit.rb
@@ -2,8 +2,6 @@
 #
 # frozen_string_literal: true
 
-require 'set'
-
 module Familia
   class Horreum
     # AuditMethods provides proactive consistency detection for Horreum models.
@@ -61,15 +59,15 @@ module Familia
       def audit_unique_indexes(scanned_identifiers: nil, loaded_objects: nil)
         return [] unless respond_to?(:indexing_relationships)
 
-        indexing_relationships.select { |r|
+        indexing_relationships.select do |r|
           r.cardinality == :unique && r.within.nil?
-        }.map { |rel|
+        end.map do |rel|
           audit_single_unique_index(
             rel,
             scanned_identifiers: scanned_identifiers,
             loaded_objects: loaded_objects,
           )
-        }
+        end
       end
 
       # Audits all multi indexes.
@@ -89,15 +87,15 @@ module Familia
       def audit_multi_indexes(scanned_identifiers: nil, loaded_objects: nil)
         return [] unless respond_to?(:indexing_relationships)
 
-        indexing_relationships.select { |r|
+        indexing_relationships.select do |r|
           r.cardinality == :multi
-        }.map { |rel|
+        end.map do |rel|
           audit_single_multi_index(
             rel,
             scanned_identifiers: scanned_identifiers,
             loaded_objects: loaded_objects,
           )
-        }
+        end
       end
 
       # Audits participation collections for stale members.
@@ -114,7 +112,7 @@ module Familia
       def audit_participations(sample_size: nil)
         return [] unless respond_to?(:participation_relationships)
 
-        participation_relationships.flat_map { |rel|
+        participation_relationships.flat_map do |rel|
           if rel.target_class == self
             # Class-level participation (class_participates_in)
             [audit_class_participation(rel, sample_size: sample_size)]
@@ -122,7 +120,7 @@ module Familia
             # Instance-level participation (participates_in TargetClass, :collection)
             audit_instance_participations(rel, sample_size: sample_size)
           end
-        }
+        end
       end
 
       # Audits instance-level related_fields (list/set/zset/hashkey) for
@@ -175,9 +173,9 @@ module Familia
 
         return empty_result unless respond_to?(:indexing_relationships)
 
-        class_unique_rels = indexing_relationships.select { |rel|
+        class_unique_rels = indexing_relationships.select do |rel|
           rel.cardinality == :unique && (rel.within.nil? || rel.within == :class)
-        }
+        end
         return empty_result if class_unique_rels.empty?
 
         instance_ids = instances.members
@@ -278,9 +276,9 @@ module Familia
         # audits. Without this, a model with N unique indexes and M multi
         # indexes would trigger N+M additional SCANs and load_multi round
         # trips during their "missing" phases.
-        has_indexes = respond_to?(:indexing_relationships) && indexing_relationships.any? { |r|
+        has_indexes = respond_to?(:indexing_relationships) && indexing_relationships.any? do |r|
           (r.cardinality == :unique && r.within.nil?) || r.cardinality == :multi
-        }
+        end
 
         if has_indexes
           shared_ids = scan_identifiers(batch_size: batch_size).to_a
@@ -313,7 +311,7 @@ module Familia
           participations: parts,
           related_fields: related,
           cross_references: cross_refs,
-          duration: duration
+          duration: duration,
         )
       end
 
@@ -331,7 +329,7 @@ module Familia
       def scan_identifiers(batch_size: 100, &progress)
         ids = Set.new
         pattern = scan_pattern
-        cursor = "0"
+        cursor = '0'
 
         loop do
           cursor, keys = dbclient.scan(cursor, match: pattern, count: batch_size)
@@ -342,7 +340,7 @@ module Familia
             ids << identifier
           end
           progress&.call(phase: :scanning, current: ids.size, total: nil)
-          break if cursor == "0"
+          break if cursor == '0'
         end
 
         ids
@@ -413,9 +411,7 @@ module Familia
           value = obj.send(field)
           next if value.nil? || value.to_s.strip.empty?
 
-          unless indexed_values.include?(value.to_s)
-            missing << { identifier: identifier, field_value: value.to_s }
-          end
+          missing << { identifier: identifier, field_value: value.to_s } unless indexed_values.include?(value.to_s)
         end
 
         { index_name: index_name, stale: stale, missing: missing }
@@ -862,7 +858,7 @@ module Familia
         unless scope_class.respond_to?(:instances)
           Familia.debug "[audit_instance_scoped_multi_index] #{name}##{rel.index_name}: " \
                         "scope class #{scope_class.name} has no instances collection; " \
-                        "missing detection requires enumerating scope instances"
+                        'missing detection requires enumerating scope instances'
           return [[], :no_scope_instances]
         end
 
@@ -1009,14 +1005,14 @@ module Familia
         raw_members = raw_members.sample(sample_size) if sample_size
 
         raw_members.each do |raw_member|
-          unless exists?(raw_member)
-            stale << {
-              identifier: raw_member,
-              collection_key: collection_key,
-              collection_name: collection_name,
-              reason: :object_missing,
-            }
-          end
+          next if exists?(raw_member)
+
+          stale << {
+            identifier: raw_member,
+            collection_key: collection_key,
+            collection_name: collection_name,
+            reason: :object_missing,
+          }
         end
 
         { collection_name: collection_name, stale_members: stale }
@@ -1080,19 +1076,19 @@ module Familia
                         client.lrange(collection_key, 0, -1)
                       else
                         return stale
-                      end
+        end
 
         raw_members = raw_members.sample(sample_size) if sample_size
 
         raw_members.each do |raw_member|
-          unless exists?(raw_member)
-            stale << {
-              identifier: raw_member,
-              collection_key: collection_key,
-              collection_name: rel.collection_name,
-              reason: :object_missing,
-            }
-          end
+          next if exists?(raw_member)
+
+          stale << {
+            identifier: raw_member,
+            collection_key: collection_key,
+            collection_name: rel.collection_name,
+            reason: :object_missing,
+          }
         end
 
         stale
@@ -1202,12 +1198,12 @@ module Familia
       #
       def scan_matching_keys(pattern, client, batch_size: 100)
         keys = []
-        cursor = "0"
+        cursor = '0'
 
         loop do
           cursor, batch = client.scan(cursor, match: pattern, count: batch_size)
           keys.concat(batch)
-          break if cursor == "0"
+          break if cursor == '0'
         end
 
         keys

--- a/lib/familia/horreum/management/audit.rb
+++ b/lib/familia/horreum/management/audit.rb
@@ -2,6 +2,8 @@
 #
 # frozen_string_literal: true
 
+require 'set' # stdlib in Ruby 3.2/3.3; autoloaded core in 3.4+. Required for Set.new usages below.
+
 module Familia
   class Horreum
     # AuditMethods provides proactive consistency detection for Horreum models.

--- a/lib/familia/horreum/persistence.rb
+++ b/lib/familia/horreum/persistence.rb
@@ -109,15 +109,19 @@ module Familia
 
           begin
             fields_count = to_h_for_storage.size
-          rescue => e
-            Familia.error "Failed to serialize fields for logging",
+          rescue StandardError => e
+            Familia.error 'Failed to serialize fields for logging',
               error: e.message,
               class: self.class.name,
-              identifier: (identifier rescue nil)
+              identifier: begin
+                identifier
+              rescue StandardError
+                nil
+              end
             fields_count = 0
           end
 
-          Familia.debug "Horreum saved",
+          Familia.debug 'Horreum saved',
             class: self.class.name,
             identifier: identifier,
             duration: duration,
@@ -127,8 +131,7 @@ module Familia
           Familia::Instrumentation.notify_lifecycle(:save, self,
             duration: duration,
             update_expiration: update_expiration,
-            fields_count: fields_count
-          )
+            fields_count: fields_count)
         end
 
         # Clear dirty tracking after successful save
@@ -401,6 +404,7 @@ module Familia
         fields = kwargs
 
         raise ArgumentError, 'No fields specified' if fields.empty?
+
         guard_allowed_fields!(fields.keys)
 
         Familia.trace :BATCH_FAST_WRITE, nil, fields.keys if Familia.debug?
@@ -414,7 +418,7 @@ module Familia
         result = transaction do |_conn|
           hmset(serialized)
 
-          self.update_expiration if update_exp
+          update_expiration if update_exp
 
           touch_instances!
         end
@@ -556,7 +560,7 @@ module Familia
         end
 
         # Structured lifecycle logging and instrumentation
-        Familia.debug "Horreum destroyed",
+        Familia.debug 'Horreum destroyed',
           class: self.class.name,
           identifier: identifier,
           key: dbkey
@@ -732,7 +736,7 @@ module Familia
 
         raise ArgumentError,
           "Undeclared fields for #{self.class}: #{unknown.join(', ')}. " \
-          "Only fields defined with `field` or `transient` are mass-assignable."
+          'Only fields defined with `field` or `transient` are mass-assignable.'
       end
 
       # Reset all transient fields to nil

--- a/try/edge_cases/fast_writer_transaction_guard_try.rb
+++ b/try/edge_cases/fast_writer_transaction_guard_try.rb
@@ -1,0 +1,126 @@
+require 'base64'
+require_relative '../support/helpers/test_helpers'
+
+Familia.debug = false
+
+# Configure encryption for encrypted field tests
+test_keys = { v1: Base64.strict_encode64('a' * 32) }
+Familia.config.encryption_keys = test_keys
+Familia.config.current_key_version = :v1
+
+# Test class for fast writer transaction/pipeline guards
+class FastWriterGuardTest < Familia::Horreum
+  identifier_field :testid
+  field :testid
+  field :name
+  field :value
+end
+
+# Test class for encrypted fast writer guards
+class EncryptedFastWriterGuardTest < Familia::Horreum
+  feature :encrypted_fields
+  identifier_field :testid
+  field :testid
+  encrypted_field :secret
+end
+
+# Clean slate
+@testobj = FastWriterGuardTest.new(testid: 'fw-guard-test', name: 'initial')
+@testobj.destroy!
+@testobj.save
+
+## Fast writer raises OperationModeError inside transaction
+begin
+  @testobj.transaction do
+    @testobj.name!('inside-transaction')
+  end
+  :should_have_raised
+rescue Familia::OperationModeError => e
+  e.message.include?('Cannot call fast writer')
+end
+#=> true
+
+## Fast writer raises OperationModeError inside pipeline
+begin
+  @testobj.pipelined do
+    @testobj.name!('inside-pipeline')
+  end
+  :should_have_raised
+rescue Familia::OperationModeError => e
+  e.message.include?('Cannot call fast writer')
+end
+#=> true
+
+## Transaction error message suggests batch_update or commit_fields
+begin
+  @testobj.transaction do
+    @testobj.name!('inside-transaction')
+  end
+  :should_have_raised
+rescue Familia::OperationModeError => e
+  e.message.include?('batch_update') && e.message.include?('commit_fields')
+end
+#=> true
+
+## Pipeline error message suggests restructuring (not batch_update)
+begin
+  @testobj.pipelined do
+    @testobj.name!('inside-pipeline')
+  end
+  :should_have_raised
+rescue Familia::OperationModeError => e
+  e.message.include?('Restructure') && !e.message.include?('batch_update')
+end
+#=> true
+
+## Fast writer works normally outside transaction
+@testobj.value!('direct-write')
+@testobj.value
+#=> 'direct-write'
+
+## Fast writer as getter works inside transaction (returns Future)
+result = nil
+@testobj.transaction do
+  result = @testobj.value!
+end
+result.is_a?(Redis::Future) || result == 'direct-write'
+#=> true
+
+## Fast writer works after transaction completes
+@testobj.transaction do
+  @testobj.hset(:name, '"modified"')
+end
+@testobj.value!('after-transaction')
+@testobj.value
+#=> 'after-transaction'
+
+## Encrypted fast writer raises OperationModeError inside transaction
+@encrypted = EncryptedFastWriterGuardTest.new(testid: 'enc-fw-guard-test')
+@encrypted.destroy!
+@encrypted.save
+begin
+  @encrypted.transaction do
+    @encrypted.secret!('sensitive-data')
+  end
+  :should_have_raised
+rescue Familia::OperationModeError => e
+  e.message.include?('Cannot call fast writer')
+end
+#=> true
+
+## Encrypted fast writer raises OperationModeError inside pipeline
+begin
+  @encrypted.pipelined do
+    @encrypted.secret!('sensitive-data')
+  end
+  :should_have_raised
+rescue Familia::OperationModeError => e
+  e.message.include?('Cannot call fast writer')
+end
+#=> true
+
+## Cleanup
+@testobj.destroy!
+@encrypted.destroy!
+true
+#=> true

--- a/try/edge_cases/fast_writer_transaction_guard_try.rb
+++ b/try/edge_cases/fast_writer_transaction_guard_try.rb
@@ -124,3 +124,7 @@ end
 @encrypted.destroy!
 true
 #=> true
+
+# Teardown - restore global encryption config so test order is not a factor
+Familia.config.encryption_keys = nil
+Familia.config.current_key_version = nil

--- a/try/edge_cases/pipeline_handler_edge_cases_try.rb
+++ b/try/edge_cases/pipeline_handler_edge_cases_try.rb
@@ -1,0 +1,214 @@
+# try/edge_cases/pipeline_handler_edge_cases_try.rb
+#
+# frozen_string_literal: true
+
+# Edge Case Tests for FiberPipelineHandler
+#
+# Tests edge cases and error handling:
+# - Pipelined block with transaction inside
+# - Error handling when pipeline fails mid-batch
+# - Connection chain precedence (pipeline before transaction handler)
+# - Cleanup after exceptions
+# - Fiber isolation
+
+require_relative '../support/helpers/test_helpers'
+
+# Test model for edge cases
+class PipelineEdgeCaseModel < Familia::Horreum
+  logical_database 4
+  identifier_field :modelid
+
+  field :modelid
+  field :name
+  field :value
+end
+
+def edge_cleanup(*keys)
+  Familia.dbclient(4).del(*keys) if keys.any?
+end
+
+# Setup
+edge_cleanup(
+  'pipelineedgecasemodel:edge_1:object',
+  'pipelineedgecasemodel:edge_2:object',
+  'pipelineedgecasemodel:edge_3:object',
+  'pipelineedgecasemodel:edge_4:object',
+  'pipelineedgecasemodel:edge_5:object'
+)
+
+## Pipeline clears Fiber local after successful completion
+Familia.pipelined do |pipe|
+  pipe.set('test:edge_cleanup', 'value')
+end
+Fiber[:familia_pipeline].nil?
+#=> true
+
+## Pipeline clears Fiber local after exception
+begin
+  Familia.pipelined do |_pipe|
+    raise 'Intentional test error'
+  end
+rescue => e
+  # Expected
+end
+
+Fiber[:familia_pipeline].nil?
+#=> true
+
+## Pipeline handler returns nil outside pipeline block
+Fiber[:familia_pipeline] = nil
+result = Familia::Connection::FiberPipelineHandler.instance.handle(nil)
+result.nil?
+#=> true
+
+## Pipeline connection is different from regular connection
+@pipeline_conn = nil
+@regular_conn = Familia.dbclient
+
+Familia.pipelined do |pipe|
+  @pipeline_conn = pipe
+end
+
+@pipeline_conn.object_id != @regular_conn.object_id
+#=> true
+
+## Nested pipelines share same connection (reentrant)
+@outer_id = nil
+@inner_id = nil
+
+Familia.pipelined do |outer|
+  @outer_id = outer.object_id
+
+  Familia.pipelined do |inner|
+    @inner_id = inner.object_id
+  end
+end
+
+@outer_id == @inner_id
+#=> true
+
+## Pipeline and transaction cannot be nested - raises ConflictingContextError
+@model1 = PipelineEdgeCaseModel.new(modelid: 'edge_1')
+@model1.save
+
+error_raised = begin
+  @model1.pipelined do |pipe|
+    pipe.hset(@model1.dbkey, 'pipe_field', 'pipe_value')
+    @model1.transaction do |txn|
+      txn.hset(@model1.dbkey, 'txn_field', 'txn_value')
+    end
+  end
+  false
+rescue Familia::ConflictingContextError
+  true
+end
+error_raised
+#=> true
+
+## Transaction and pipeline fiber locals are independent
+@pipe_set = false
+@txn_set = false
+
+Familia.pipelined do |pipe|
+  @pipe_set = !Fiber[:familia_pipeline].nil?
+  @txn_set_in_pipe = Fiber[:familia_transaction].nil?
+end
+
+Familia.transaction do |txn|
+  @txn_set = !Fiber[:familia_transaction].nil?
+  @pipe_set_in_txn = Fiber[:familia_pipeline].nil?
+end
+
+[@pipe_set, @txn_set_in_pipe, @txn_set, @pipe_set_in_txn]
+#=> [true, true, true, true]
+
+## Multiple sequential pipelines each get fresh context
+@conn_ids = []
+
+3.times do
+  Familia.pipelined do |pipe|
+    @conn_ids << pipe.object_id
+  end
+end
+
+# Connections may or may not be same (depends on pool) but each pipeline completes
+@conn_ids.size == 3
+#=> true
+
+## Pipeline returns all command results
+result = Familia.pipelined do |pipe|
+  pipe.set('test:edge_multi_1', 'a')
+  pipe.set('test:edge_multi_2', 'b')
+  pipe.get('test:edge_multi_1')
+  pipe.get('test:edge_multi_2')
+end
+
+result.results.last(2)
+#=> ["a", "b"]
+
+## Pipeline with no commands returns empty results
+result = Familia.pipelined { |_pipe| }
+result.results
+#=> []
+
+## Handler allows_pipelined is :reentrant not true
+Familia::Connection::FiberPipelineHandler.allows_pipelined == :reentrant
+#=> true
+
+## Handler allows_transaction is false (cannot start transaction on pipeline connection)
+Familia::Connection::FiberPipelineHandler.allows_transaction == false
+#=> true
+
+## FiberPipelineHandler comes before FiberTransactionHandler in connection chain
+# This ensures pipeline connections are detected before transaction connections
+@model2 = PipelineEdgeCaseModel.new(modelid: 'edge_2')
+@model2.save
+
+chain = @model2.class.instance_variable_get(:@class_connection_chain)
+handlers = chain.instance_variable_get(:@handlers)
+handler_classes = handlers.map(&:class)
+
+pipe_index = handler_classes.index(Familia::Connection::FiberPipelineHandler)
+txn_index = handler_classes.index(Familia::Connection::FiberTransactionHandler)
+
+# Pipeline handler should come first (lower index = higher priority)
+pipe_index < txn_index
+#=> true
+
+## Deeply nested pipelines all share same connection
+@ids = []
+
+Familia.pipelined do |p1|
+  @ids << p1.object_id
+  Familia.pipelined do |p2|
+    @ids << p2.object_id
+    Familia.pipelined do |p3|
+      @ids << p3.object_id
+    end
+  end
+end
+
+@ids.uniq.size == 1
+#=> true
+
+## Pipeline works with different logical databases
+model_db4 = PipelineEdgeCaseModel.new(modelid: 'edge_3')
+model_db4.save
+
+result = model_db4.pipelined do |pipe|
+  pipe.hset(model_db4.dbkey, 'db4_field', 'db4_value')
+end
+
+result.is_a?(MultiResult)
+#=> true
+
+# Cleanup
+edge_cleanup(
+  'pipelineedgecasemodel:edge_1:object',
+  'pipelineedgecasemodel:edge_2:object',
+  'pipelineedgecasemodel:edge_3:object',
+  'test:edge_cleanup',
+  'test:edge_multi_1',
+  'test:edge_multi_2'
+)
+PipelineEdgeCaseModel.instances.clear

--- a/try/features/housekeeping/housekeeping_try.rb
+++ b/try/features/housekeeping/housekeeping_try.rb
@@ -257,6 +257,115 @@ HousekeepingOverride.chores.keys
 HousekeepingParent.chores[:from_parent].equal?(HousekeepingOverride.chores[:from_parent])
 #=> false
 
+## run_chores! returns model name, scanned count, and per-chore stats
+class HousekeepingBulk < Familia::Horreum
+  feature :housekeeping
+  identifier_field :id
+  field :id
+  field :code
+
+  chore :uppercase_code do |obj|
+    next unless obj.code && obj.code != obj.code.upcase
+    obj.code = obj.code.upcase
+    obj.save
+    true
+  end
+end
+@bulk1 = HousekeepingBulk.new(id: 'b1', code: 'aaa'); @bulk1.save
+@bulk2 = HousekeepingBulk.new(id: 'b2', code: 'BBB'); @bulk2.save
+@bulk3 = HousekeepingBulk.new(id: 'b3', code: 'ccc'); @bulk3.save
+@bulk_result = HousekeepingBulk.run_chores!
+[@bulk_result[:model], @bulk_result[:scanned]]
+#=> [HousekeepingBulk.name, 3]
+
+## run_chores! per-chore stats count modifications (truthy returns)
+@bulk_result[:chores][:uppercase_code]
+#=> {modified: 2, errors: 0}
+
+## run_chores! actually persists changes
+HousekeepingBulk.find_by_identifier('b1').code
+#=> "AAA"
+
+## run_chores! with chore_name: filters to a single chore
+class HousekeepingBulkMulti < Familia::Horreum
+  feature :housekeeping
+  identifier_field :id
+  field :id
+  field :name
+  field :country
+
+  chore(:strip_name) { |o| o.name && o.name != o.name.strip ? (o.name = o.name.strip; o.save; true) : nil }
+  chore(:upper_country) { |o| o.country && o.country != o.country.upcase ? (o.country = o.country.upcase; o.save; true) : nil }
+end
+@m1 = HousekeepingBulkMulti.new(id: 'm1', name: '  alice  ', country: 'us'); @m1.save
+@m2 = HousekeepingBulkMulti.new(id: 'm2', name: 'bob',       country: 'ca'); @m2.save
+HousekeepingBulkMulti.run_chores!(chore_name: :upper_country)[:chores].keys
+#=> [:upper_country]
+
+## run_chores! with chore_name does not run the other chore
+HousekeepingBulkMulti.find_by_identifier('m1').name
+#=> "  alice  "
+
+## run_chores! with chore_name actually ran the named chore
+HousekeepingBulkMulti.find_by_identifier('m1').country
+#=> "US"
+
+## run_chores! honors limit
+@m3 = HousekeepingBulkMulti.new(id: 'm3', name: 'carol', country: 'mx'); @m3.save
+@m4 = HousekeepingBulkMulti.new(id: 'm4', name: 'dave',  country: 'br'); @m4.save
+HousekeepingBulkMulti.run_chores!(chore_name: :upper_country, limit: 2)[:scanned]
+#=> 2
+
+## run_chores! batches via load_multi (batch_size smaller than population)
+HousekeepingBulkMulti.run_chores!(chore_name: :strip_name, batch_size: 1)[:scanned]
+#=> 4
+
+## run_chores! isolates per-record errors and continues
+class HousekeepingBulkError < Familia::Horreum
+  feature :housekeeping
+  identifier_field :id
+  field :id
+  field :payload
+
+  chore(:explode) { |o| raise 'kaboom' if o.payload == 'bad'; o.payload && true }
+end
+@be1 = HousekeepingBulkError.new(id: 'be1', payload: 'good'); @be1.save
+@be2 = HousekeepingBulkError.new(id: 'be2', payload: 'bad');  @be2.save
+@be3 = HousekeepingBulkError.new(id: 'be3', payload: 'good'); @be3.save
+@err_result = HousekeepingBulkError.run_chores!
+@err_result[:chores][:explode]
+#=> {modified: 2, errors: 1}
+
+## run_chores! still reports scanned count including failed records
+@err_result[:scanned]
+#=> 3
+
+## run_chores! raises when no chores are registered
+class HousekeepingBulkEmpty < Familia::Horreum
+  feature :housekeeping
+  identifier_field :id
+  field :id
+end
+begin
+  HousekeepingBulkEmpty.run_chores!
+rescue ArgumentError => e
+  e.message
+end
+#=> "#{HousekeepingBulkEmpty.name} has no chores registered"
+
+## run_chores! raises on unknown chore_name
+begin
+  HousekeepingBulk.run_chores!(chore_name: :nonexistent)
+rescue ArgumentError => e
+  e.message
+end
+#=> "unknown chore :nonexistent"
+
+## run_chores! returns scanned: 0 when instances collection is empty
+@bulk1.destroy!; @bulk2.destroy!; @bulk3.destroy!
+HousekeepingBulk.run_chores!.slice(:scanned, :chores)
+#=> {scanned: 0, chores: {uppercase_code: {modified: 0, errors: 0}}}
+
 ## Cleanup
 @org.destroy! if @org.exists?
 @org2.destroy! if @org2.exists?
@@ -266,5 +375,12 @@ HousekeepingParent.chores[:from_parent].equal?(HousekeepingOverride.chores[:from
 @rep.destroy! if @rep.exists?
 @child.destroy! if @child.exists?
 @override.destroy! if @override.exists?
+@m1.destroy! if @m1.exists?
+@m2.destroy! if @m2.exists?
+@m3.destroy! if @m3.exists?
+@m4.destroy! if @m4.exists?
+@be1.destroy! if @be1.exists?
+@be2.destroy! if @be2.exists?
+@be3.destroy! if @be3.exists?
 true
 #=> true

--- a/try/features/housekeeping/housekeeping_try.rb
+++ b/try/features/housekeeping/housekeeping_try.rb
@@ -52,52 +52,94 @@ HousekeepingOrg.respond_to?(:chore)
 HousekeepingOrg.respond_to?(:chores)
 #=> true
 
-## Instance responds to tidy!
+## Instance responds to do_chore!
+@org.respond_to?(:do_chore!)
+#=> true
+
+## Instance responds to do_chores!
+@org.respond_to?(:do_chores!)
+#=> true
+
+## Instance responds to tidy! (alias for do_chores!)
 @org.respond_to?(:tidy!)
+#=> true
+
+## tidy! is an alias of do_chores! (same method, not a wrapper)
+@org.method(:tidy!) == @org.method(:do_chores!)
 #=> true
 
 ## Chores are registered in declaration order
 HousekeepingOrg.chores.keys
 #=> [:standardize_planid, :uppercase_country]
 
-## tidy! with no args runs every registered chore and returns a Hash
-results = @org.tidy!
+## do_chores! runs every registered chore and returns a Hash
+results = @org.do_chores!
 results.keys.sort
 #=> [:standardize_planid, :uppercase_country]
 
-## tidy! persists changes via the block (planid normalized)
+## do_chores! persists changes via the block (planid normalized)
 @org.refresh!
 @org.planid
 #=> "professional"
 
-## tidy! persists changes via the block (country uppercased)
+## do_chores! persists changes via the block (country uppercased)
 @org.country
 #=> "US"
 
-## A second tidy! is a no-op (idempotent by convention)
-second = @org.tidy!
+## A second do_chores! is a no-op (idempotent by convention)
+second = @org.do_chores!
 second
 #=> {:standardize_planid=>nil, :uppercase_country=>nil}
 
-## tidy! with a name runs only that chore
+## tidy! delegates to do_chores! and returns the same Hash shape
+tidy_results = @org.tidy!
+tidy_results
+#=> {:standardize_planid=>nil, :uppercase_country=>nil}
+
+## do_chore! runs only the named chore and returns the block's raw value
 @org2 = HousekeepingOrg.new(orgid: 'beta', planid: 'free', country: 'ca')
 @org2.save
-result = @org2.tidy!(:uppercase_country)
-result
-#=> {:uppercase_country=>true}
+@org2.do_chore!(:uppercase_country)
+#=> true
 
-## Other chores are not run when called by name
+## do_chore! accepts a String name as well as a Symbol
+@org3 = HousekeepingOrg.new(orgid: 'gamma', planid: 'free', country: 'mx')
+@org3.save
+@org3.do_chore!('uppercase_country')
+#=> true
+
+## Other chores are not run when do_chore! is called by name
 @org2.refresh!
 @org2.planid # untouched (still 'free' which case maps to 'free' so no change)
 #=> "free"
 
-## tidy! with unknown chore raises ArgumentError
+## do_chore! returns the raw value when the block returns a no-op (nil)
+@org2.do_chore!(:standardize_planid)
+#=> nil
+
+## do_chore! with unknown chore raises ArgumentError
 begin
-  @org.tidy!(:nonexistent)
+  @org.do_chore!(:nonexistent)
 rescue ArgumentError => e
   e.message
 end
 #=> "unknown chore :nonexistent"
+
+## do_chore! with nil name raises ArgumentError
+begin
+  @org.do_chore!(nil)
+rescue ArgumentError => e
+  e.message
+end
+#=> "chore name required"
+
+## do_chore! with empty name raises ArgumentError
+begin
+  @org.do_chore!('')
+rescue ArgumentError => e
+  e.message
+end
+#=> "chore name required"
 
 ## chore registered without a block raises
 begin
@@ -115,16 +157,28 @@ rescue ArgumentError => e
 end
 #=> "chore name required"
 
-## A class with no chores returns an empty hash from tidy!
+## A class with no chores returns an empty hash from do_chores!
 @noop = HousekeepingNoop.new(id: 'x')
+@noop.do_chores!
+#=> {}
+
+## tidy! on a class with no chores also returns an empty hash
 @noop.tidy!
 #=> {}
+
+## tidy! no longer accepts a name argument (was a single-arg form in 2.7.0)
+begin
+  @org.tidy!(:standardize_planid)
+rescue ArgumentError => e
+  e.message.include?('wrong number of arguments')
+end
+#=> true
 
 ## chore registration is per-class (HousekeepingNoop has no chores)
 HousekeepingNoop.chores
 #=> {}
 
-## Errors raised in a chore propagate to the caller
+## Errors raised in a chore propagate to the caller via do_chores!
 class HousekeepingRaise < Familia::Horreum
   feature :housekeeping
   identifier_field :id
@@ -134,7 +188,15 @@ end
 @raiser = HousekeepingRaise.new(id: 'r')
 @raiser.save
 begin
-  @raiser.tidy!
+  @raiser.do_chores!
+rescue RuntimeError => e
+  e.message
+end
+#=> "kaboom"
+
+## Errors raised in a chore propagate to the caller via do_chore!
+begin
+  @raiser.do_chore!(:boom)
 rescue RuntimeError => e
   e.message
 end
@@ -151,7 +213,7 @@ class HousekeepingReplace < Familia::Horreum
 end
 @rep = HousekeepingReplace.new(id: 'r')
 @rep.save
-@rep.tidy!
+@rep.do_chores!
 #=> {:mark=>:second}
 
 ## Subclasses inherit chores from their parent (copy-on-access)
@@ -175,7 +237,7 @@ HousekeepingParent.chores.keys
 ## Inherited chores run alongside child-specific ones
 @child = HousekeepingChild.new(id: 'c')
 @child.save
-@child.tidy!.keys.sort
+@child.do_chores!.keys.sort
 #=> [:from_child, :from_parent]
 
 ## Subclass can override a parent chore by re-registering the same name
@@ -185,10 +247,10 @@ end
 HousekeepingOverride.chores.keys
 #=> [:from_parent]
 
-## Override chore runs the subclass block, not the parent block
+## do_chore! on subclass runs the override block, not the parent block
 @override = HousekeepingOverride.new(id: 'ov')
 @override.save
-@override.tidy!(:from_parent)[:from_parent]
+@override.do_chore!(:from_parent)
 #=> :overridden
 
 ## Parent registry is unchanged by a subclass override
@@ -198,6 +260,7 @@ HousekeepingParent.chores[:from_parent].equal?(HousekeepingOverride.chores[:from
 ## Cleanup
 @org.destroy! if @org.exists?
 @org2.destroy! if @org2.exists?
+@org3.destroy! if @org3.exists?
 @noop.destroy! if @noop.exists?
 @raiser.destroy! if @raiser.exists?
 @rep.destroy! if @rep.exists?

--- a/try/integration/connection/handler_constraints_try.rb
+++ b/try/integration/connection/handler_constraints_try.rb
@@ -61,11 +61,3 @@ Familia::Connection::CreateConnectionHandler.allows_transaction
 ## CreateConnectionHandler allows pipelines
 Familia::Connection::CreateConnectionHandler.allows_pipelined
 #=> true
-
-## BaseConnectionHandler defaults to allow all
-Familia::Connection::BaseConnectionHandler.allows_transaction
-#=> true
-
-## BaseConnectionHandler defaults to allow all pipelines
-Familia::Connection::BaseConnectionHandler.allows_pipelined
-#=> true

--- a/try/integration/connection/handler_constraints_try.rb
+++ b/try/integration/connection/handler_constraints_try.rb
@@ -14,6 +14,14 @@
 
 require_relative '../../support/helpers/test_helpers'
 
+## FiberPipelineHandler blocks transactions
+Familia::Connection::FiberPipelineHandler.allows_transaction
+#=> false
+
+## FiberPipelineHandler is reentrant for pipelines
+Familia::Connection::FiberPipelineHandler.allows_pipelined
+#=> :reentrant
+
 ## FiberTransactionHandler constraints
 Familia::Connection::FiberTransactionHandler.allows_transaction
 #=> :reentrant

--- a/try/integration/connection/pipeline_handler_integration_try.rb
+++ b/try/integration/connection/pipeline_handler_integration_try.rb
@@ -1,0 +1,171 @@
+# try/integration/connection/pipeline_handler_integration_try.rb
+#
+# frozen_string_literal: true
+
+# Integration Tests for FiberPipelineHandler
+#
+# Tests that Horreum methods correctly route through the pipeline connection
+# when called inside pipelined blocks:
+# - commit_fields inside pipelined block uses pipeline connection
+# - Fast writers (field!) inside pipelined block use pipeline connection
+# - Nested DataType operations also route correctly
+# - Commands are batched, not executed immediately
+#
+# These tests verify the handler's integration with the connection chain.
+
+require_relative '../../support/helpers/test_helpers'
+
+# Test model for pipeline handler integration
+class PipelineHandlerTestUser < Familia::Horreum
+  logical_database 4
+  identifier_field :userid
+  field :userid
+  field :name
+  field :status
+
+  list :activities
+  set :permissions
+  hashkey :metadata
+end
+
+def pipe_test_cleanup(*keys)
+  Familia.dbclient(4).del(*keys) if keys.any?
+end
+
+# Setup - clean state
+pipe_test_cleanup(
+  'pipelinehandlertestuser:pipe_user_1:object',
+  'pipelinehandlertestuser:pipe_user_2:object',
+  'pipelinehandlertestuser:pipe_user_3:object',
+  'pipelinehandlertestuser:pipe_user_4:object',
+  'pipelinehandlertestuser:pipe_user_5:object'
+)
+
+## Connection chain includes FiberPipelineHandler before FiberTransactionHandler
+# Verify the handler is present in the chain
+@user = PipelineHandlerTestUser.new(userid: 'chain_check')
+@user.save
+chain = @user.instance_variable_get(:@class_connection_chain) ||
+        @user.class.instance_variable_get(:@class_connection_chain)
+handlers = chain.instance_variable_get(:@handlers)
+handler_classes = handlers.map(&:class)
+pipe_idx = handler_classes.index(Familia::Connection::FiberPipelineHandler)
+txn_idx = handler_classes.index(Familia::Connection::FiberTransactionHandler)
+@user.destroy!
+pipe_idx < txn_idx  # Pipeline should come before transaction in chain
+#=> true
+
+## Fiber[:familia_pipeline] is set during pipelined block
+@pipeline_set = false
+@user = PipelineHandlerTestUser.new(userid: 'pipe_user_1')
+@user.name = 'Test User'
+@user.save
+
+result = @user.pipelined do |pipe|
+  @pipeline_set = !Fiber[:familia_pipeline].nil?
+  pipe.hset(@user.dbkey, 'status', 'active')
+end
+
+[@pipeline_set, result.is_a?(MultiResult)]
+#=> [true, true]
+
+## Fiber[:familia_pipeline] cleared after pipelined block
+@user.pipelined do |pipe|
+  pipe.hset(@user.dbkey, 'name', 'Updated')
+end
+Fiber[:familia_pipeline].nil?
+#=> true
+
+## hset inside pipelined block uses pipeline connection
+@user2 = PipelineHandlerTestUser.new(userid: 'pipe_user_2')
+@user2.name = 'Pipeline Test'
+@user2.save
+
+@conn_inside_pipeline = nil
+result = @user2.pipelined do |pipe|
+  @conn_inside_pipeline = pipe.object_id
+  @user2.hset(:status, 'pipelined')
+end
+
+[result.is_a?(MultiResult), @user2.hget(:status)]
+#=> [true, "pipelined"]
+
+## Multiple Horreum operations inside single pipeline are batched
+@user3 = PipelineHandlerTestUser.new(userid: 'pipe_user_3')
+@user3.name = 'Multi Op User'
+@user3.save
+
+result = @user3.pipelined do |_pipe|
+  @user3.hset(:status, 'batch_1')
+  @user3.hset(:name, 'Batch User')
+  @user3.expire(3600)
+end
+
+# All operations completed - check final state
+[@user3.hget(:status), @user3.hget(:name)]
+#=> ["batch_1", "Batch User"]
+
+## Nested pipelined calls reuse same connection
+@outer_conn_id = nil
+@inner_conn_id = nil
+
+@user4 = PipelineHandlerTestUser.new(userid: 'pipe_user_4')
+@user4.save
+
+@user4.pipelined do |outer_pipe|
+  @outer_conn_id = outer_pipe.object_id
+
+  @user4.pipelined do |inner_pipe|
+    @inner_conn_id = inner_pipe.object_id
+    inner_pipe.hset(@user4.dbkey, 'nested', 'yes')
+  end
+end
+
+@outer_conn_id == @inner_conn_id
+#=> true
+
+## DataType operations inside parent's pipelined block
+@user5 = PipelineHandlerTestUser.new(userid: 'pipe_user_5')
+@user5.name = 'DataType Test'
+@user5.save
+
+result = @user5.pipelined do |pipe|
+  # Direct pipe commands for DataType operations
+  pipe.sadd(@user5.permissions.dbkey, @user5.permissions.serialize_value('read'))
+  pipe.sadd(@user5.permissions.dbkey, @user5.permissions.serialize_value('write'))
+  pipe.hset(@user5.metadata.dbkey, 'level', @user5.metadata.serialize_value('admin'))
+end
+
+[@user5.permissions.member?('read'), @user5.permissions.member?('write'), @user5.metadata['level']]
+#=> [true, true, "admin"]
+
+## Connection handler class is tracked during pipeline
+@handler_during_pipeline = nil
+
+Familia.pipelined do |_pipe|
+  @handler_during_pipeline = Fiber[:familia_connection_handler_class]
+end
+
+# The handler class should be set (may be CreateConnectionHandler or others)
+!@handler_during_pipeline.nil?
+#=> true
+
+## Pipeline works with class-level pipelined method
+result = PipelineHandlerTestUser.pipelined do |pipe|
+  pipe.set('test:class_pipe', 'value')
+  pipe.get('test:class_pipe')
+end
+
+[result.is_a?(MultiResult), result.results.last]
+#=> [true, "value"]
+
+# Cleanup
+pipe_test_cleanup(
+  'pipelinehandlertestuser:pipe_user_1:object',
+  'pipelinehandlertestuser:pipe_user_2:object',
+  'pipelinehandlertestuser:pipe_user_3:object',
+  'pipelinehandlertestuser:pipe_user_4:object',
+  'pipelinehandlertestuser:pipe_user_5:object',
+  'test:class_pipe'
+)
+PipelineHandlerTestUser.instances.clear

--- a/try/integration/connection/pipeline_handler_integration_try.rb
+++ b/try/integration/connection/pipeline_handler_integration_try.rb
@@ -4,14 +4,18 @@
 
 # Integration Tests for FiberPipelineHandler
 #
-# Tests that Horreum methods correctly route through the pipeline connection
-# when called inside pipelined blocks:
-# - commit_fields inside pipelined block uses pipeline connection
-# - Fast writers (field!) inside pipelined block use pipeline connection
-# - Nested DataType operations also route correctly
-# - Commands are batched, not executed immediately
+# Tests that Horreum and DataType operations route through the pipeline
+# connection when called inside a pipelined block:
+# - Connection chain ordering (FiberPipelineHandler before FiberTransactionHandler)
+# - Fiber[:familia_pipeline] is set inside the block and cleared on exit
+# - Ad-hoc database commands (e.g. #hset) inside the block use the pipeline conn
+# - Multiple Horreum operations are batched within a single pipeline
+# - Nested pipelined calls reuse the same connection (reentrant)
+# - DataType operations issued inside the parent's pipeline route correctly
 #
-# These tests verify the handler's integration with the connection chain.
+# Note: Fast writers (field!) and #commit_fields are NOT exercised here — they
+# raise Familia::OperationModeError inside pipeline/transaction contexts. See
+# try/edge_cases/fast_writer_transaction_guard_try.rb for that coverage.
 
 require_relative '../../support/helpers/test_helpers'
 

--- a/try/integration/connection/pipeline_horreum_routing_try.rb
+++ b/try/integration/connection/pipeline_horreum_routing_try.rb
@@ -1,0 +1,147 @@
+# try/integration/connection/pipeline_horreum_routing_try.rb
+#
+# frozen_string_literal: true
+
+# Pipeline Routing Tests for Horreum Operations
+#
+# Tests that Horreum methods properly route through the pipeline when
+# called inside pipelined blocks. This is the critical integration that
+# FiberPipelineHandler enables.
+#
+# Covers:
+# - hset/hmset inside pipelined blocks
+# - expire inside pipelined blocks
+# - Mixed Horreum and DataType operations
+# - Connection routing via FiberPipelineHandler
+#
+# NOTE: Fast writers (field!) and commit_fields have limitations inside
+# pipelines due to Redis::Future return values. Those edge cases are
+# documented separately.
+
+require_relative '../../support/helpers/test_helpers'
+
+# Test model for Horreum pipeline routing
+class PipelineRoutingTestModel < Familia::Horreum
+  logical_database 4
+  identifier_field :modelid
+
+  field :modelid
+  field :name
+  field :status
+  field :counter
+
+  list :log_entries
+  set :flags
+  hashkey :settings
+end
+
+def routing_test_cleanup(*keys)
+  Familia.dbclient(4).del(*keys) if keys.any?
+end
+
+# Setup
+@test_keys = []
+
+## hset inside pipelined uses pipeline connection
+@model1 = PipelineRoutingTestModel.new(modelid: 'routing_model_1')
+@model1.save
+@test_keys << @model1.dbkey
+
+result = @model1.pipelined do |pipe|
+  @model1.hset(:name, 'Direct hset')
+  @model1.hset(:status, 'hset_active')
+end
+
+[@model1.hget(:name), @model1.hget(:status)]
+#=> ["Direct hset", "hset_active"]
+
+## hmset inside pipelined uses pipeline connection
+@model2 = PipelineRoutingTestModel.new(modelid: 'routing_model_2')
+@model2.save
+@test_keys << @model2.dbkey
+
+result = @model2.pipelined do |_pipe|
+  @model2.hmset(name: 'Bulk Set', status: 'bulk_active', counter: '100')
+end
+
+[@model2.hget(:name), @model2.hget(:status), @model2.hget(:counter)]
+#=> ["Bulk Set", "bulk_active", "100"]
+
+## Pipeline with mixed Horreum and DataType operations
+@model3 = PipelineRoutingTestModel.new(modelid: 'routing_model_3')
+@model3.name = 'Mixed Ops'
+@model3.save
+@test_keys << @model3.dbkey
+@test_keys << @model3.flags.dbkey
+@test_keys << @model3.settings.dbkey
+
+result = @model3.pipelined do |pipe|
+  # Horreum operation
+  @model3.hset(:status, 'mixed')
+
+  # DataType operations via raw commands
+  pipe.sadd(@model3.flags.dbkey, @model3.flags.serialize_value('important'))
+  pipe.hset(@model3.settings.dbkey, 'theme', @model3.settings.serialize_value('dark'))
+end
+
+[@model3.hget(:status), @model3.flags.member?('important'), @model3.settings['theme']]
+#=> ["mixed", true, "dark"]
+
+## Pipelined block returns MultiResult
+@model4 = PipelineRoutingTestModel.new(modelid: 'routing_model_4')
+@model4.save
+@test_keys << @model4.dbkey
+
+result = @model4.pipelined do |pipe|
+  pipe.hset(@model4.dbkey, 'name', 'Result Test')
+  pipe.hget(@model4.dbkey, 'name')
+end
+
+[result.is_a?(MultiResult), result.results.is_a?(Array)]
+#=> [true, true]
+
+## Empty pipelined block returns empty MultiResult
+@model5 = PipelineRoutingTestModel.new(modelid: 'routing_model_5')
+@model5.save
+@test_keys << @model5.dbkey
+
+result = @model5.pipelined { |_pipe| }
+[result.is_a?(MultiResult), result.results.empty?]
+#=> [true, true]
+
+## Transaction inside pipelined block raises ConflictingContextError
+@model6 = PipelineRoutingTestModel.new(modelid: 'routing_model_6')
+@model6.save
+@test_keys << @model6.dbkey
+
+error_raised = begin
+  @model6.pipelined do |pipe|
+    pipe.hset(@model6.dbkey, 'before_txn', 'yes')
+    @model6.transaction do |txn|
+      txn.hset(@model6.dbkey, 'in_txn', 'yes')
+    end
+  end
+  false
+rescue Familia::ConflictingContextError
+  true
+end
+error_raised
+#=> true
+
+## expire inside pipelined uses pipeline
+@model7 = PipelineRoutingTestModel.new(modelid: 'routing_model_7')
+@model7.name = 'Expire Test'
+@model7.save
+@test_keys << @model7.dbkey
+
+result = @model7.pipelined do |_pipe|
+  @model7.expire(7200)
+end
+
+# TTL should be set (value depends on timing, just check it's positive)
+@model7.current_expiration > 0
+#=> true
+
+# Cleanup
+routing_test_cleanup(*@test_keys.uniq)
+PipelineRoutingTestModel.instances.clear

--- a/try/integration/data_types/datatype_pipelines_try.rb
+++ b/try/integration/data_types/datatype_pipelines_try.rb
@@ -55,14 +55,18 @@ end
 [result.is_a?(MultiResult), leaderboard.members.size]
 #=> [true, 2]
 
-## Pipeline with direct_access works correctly
-result = @user.profile.pipelined do |pipe_conn|
+## DataType operations inside a pipeline route through the pipeline connection
+# HashKey#[]= and Fiber[:familia_pipeline] should agree: the pipeline
+# connection is what receives the writes. Raw pipe.hset bypasses
+# serialize_value, so 'yes' is stored as a bare string.
+@user.profile.pipelined do |pipe_conn|
   pipe_conn.hset(@user.profile.dbkey, 'pipeline_test', 'yes')
 
-  @user.profile.direct_access do |conn, key|
-    conn.object_id == pipe_conn.object_id &&
-    conn.hset(key, 'direct_test', 'yes')
-  end
+  # The DataType wrapper's mutating methods auto-route to Fiber[:familia_pipeline]
+  @user.profile['direct_test'] = 'yes'
+
+  # The Fiber-local exposes the same connection used by the wrapper
+  pipe_conn.object_id == Fiber[:familia_pipeline].object_id
 end
 [@user.profile['pipeline_test'], @user.profile['direct_test']]
 #=> ["yes", "yes"]
@@ -104,6 +108,22 @@ result = custom.pipelined do |pipe|
   pipe.hget(custom.dbkey, 'key1')
 end
 result.is_a?(MultiResult)
+#=> true
+
+## DataType call site raises ConflictingContextError when pipeline+transaction nest
+# Routing through the DataType chain must surface the same conflict semantics as
+# Horreum (FiberPipelineHandler raises if Fiber[:familia_transaction] is also set).
+error_raised = begin
+  @user.profile.pipelined do |_pipe|
+    @user.profile.transaction do |_txn|
+      # Should not reach here — handler should raise before yielding
+    end
+  end
+  false
+rescue Familia::ConflictingContextError
+  true
+end
+error_raised
 #=> true
 
 # Cleanup

--- a/try/integration/data_types/datatype_transactions_try.rb
+++ b/try/integration/data_types/datatype_transactions_try.rb
@@ -151,20 +151,21 @@ end
 conn_class
 #=> "Redis::MultiConnection"
 
-## Transaction with direct_access works correctly
-# Note: direct_access bypasses serialize_value, so raw 'true' string
-# gets parsed as JSON boolean true on retrieval (Issue #190 behavior)
-result = @user.profile.transaction do |trans_conn|
-  trans_conn.hset(@user.profile.dbkey, 'status', 'active')
+## DataType operations inside a transaction route through the transaction connection
+# HashKey#[]= and Fiber[:familia_transaction] should agree: the transaction
+# connection is what receives the writes. The wrapper serializes via JSON
+# (Issue #190), so string values round-trip as strings.
+@user.profile.transaction do |trans_conn|
+  trans_conn.hset(@user.profile.dbkey, 'status', @user.profile.serialize_value('active'))
 
-  # direct_access should use the same transaction connection
-  @user.profile.direct_access do |conn, key|
-    conn.object_id == trans_conn.object_id &&
-    conn.hset(key, 'verified', 'true')
-  end
+  # The DataType wrapper's mutating methods auto-route to Fiber[:familia_transaction]
+  @user.profile['verified'] = 'yes'
+
+  # The Fiber-local exposes the same connection used by the wrapper
+  trans_conn.object_id == Fiber[:familia_transaction].object_id
 end
 [@user.profile['status'], @user.profile['verified']]
-#=> ["active", true]
+#=> ["active", "yes"]
 
 ## Transaction atomicity - all commands succeed or none
 test_zset = Familia::SortedSet.new('atomic:test')

--- a/try/integration/data_types/datatype_transactions_try.rb
+++ b/try/integration/data_types/datatype_transactions_try.rb
@@ -154,18 +154,19 @@ conn_class
 ## DataType operations inside a transaction route through the transaction connection
 # HashKey#[]= and Fiber[:familia_transaction] should agree: the transaction
 # connection is what receives the writes. The wrapper serializes via JSON
-# (Issue #190), so string values round-trip as strings.
+# (Issue #190), so string values round-trip as strings -- writing 'true'
+# yields the string "true" back, not the boolean true that raw hset produced.
 @user.profile.transaction do |trans_conn|
   trans_conn.hset(@user.profile.dbkey, 'status', @user.profile.serialize_value('active'))
 
   # The DataType wrapper's mutating methods auto-route to Fiber[:familia_transaction]
-  @user.profile['verified'] = 'yes'
+  @user.profile['verified'] = 'true'
 
   # The Fiber-local exposes the same connection used by the wrapper
   trans_conn.object_id == Fiber[:familia_transaction].object_id
 end
 [@user.profile['status'], @user.profile['verified']]
-#=> ["active", "yes"]
+#=> ["active", "true"]
 
 ## Transaction atomicity - all commands succeed or none
 test_zset = Familia::SortedSet.new('atomic:test')

--- a/try/thread_safety/fiber_pipeline_isolation_try.rb
+++ b/try/thread_safety/fiber_pipeline_isolation_try.rb
@@ -206,30 +206,22 @@ multi_pipe_results
 #==> _.size == 6
 #==> _.select { |(label, _)| label == :between }.all? { |(_, is_nil)| is_nil }
 
-## Pipeline and transaction isolation in same fiber
-mixed_results = Concurrent::Array.new
+## Pipeline and transaction cannot be nested - raises ConflictingContextError
+error_raised = false
 
 fiber = Fiber.new do
-  Familia.pipeline do
-    pipe_conn = Fiber[:familia_pipeline]
-    mixed_results << [:pipeline, pipe_conn.object_id]
-
-    Familia.transaction do
-      txn_conn = Fiber[:familia_transaction]
-      pipe_during_txn = Fiber[:familia_pipeline]
-      mixed_results << [:transaction, txn_conn.object_id]
-      mixed_results << [:pipeline_during_txn, pipe_during_txn.object_id]
+  begin
+    Familia.pipeline do
+      Familia.transaction do
+        # Should not reach here
+      end
     end
-
-    pipe_after_txn = Fiber[:familia_pipeline]
-    mixed_results << [:pipeline_after_txn, pipe_after_txn.object_id]
+  rescue Familia::ConflictingContextError
+    error_raised = true
   end
 end
 
 fiber.resume
 
-mixed_results
-#==> _.size == 4
-#==> _[0][1] == _[2][1]  # Pipeline preserved during transaction
-#==> _[0][1] == _[3][1]  # Pipeline preserved after transaction
-#==> _[0][1] != _[1][1]  # Different connections for pipeline and transaction
+error_raised
+#=> true

--- a/try/unit/fiber_pipeline_handler_try.rb
+++ b/try/unit/fiber_pipeline_handler_try.rb
@@ -1,0 +1,147 @@
+# try/unit/fiber_pipeline_handler_try.rb
+#
+# frozen_string_literal: true
+
+# Unit Tests for FiberPipelineHandler
+#
+# Tests the FiberPipelineHandler in isolation, verifying:
+# - Returns nil when Fiber[:familia_pipeline] is not set
+# - Returns the pipeline connection when Fiber[:familia_pipeline] is set
+# - Correct allows_transaction and allows_pipelined flags
+# - Singleton pattern works correctly
+#
+# These tests focus on the handler behavior itself, not integration with Horreum.
+
+require_relative '../support/helpers/test_helpers'
+
+## FiberPipelineHandler singleton instance is frozen
+Familia::Connection::FiberPipelineHandler.instance.frozen?
+#=> true
+
+## FiberPipelineHandler singleton returns same instance
+handler1 = Familia::Connection::FiberPipelineHandler.instance
+handler2 = Familia::Connection::FiberPipelineHandler.instance
+handler1.object_id == handler2.object_id
+#=> true
+
+## FiberPipelineHandler allows_transaction is false
+Familia::Connection::FiberPipelineHandler.allows_transaction
+#=> false
+
+## FiberPipelineHandler allows_pipelined is :reentrant
+Familia::Connection::FiberPipelineHandler.allows_pipelined
+#=> :reentrant
+
+## FiberPipelineHandler returns nil when Fiber[:familia_pipeline] not set
+original = Fiber[:familia_pipeline]
+Fiber[:familia_pipeline] = nil
+result = Familia::Connection::FiberPipelineHandler.instance.handle(nil)
+Fiber[:familia_pipeline] = original
+result
+#=> nil
+
+## FiberPipelineHandler returns nil with URI when Fiber[:familia_pipeline] not set
+original = Fiber[:familia_pipeline]
+Fiber[:familia_pipeline] = nil
+result = Familia::Connection::FiberPipelineHandler.instance.handle('redis://localhost:6379')
+Fiber[:familia_pipeline] = original
+result
+#=> nil
+
+## FiberPipelineHandler returns pipeline connection when set
+@mock_pipeline = Object.new
+original = Fiber[:familia_pipeline]
+Fiber[:familia_pipeline] = @mock_pipeline
+result = Familia::Connection::FiberPipelineHandler.instance.handle(nil)
+Fiber[:familia_pipeline] = original
+result.object_id == @mock_pipeline.object_id
+#=> true
+
+## FiberPipelineHandler returns pipeline regardless of URI argument
+@mock_pipeline = Object.new
+original = Fiber[:familia_pipeline]
+Fiber[:familia_pipeline] = @mock_pipeline
+result = Familia::Connection::FiberPipelineHandler.instance.handle('redis://different:6380/5')
+Fiber[:familia_pipeline] = original
+result.object_id == @mock_pipeline.object_id
+#=> true
+
+## FiberPipelineHandler is a subclass of BaseConnectionHandler
+Familia::Connection::FiberPipelineHandler < Familia::Connection::BaseConnectionHandler
+#=> true
+
+## FiberPipelineHandler instance responds to handle
+Familia::Connection::FiberPipelineHandler.instance.respond_to?(:handle)
+#=> true
+
+## FiberPipelineHandler class has singleton accessor
+Familia::Connection::FiberPipelineHandler.respond_to?(:instance)
+#=> true
+
+## FiberPipelineHandler different from FiberTransactionHandler
+handler1 = Familia::Connection::FiberPipelineHandler.instance
+handler2 = Familia::Connection::FiberTransactionHandler.instance
+handler1.object_id != handler2.object_id
+#=> true
+
+## FiberPipelineHandler and FiberTransactionHandler have opposite flags
+pipe_txn = Familia::Connection::FiberPipelineHandler.allows_transaction
+pipe_pipe = Familia::Connection::FiberPipelineHandler.allows_pipelined
+txn_txn = Familia::Connection::FiberTransactionHandler.allows_transaction
+txn_pipe = Familia::Connection::FiberTransactionHandler.allows_pipelined
+[pipe_txn, pipe_pipe, txn_txn, txn_pipe]
+#=> [false, :reentrant, :reentrant, false]
+
+## FiberPipelineHandler raises ConflictingContextError when both contexts are set
+@pipe_conn = Object.new
+@txn_conn = Object.new
+original_pipe = Fiber[:familia_pipeline]
+original_txn = Fiber[:familia_transaction]
+
+Fiber[:familia_pipeline] = @pipe_conn
+Fiber[:familia_transaction] = @txn_conn
+
+error_raised = begin
+  Familia::Connection::FiberPipelineHandler.instance.handle(nil)
+  false
+rescue Familia::ConflictingContextError
+  true
+ensure
+  Fiber[:familia_pipeline] = original_pipe
+  Fiber[:familia_transaction] = original_txn
+end
+error_raised
+#=> true
+
+## FiberTransactionHandler raises ConflictingContextError when both contexts are set
+@pipe_conn = Object.new
+@txn_conn = Object.new
+original_pipe = Fiber[:familia_pipeline]
+original_txn = Fiber[:familia_transaction]
+
+Fiber[:familia_pipeline] = @pipe_conn
+Fiber[:familia_transaction] = @txn_conn
+
+error_raised = begin
+  Familia::Connection::FiberTransactionHandler.instance.handle(nil)
+  false
+rescue Familia::ConflictingContextError
+  true
+ensure
+  Fiber[:familia_pipeline] = original_pipe
+  Fiber[:familia_transaction] = original_txn
+end
+error_raised
+#=> true
+
+## Clearing Fiber[:familia_pipeline] makes handler return nil
+@mock_pipeline = Object.new
+original_txn = Fiber[:familia_transaction]
+Fiber[:familia_transaction] = nil  # ensure no conflict
+Fiber[:familia_pipeline] = @mock_pipeline
+first_result = Familia::Connection::FiberPipelineHandler.instance.handle(nil)
+Fiber[:familia_pipeline] = nil
+second_result = Familia::Connection::FiberPipelineHandler.instance.handle(nil)
+Fiber[:familia_transaction] = original_txn  # restore
+[first_result.object_id == @mock_pipeline.object_id, second_result]
+#=> [true, nil]

--- a/try/unit/fiber_pipeline_handler_try.rb
+++ b/try/unit/fiber_pipeline_handler_try.rb
@@ -66,8 +66,8 @@ Fiber[:familia_pipeline] = original
 result.object_id == @mock_pipeline.object_id
 #=> true
 
-## FiberPipelineHandler is a subclass of BaseConnectionHandler
-Familia::Connection::FiberPipelineHandler < Familia::Connection::BaseConnectionHandler
+## FiberPipelineHandler includes the Handler interface module
+Familia::Connection::FiberPipelineHandler.include?(Familia::Connection::Handler)
 #=> true
 
 ## FiberPipelineHandler instance responds to handle


### PR DESCRIPTION
## Summary

Strengthens connection handling by adding explicit mutual exclusion between pipeline and transaction contexts, and guards fast writers that would fail inside these contexts.

**FiberPipelineHandler**: New handler enforces that pipelines and transactions cannot nest. Attempting to start one inside the other raises `ConflictingContextError` with guidance to restructure. The connection chain is now explicit: FiberPipeline → FiberTransaction → FiberConnection → Provider → Cached → Create.

**Fast writer guards**: Fast writers (`field!`) call `ret.zero? || ret.positive?` on the hset return value. Inside transactions/pipelines, hset returns `Redis::Future` which doesn't support those methods. Added guards to all three implementations (FieldType, DefinitionMethods, EncryptedFieldType) with context-aware error messages suggesting alternatives.

## Test coverage

- `fiber_pipeline_handler_try.rb` - handler behavior, singleton pattern, flags
- `pipeline_handler_integration_try.rb` - real pipelined operations with Horreum models  
- `pipeline_handler_edge_cases_try.rb` - conflict detection, reentrancy, fiber cleanup
- `fast_writer_transaction_guard_try.rb` - guards for regular and encrypted fields

## Test plan

- [x] All 4805 tests pass
- [x] Pipeline/transaction conflict raises `ConflictingContextError`
- [x] Fast writers raise `OperationModeError` inside transaction/pipeline
- [x] Fast writers work normally outside these contexts
- [x] Encrypted fast writers have same guards