### PR TITLE
Add trace events for connection-mode conflicts

### DIFF
--- a/changelog.d/20260515_060502_claude_pr263_feedback.rst
+++ b/changelog.d/20260515_060502_claude_pr263_feedback.rst
@@ -1,0 +1,20 @@
+Added
+~~~~~
+
+- Trace events for connection-mode conflicts. ``Familia.trace`` now
+  emits ``CONFLICTING_CONTEXT`` when pipeline and transaction
+  contexts collide (in both ``FiberPipelineHandler``/
+  ``FiberTransactionHandler`` and the
+  ``execute_transaction``/``execute_pipeline`` entry points), and
+  ``FAST_WRITER_BLOCKED`` when a fast writer (``field!``) is called
+  inside a transaction or pipeline. These fire just before the
+  corresponding ``ConflictingContextError`` /
+  ``OperationModeError`` is raised, so operators can pinpoint where
+  blocked operations originate when ``FAMILIA_TRACE=1``.
+
+AI Assistance
+~~~~~~~~~~~~~
+
+- Added the trace instrumentation in response to PR #263 review
+  feedback (Claude Code review bot) recommending tracing for
+  conflict detection events.

--- a/lib/familia/connection/handlers.rb
+++ b/lib/familia/connection/handlers.rb
@@ -188,6 +188,8 @@ module Familia
         return nil unless Fiber[:familia_pipeline]
 
         if Fiber[:familia_transaction]
+          Familia.trace :CONFLICTING_CONTEXT, nil,
+                       'Pipeline handler detected active transaction context'
           raise Familia::ConflictingContextError,
             'Cannot mix pipeline and transaction contexts. ' \
             'Restructure to use one or the other.'
@@ -227,6 +229,8 @@ module Familia
         return nil unless Fiber[:familia_transaction]
 
         if Fiber[:familia_pipeline]
+          Familia.trace :CONFLICTING_CONTEXT, nil,
+                       'Transaction handler detected active pipeline context'
           raise Familia::ConflictingContextError,
             'Cannot mix pipeline and transaction contexts. ' \
             'Restructure to use one or the other.'

--- a/lib/familia/connection/handlers.rb
+++ b/lib/familia/connection/handlers.rb
@@ -188,7 +188,7 @@ module Familia
         return nil unless Fiber[:familia_pipeline]
 
         if Fiber[:familia_transaction]
-          Familia.trace :CONFLICTING_CONTEXT, nil,
+          Familia.trace :CONFLICTING_CONTEXT, _uri,
                        'Pipeline handler detected active transaction context'
           raise Familia::ConflictingContextError,
             'Cannot mix pipeline and transaction contexts. ' \
@@ -229,7 +229,7 @@ module Familia
         return nil unless Fiber[:familia_transaction]
 
         if Fiber[:familia_pipeline]
-          Familia.trace :CONFLICTING_CONTEXT, nil,
+          Familia.trace :CONFLICTING_CONTEXT, _uri,
                        'Transaction handler detected active pipeline context'
           raise Familia::ConflictingContextError,
             'Cannot mix pipeline and transaction contexts. ' \

--- a/lib/familia/connection/pipelined_core.rb
+++ b/lib/familia/connection/pipelined_core.rb
@@ -42,6 +42,8 @@ module Familia
       def self.execute_pipeline(dbclient_proc, &)
         # Prevent mixing pipeline and transaction contexts
         if Fiber[:familia_transaction]
+          Familia.trace :CONFLICTING_CONTEXT, nil,
+                       'Attempted to start pipeline inside active transaction'
           raise Familia::ConflictingContextError,
             'Cannot start pipeline inside transaction. ' \
             'Restructure to use one or the other.'

--- a/lib/familia/connection/transaction_core.rb
+++ b/lib/familia/connection/transaction_core.rb
@@ -95,6 +95,8 @@ module Familia
       def self.execute_transaction(dbclient_proc, &)
         # Prevent mixing pipeline and transaction contexts
         if Fiber[:familia_pipeline]
+          Familia.trace :CONFLICTING_CONTEXT, nil,
+                       'Attempted to start transaction inside active pipeline'
           raise Familia::ConflictingContextError,
             'Cannot start transaction inside pipeline. ' \
             'Restructure to use one or the other.'

--- a/lib/familia/features/encrypted_fields/encrypted_field_type.rb
+++ b/lib/familia/features/encrypted_fields/encrypted_field_type.rb
@@ -111,11 +111,15 @@ module Familia
           # Prevent fast writer within transaction/pipeline - the return value
           # would be Redis::Future which doesn't support zero?/positive? checks
           if Fiber[:familia_transaction]
+            Familia.trace :FAST_WRITER_BLOCKED, nil,
+                         "#{fast_method_name} blocked by active transaction context"
             raise Familia::OperationModeError, <<~ERROR_MESSAGE.chomp
               Cannot call fast writer #{fast_method_name} within a transaction.
               Use batch_update or commit_fields instead.
             ERROR_MESSAGE
           elsif Fiber[:familia_pipeline]
+            Familia.trace :FAST_WRITER_BLOCKED, nil,
+                         "#{fast_method_name} blocked by active pipeline context"
             raise Familia::OperationModeError, <<~ERROR_MESSAGE.chomp
               Cannot call fast writer #{fast_method_name} within a pipeline.
               Restructure to call fast writers outside the pipeline.

--- a/lib/familia/features/encrypted_fields/encrypted_field_type.rb
+++ b/lib/familia/features/encrypted_fields/encrypted_field_type.rb
@@ -111,14 +111,14 @@ module Familia
           # Prevent fast writer within transaction/pipeline - the return value
           # would be Redis::Future which doesn't support zero?/positive? checks
           if Fiber[:familia_transaction]
-            Familia.trace :FAST_WRITER_BLOCKED, nil,
+            Familia.trace :FAST_WRITER_BLOCKED, dbkey,
                          "#{fast_method_name} blocked by active transaction context"
             raise Familia::OperationModeError, <<~ERROR_MESSAGE.chomp
               Cannot call fast writer #{fast_method_name} within a transaction.
               Use batch_update or commit_fields instead.
             ERROR_MESSAGE
           elsif Fiber[:familia_pipeline]
-            Familia.trace :FAST_WRITER_BLOCKED, nil,
+            Familia.trace :FAST_WRITER_BLOCKED, dbkey,
                          "#{fast_method_name} blocked by active pipeline context"
             raise Familia::OperationModeError, <<~ERROR_MESSAGE.chomp
               Cannot call fast writer #{fast_method_name} within a pipeline.

--- a/lib/familia/field_type.rb
+++ b/lib/familia/field_type.rb
@@ -157,14 +157,14 @@ module Familia
           # Prevent fast writer within transaction/pipeline - the return value
           # would be Redis::Future which doesn't support zero?/positive? checks
           if Fiber[:familia_transaction]
-            Familia.trace :FAST_WRITER_BLOCKED, nil,
+            Familia.trace :FAST_WRITER_BLOCKED, dbkey,
                          "#{fast_method_name} blocked by active transaction context"
             raise Familia::OperationModeError, <<~ERROR_MESSAGE.chomp
               Cannot call fast writer #{fast_method_name} within a transaction.
               Use batch_update or commit_fields instead.
             ERROR_MESSAGE
           elsif Fiber[:familia_pipeline]
-            Familia.trace :FAST_WRITER_BLOCKED, nil,
+            Familia.trace :FAST_WRITER_BLOCKED, dbkey,
                          "#{fast_method_name} blocked by active pipeline context"
             raise Familia::OperationModeError, <<~ERROR_MESSAGE.chomp
               Cannot call fast writer #{fast_method_name} within a pipeline.

--- a/lib/familia/field_type.rb
+++ b/lib/familia/field_type.rb
@@ -157,11 +157,15 @@ module Familia
           # Prevent fast writer within transaction/pipeline - the return value
           # would be Redis::Future which doesn't support zero?/positive? checks
           if Fiber[:familia_transaction]
+            Familia.trace :FAST_WRITER_BLOCKED, nil,
+                         "#{fast_method_name} blocked by active transaction context"
             raise Familia::OperationModeError, <<~ERROR_MESSAGE.chomp
               Cannot call fast writer #{fast_method_name} within a transaction.
               Use batch_update or commit_fields instead.
             ERROR_MESSAGE
           elsif Fiber[:familia_pipeline]
+            Familia.trace :FAST_WRITER_BLOCKED, nil,
+                         "#{fast_method_name} blocked by active pipeline context"
             raise Familia::OperationModeError, <<~ERROR_MESSAGE.chomp
               Cannot call fast writer #{fast_method_name} within a pipeline.
               Restructure to call fast writers outside the pipeline.

--- a/lib/familia/horreum/definition.rb
+++ b/lib/familia/horreum/definition.rb
@@ -483,11 +483,15 @@ module Familia
             # Prevent fast writer within transaction/pipeline - the return value
             # would be Redis::Future which doesn't support zero?/positive? checks
             if Fiber[:familia_transaction]
+              Familia.trace :FAST_WRITER_BLOCKED, nil,
+                           "#{fast_method_name} blocked by active transaction context"
               raise Familia::OperationModeError, <<~ERROR_MESSAGE.chomp
                 Cannot call fast writer #{fast_method_name} within a transaction.
                 Use batch_update or commit_fields instead.
               ERROR_MESSAGE
             elsif Fiber[:familia_pipeline]
+              Familia.trace :FAST_WRITER_BLOCKED, nil,
+                           "#{fast_method_name} blocked by active pipeline context"
               raise Familia::OperationModeError, <<~ERROR_MESSAGE.chomp
                 Cannot call fast writer #{fast_method_name} within a pipeline.
                 Restructure to call fast writers outside the pipeline.

--- a/lib/familia/horreum/definition.rb
+++ b/lib/familia/horreum/definition.rb
@@ -483,14 +483,14 @@ module Familia
             # Prevent fast writer within transaction/pipeline - the return value
             # would be Redis::Future which doesn't support zero?/positive? checks
             if Fiber[:familia_transaction]
-              Familia.trace :FAST_WRITER_BLOCKED, nil,
+              Familia.trace :FAST_WRITER_BLOCKED, dbkey,
                            "#{fast_method_name} blocked by active transaction context"
               raise Familia::OperationModeError, <<~ERROR_MESSAGE.chomp
                 Cannot call fast writer #{fast_method_name} within a transaction.
                 Use batch_update or commit_fields instead.
               ERROR_MESSAGE
             elsif Fiber[:familia_pipeline]
-              Familia.trace :FAST_WRITER_BLOCKED, nil,
+              Familia.trace :FAST_WRITER_BLOCKED, dbkey,
                            "#{fast_method_name} blocked by active pipeline context"
               raise Familia::OperationModeError, <<~ERROR_MESSAGE.chomp
                 Cannot call fast writer #{fast_method_name} within a pipeline.


### PR DESCRIPTION
## Summary

This PR adds trace instrumentation for connection-mode conflict detection, enabling operators to pinpoint where blocked operations originate when `FAMILIA_TRACE=1` is enabled.

## Changes

- **New trace events**: Added two new trace event types:
  - `CONFLICTING_CONTEXT`: Emitted when pipeline and transaction contexts collide
  - `FAST_WRITER_BLOCKED`: Emitted when a fast writer (e.g., `field!`) is called inside a transaction or pipeline

- **Instrumentation locations**:
  - `FiberPipelineHandler` and `FiberTransactionHandler`: Trace `CONFLICTING_CONTEXT` when handlers detect conflicting contexts
  - `execute_transaction` and `execute_pipeline` entry points: Trace `CONFLICTING_CONTEXT` when attempting to nest contexts
  - Fast writer definitions (3 locations): Trace `FAST_WRITER_BLOCKED` in `FieldType`, `EncryptedFieldType`, and `Horreum::Definition`

- **Timing**: All trace events fire immediately before the corresponding `ConflictingContextError` or `OperationModeError` is raised, allowing operators to correlate trace output with error logs

## Implementation Details

The trace calls use the pattern:
```ruby
Familia.trace :EVENT_TYPE, nil, 'descriptive message'
```

Each trace event includes context-specific information (e.g., which handler detected the conflict, which fast writer was blocked) to aid in debugging.

This change was made in response to PR #263 review feedback recommending tracing for conflict detection events.

https://claude.ai/code/session_019Up5j9Y3Yti6o1TUyREg9C