### PR TITLE
Redesign each_record pipelining knob: rename write_size → pipeline, safe-by-default

### DIFF
--- a/docs/archive/.gitignore
+++ b/docs/archive/.gitignore
@@ -1,2 +1,0 @@
-# Even all uppercase markdown docs get the blues
-!*.md

--- a/docs/guides/datatype-collections.md
+++ b/docs/guides/datatype-collections.md
@@ -1,0 +1,128 @@
+# docs/guides/datatype-collections.md
+---
+
+# DataType - Collection classes
+
+UnsortedSet, Sorted Set, List, and Hash data types all include the `Collection` module, which provides two main iteration methods: `each` and `each_record`. Both methods are designed to efficiently handle large collections by paginating through Valkey/Redis data structures, but they serve different purposes and yield different results.
+
+Here's how the two methods iterate, using `ModelClass.instances` (a `SortedSet` with `reference: true`) as the running example.
+
+## `each` — yields **members** (identifiers, raw strings)
+
+`each` is implemented per type. For the `instances` SortedSet, it pages through the ZSET with either `ZRANGEBYSCORE` (when `since:`/`until:` are given) or `ZSCAN` (unbounded), yielding one deserialized member at a time.
+
+```mermaid
+flowchart TD
+  Caller["ModelClass.instances.each { |id| ... }"] --> EachImpl["SortedSet#each"]
+  EachImpl --> Decide{since/until?}
+  Decide -- yes --> ZRBS["ZRANGEBYSCORE key min max LIMIT 0 batch_size WITHSCORES"]
+  Decide -- no --> ZSCAN["ZSCAN key cursor COUNT batch_size"]
+  ZRBS --> Page["Page of raw members"]
+  ZSCAN --> Page
+  Page --> Yield["yield deserialize_value(member)"]
+  Yield --> More{more pages?}
+  More -- yes --> Decide
+  More -- no --> Done["return self"]
+```
+
+Per-type variations:
+- `ListKey#each` — paginates with `LRANGE start stop` (no SCAN equivalent)
+- `UnsortedSet#each` / `HashKey#each` — `SSCAN` / `HSCAN`, optional `matching:` glob
+- `SortedSet#each` — `ZRANGEBYSCORE` (bounded) or `ZSCAN` (unbounded)
+
+You get **identifiers only**. No record loading. One Redis round-trip per page.
+
+## `each_record` — yields **loaded Horreum records**
+
+`each_record` is defined once in `CollectionBase` and delegates to `each` to collect identifiers, then batches them into `record_class.load_multi` (pipelined `HGETALL`s), filters ghosts, and yields the live records.
+
+```mermaid
+flowchart TD
+  Caller["ModelClass.instances.each_record { |rec| ... }"] --> ER["each_record(batch_size, pipeline, **filters)"]
+  ER --> Validate{"pipeline <= batch_size?"}
+  Validate -- no --> Raise["raise ArgumentError"]
+  Validate -- yes --> CallEach["each(**filters) do |member|"]
+  CallEach --> Extract["id = member.is_a?(Array) ? member.first : member"]
+  Extract --> Buffer["buffer << id"]
+  Buffer --> Full{"buffer.size >= batch_size?"}
+  Full -- no --> CallEach
+  Full -- yes --> Load["record_class.load_multi(ids)  -- pipelined HGETALLs"]
+  Load --> Compact["live = records.compact  -- drop ghosts"]
+  Compact --> Mode{pipeline?}
+  Mode -- nil --> Serial["live.each { |r| block.call(r) }"]
+  Mode -- positive --> Pipe["live.each_slice(pipeline) do |group|<br/>record_class.pipelined { group.each &block }<br/>end"]
+  Serial --> Clear["buffer.clear; resume each"]
+  Pipe --> Clear
+  Clear --> CallEach
+  CallEach -. each exhausted .-> Flush["process_batch(buffer) if any remain"]
+  Flush --> Return["return self"]
+```
+
+### Concrete timeline for `User.instances.each_record(batch_size: 100, pipeline: 25) { |u| u.touch! }`
+
+```
+SortedSet#each (ZSCAN page 1, 100 ids)
+   ├─ buffer fills to 100
+   ├─ load_multi(ids)        → 1 pipeline of 100 HGETALLs
+   ├─ compact ghosts          → e.g. 97 live records
+   ├─ slice(25):
+   │     pipelined { 25 × u.touch! }   ← 1 Redis pipeline
+   │     pipelined { 25 × u.touch! }   ← 1 Redis pipeline
+   │     pipelined { 25 × u.touch! }   ← 1 Redis pipeline
+   │     pipelined { 22 × u.touch! }   ← 1 Redis pipeline
+   └─ buffer.clear
+SortedSet#each (ZSCAN page 2, 100 ids)
+   └─ … repeat …
+SortedSet#each exhausted
+   └─ flush any remaining buffered ids the same way
+```
+
+## Key differences
+
+| Aspect | `each` | `each_record` |
+|---|---|---|
+| Yields | raw identifier (or `[field, value]` for `HashKey`) | loaded Horreum instance |
+| Redis ops per yield | 0 extra (already paged) | amortized `HGETALL` via `load_multi` batch |
+| Requires `reference: true` + `:class` | no | yes (raises `Familia::Problem` otherwise) |
+| Ghost handling | yields the dangling id | `compact` drops them silently |
+| Write pipelining | not built-in | `pipeline:` groups block-body writes into `pipelined` blocks |
+| Filters | type-specific (`since:`, `matching:`, …) | forwarded to underlying `each` |
+
+So `each_record` is a thin orchestration layer: it leans on the type's own `each` for read pagination, then layers (1) batched record hydration and (2) optional write pipelining on top.
+
+## Choosing a `pipeline` mode
+
+`each_record` has two dispatch modes, controlled by `pipeline:`. The parameter answers a single question: **may the dispatch loop wrap your block in a `pipelined { }`?**
+
+| Value | Dispatch | Use when the block… |
+|---|---|---|
+| `nil` (default) | Each record runs in its own connection context, no pipeline wrapper | …reads, OR calls `save` / `commit_fields` / `transaction` / anything with its own internal MULTI |
+| positive integer | Groups of `pipeline` records run inside `record_class.pipelined { ... }` | …only issues fast writers (`record.field!`) that tolerate being queued |
+
+Note: `pipeline: 0` raises `ArgumentError`. Use `pipeline: nil` to disable pipelining.
+
+The read-only case and the serial-write case collapse into the same mode because both require **immediate** execution with real return values. Wrapping `save` in an outer `pipelined` would either return `Redis::Future` objects or raise `ConflictingContextError` when `save`'s internal transaction tries to open.
+
+### The three idiomatic patterns
+
+```ruby
+# 1. Read-only iteration — the default (pipeline: nil) is correct
+User.instances.each_record do |user|
+  puts "#{user.email} #{user.last_login}"
+end
+
+# 2. Serial writes — the default (pipeline: nil) is required for save / commit_fields / transaction
+User.instances.each_record do |user|
+  user.score = recompute(user)
+  user.save
+end
+
+# 3. Pipelined fast writers — opt-in optimization
+User.instances.each_record(pipeline: 50) do |user|
+  user.last_seen_at! Familia.now   # single HSET, safe to queue in pipeline
+end
+```
+
+### Pipelining footgun
+
+If you enable pipelining and your block reads from a related collection (e.g. `user.sessions.size`), that read is queued into the pipeline and returns a `Redis::Future` rather than a value. Omit the `pipeline:` parameter (or explicitly pass `pipeline: nil`) whenever the block needs real return values from Redis.

--- a/docs/migrating/v2.9.0.md
+++ b/docs/migrating/v2.9.0.md
@@ -82,12 +82,12 @@ Org.instances.each_record(batch_size: 100) do |org|
 end
 
 # Control pipelining depth separately from fetch batch size
-Org.instances.each_record(batch_size: 500, write_size: 50) do |org|
+Org.instances.each_record(batch_size: 500, pipeline: 50) do |org|
   org.status!("active")
 end
 
-# Serial execution (no pipelining)
-Org.instances.each_record(batch_size: 100, write_size: nil) do |org|
+# Serial execution (no pipelining) — this is the default
+Org.instances.each_record(batch_size: 100) do |org|
   org.complex_operation
 end
 ```

--- a/lib/familia/data_type/collection_base.rb
+++ b/lib/familia/data_type/collection_base.rb
@@ -45,10 +45,10 @@ module Familia
       # filtered out.
       #
       # @param batch_size [Integer] Number of identifiers to load per batch
-      # @param write_size [Integer, nil] Controls pipelining depth for writes
-      #   in the block. When nil or 0, writes are serial (no pipelining).
-      #   When positive, fast writers in the block will be pipelined in
-      #   groups of this size.
+      # @param pipeline [Integer, nil] Controls pipelining depth for writes
+      #   in the block. When nil (default), writes are serial (no pipelining).
+      #   When a positive integer, fast writers in the block will be pipelined
+      #   in groups of this size. Must not exceed batch_size.
       # @param filters [Hash] Additional filter parameters passed to `each`.
       #   Available filters depend on the collection type:
       #   - SortedSet: `since:`, `until:`, `cursor_batch_size:`
@@ -58,20 +58,17 @@ module Familia
       # @yield [record] Each loaded Horreum record (non-nil)
       # @return [Enumerator, self] Returns Enumerator if no block given, self otherwise
       #
-      # @example Iterate over all records
+      # @example Iterate over all records (no pipelining, safe default)
       #   User.instances.each_record { |user| user.deactivate! }
       #
       # @example With time filter (for SortedSet)
       #   User.instances.each_record(since: 1.day.ago) { |u| notify(u) }
       #
       # @example Pipeline writes in groups
-      #   items.each_record(batch_size: 500, write_size: 50) { |r| r.foo! 'bar' }
+      #   items.each_record(batch_size: 500, pipeline: 50) { |r| r.foo! 'bar' }
       #
-      # @example Serial writes (no pipelining)
-      #   items.each_record(write_size: nil) { |r| r.save }
-      #
-      def each_record(batch_size: 100, write_size: batch_size, **filters, &block)
-        return to_enum(:each_record, batch_size: batch_size, write_size: write_size, **filters) unless block
+      def each_record(batch_size: 100, pipeline: nil, **filters, &block)
+        return to_enum(:each_record, batch_size: batch_size, pipeline: pipeline, **filters) unless block
 
         # Determine the class to load records from
         # For reference DataTypes, @opts[:class] holds the Horreum class
@@ -80,10 +77,9 @@ module Familia
           raise Familia::Problem, "each_record requires a reference DataType with a :class option that responds to load_multi"
         end
 
-        # Validate write_size constraints
-        if write_size && write_size > batch_size
-          raise ArgumentError, "write_size (#{write_size}) cannot exceed batch_size (#{batch_size})"
-        end
+        # Validate pipeline constraints using Ruby 3.2+ nil-safety
+        raise ArgumentError, "pipeline must be nil or a positive integer (got #{pipeline.inspect})" if pipeline && !pipeline.positive?
+        raise ArgumentError, "pipeline (#{pipeline}) cannot exceed batch_size (#{batch_size})" if pipeline&.> batch_size
 
         # Collect identifiers in batches
         buffer = []
@@ -97,12 +93,12 @@ module Familia
           # Filter out ghosts (nil results from expired keys)
           live_records = records.compact
 
-          if write_size.nil? || write_size.zero?
+          if pipeline.nil?
             # Serial mode - no pipelining, execute block for each record directly
             live_records.each { |record| block.call(record) }
           else
             # Pipelined mode - group records and wrap each group in a pipeline
-            live_records.each_slice(write_size) do |group|
+            live_records.each_slice(pipeline) do |group|
               record_class.pipelined do
                 group.each { |record| block.call(record) }
               end

--- a/lib/familia/data_type/collection_base.rb
+++ b/lib/familia/data_type/collection_base.rb
@@ -77,7 +77,8 @@ module Familia
           raise Familia::Problem, "each_record requires a reference DataType with a :class option that responds to load_multi"
         end
 
-        # Validate pipeline constraints
+        # Validate batch_size and pipeline constraints
+        raise ArgumentError, "batch_size must be a positive integer (got #{batch_size.inspect})" unless batch_size.is_a?(Integer) && batch_size.positive?
         raise ArgumentError, "pipeline must be nil or a positive integer (got #{pipeline.inspect})" unless pipeline.nil? || (pipeline.is_a?(Integer) && pipeline.positive?)
         raise ArgumentError, "pipeline (#{pipeline}) cannot exceed batch_size (#{batch_size})" if pipeline&.> batch_size
 

--- a/lib/familia/data_type/collection_base.rb
+++ b/lib/familia/data_type/collection_base.rb
@@ -77,8 +77,8 @@ module Familia
           raise Familia::Problem, "each_record requires a reference DataType with a :class option that responds to load_multi"
         end
 
-        # Validate pipeline constraints using Ruby 3.2+ nil-safety
-        raise ArgumentError, "pipeline must be nil or a positive integer (got #{pipeline.inspect})" if pipeline && !pipeline.positive?
+        # Validate pipeline constraints
+        raise ArgumentError, "pipeline must be nil or a positive integer (got #{pipeline.inspect})" unless pipeline.nil? || (pipeline.is_a?(Integer) && pipeline.positive?)
         raise ArgumentError, "pipeline (#{pipeline}) cannot exceed batch_size (#{batch_size})" if pipeline&.> batch_size
 
         # Collect identifiers in batches

--- a/try/unit/data_types/each_record_try.rb
+++ b/try/unit/data_types/each_record_try.rb
@@ -251,6 +251,46 @@ records.size
 # Argument validation
 # ============================================================
 
+## each_record raises ArgumentError when batch_size is nil
+begin
+  Customer.instances.each_record(batch_size: nil) { |r| }
+  raised = false
+rescue ArgumentError => e
+  raised = e.message.include?('batch_size') && e.message.include?('positive')
+end
+raised
+#=> true
+
+## each_record raises ArgumentError when batch_size is 0
+begin
+  Customer.instances.each_record(batch_size: 0) { |r| }
+  raised = false
+rescue ArgumentError => e
+  raised = e.message.include?('batch_size') && e.message.include?('positive')
+end
+raised
+#=> true
+
+## each_record raises ArgumentError when batch_size is negative
+begin
+  Customer.instances.each_record(batch_size: -5) { |r| }
+  raised = false
+rescue ArgumentError => e
+  raised = e.message.include?('batch_size') && e.message.include?('positive')
+end
+raised
+#=> true
+
+## each_record raises ArgumentError when batch_size is non-integer
+begin
+  Customer.instances.each_record(batch_size: "100") { |r| }
+  raised = false
+rescue ArgumentError => e
+  raised = e.message.include?('batch_size') && e.message.include?('positive')
+end
+raised
+#=> true
+
 ## each_record raises ArgumentError when pipeline exceeds batch_size
 begin
   Customer.instances.each_record(batch_size: 10, pipeline: 20) { |r| }

--- a/try/unit/data_types/each_record_try.rb
+++ b/try/unit/data_types/each_record_try.rb
@@ -89,26 +89,33 @@ records.size
 #=> 5
 
 # ============================================================
-# write_size parameter for pipelining
+# pipeline parameter for pipelining (renamed from write_size)
 # ============================================================
 
-## each_record with write_size for batched writes
-# write_size controls how many records are processed before flushing writes
+## each_record with no pipeline param uses serial execution (safe-by-default)
+# Default behavior is no pipelining - each record processed individually
 records = []
-Customer.instances.each_record(write_size: 2) { |r| records << r if r.custid.start_with?(@test_prefix) }
+Customer.instances.each_record { |r| records << r if r.custid.start_with?(@test_prefix) }
 records.size
 #=> 5
 
-## each_record with write_size: nil for serial execution
+## each_record with pipeline: for batched writes
+# pipeline controls how many records are processed before flushing writes
+records = []
+Customer.instances.each_record(pipeline: 2) { |r| records << r if r.custid.start_with?(@test_prefix) }
+records.size
+#=> 5
+
+## each_record with pipeline: nil for explicit serial execution
 # Serial execution processes one at a time without batching
 records = []
-Customer.instances.each_record(write_size: nil) { |r| records << r if r.custid.start_with?(@test_prefix) }
+Customer.instances.each_record(pipeline: nil) { |r| records << r if r.custid.start_with?(@test_prefix) }
 records.size
 #=> 5
 
-## each_record with both batch_size and write_size
+## each_record with both batch_size and pipeline
 records = []
-Customer.instances.each_record(batch_size: 3, write_size: 2) { |r| records << r if r.custid.start_with?(@test_prefix) }
+Customer.instances.each_record(batch_size: 3, pipeline: 2) { |r| records << r if r.custid.start_with?(@test_prefix) }
 records.size
 #=> 5
 
@@ -244,24 +251,44 @@ records.size
 # Argument validation
 # ============================================================
 
-## each_record raises ArgumentError when write_size exceeds batch_size
+## each_record raises ArgumentError when pipeline exceeds batch_size
 begin
-  Customer.instances.each_record(batch_size: 10, write_size: 20) { |r| }
+  Customer.instances.each_record(batch_size: 10, pipeline: 20) { |r| }
   raised = false
 rescue ArgumentError => e
-  raised = e.message.include?('write_size') && e.message.include?('batch_size')
+  raised = e.message.include?('pipeline') && e.message.include?('batch_size')
 end
 raised
 #=> true
 
 ## each_record error message includes both values
 begin
-  Customer.instances.each_record(batch_size: 10, write_size: 20) { |r| }
+  Customer.instances.each_record(batch_size: 10, pipeline: 20) { |r| }
   ''
 rescue ArgumentError => e
   e.message
 end
-#=~ /write_size.*20.*batch_size.*10|batch_size.*10.*write_size.*20/
+#=~ /pipeline.*20.*batch_size.*10|batch_size.*10.*pipeline.*20/
+
+## each_record raises ArgumentError when pipeline is 0
+begin
+  Customer.instances.each_record(pipeline: 0) { |r| }
+  raised = false
+rescue ArgumentError => e
+  raised = e.message.include?('pipeline') && e.message.include?('positive')
+end
+raised
+#=> true
+
+## each_record raises ArgumentError when pipeline is negative
+begin
+  Customer.instances.each_record(pipeline: -1) { |r| }
+  raised = false
+rescue ArgumentError => e
+  raised = e.message.include?('pipeline') && e.message.include?('positive')
+end
+raised
+#=> true
 
 # ============================================================
 # Non-reference DataType error handling

--- a/try/unit/data_types/each_record_try.rb
+++ b/try/unit/data_types/each_record_try.rb
@@ -290,6 +290,16 @@ end
 raised
 #=> true
 
+## each_record raises ArgumentError when pipeline is non-integer
+begin
+  Customer.instances.each_record(pipeline: "10") { |r| }
+  raised = false
+rescue ArgumentError => e
+  raised = e.message.include?('pipeline') && e.message.include?('positive')
+end
+raised
+#=> true
+
 # ============================================================
 # Non-reference DataType error handling
 # ============================================================


### PR DESCRIPTION
Renames `write_size:` to `pipeline:` in `CollectionBase#each_record` and flips the default from pipelining-on to pipelining-off (`nil`).

- `pipeline: nil` (default) runs the block serially — no `pipelined {}` wrapper, no Redis::Future surprises, no ConflictingContextError on `save`/`transaction` calls
- Positive integer opts in to pipelining at that group size
- Validation rejects `0`, negatives, non-integers, and values exceeding `batch_size` with a clean ArgumentError at the API boundary
- Docs guide and migration examples updated to reflect new parameter name and safe-default semantics

Closes #270