### PR TITLE
Optimize bulk writes for collections with single Redis command

### DIFF
--- a/changelog.d/20260518_193907_claude_optimize_set_sadd.rst
+++ b/changelog.d/20260518_193907_claude_optimize_set_sadd.rst
@@ -1,0 +1,18 @@
+Changed
+-------
+
+- Bulk-write optimization for multi-value collection mutations. ``UnsortedSet#add``,
+  ``ListKey#push``, and ``ListKey#unshift`` previously issued one Redis command per
+  element (a loop of ``SADD``/``RPUSH``/``LPUSH`` calls), making large populations
+  slow even when pipelined. They now serialize all values and issue a single bulk
+  ``SADD``/``RPUSH``/``LPUSH`` command. Element ordering, ``nil`` compaction, nested
+  array flattening, return values, dirty-write warnings, and expiration cascading
+  are unchanged; empty calls remain no-ops. PR #269
+
+AI Assistance
+-------------
+
+- AI investigated all collection ``DataType`` classes for the same per-element
+  loop anti-pattern, identified the three affected methods, verified
+  behavior-preservation (ordering, edge cases, chainability) at the Redis wire
+  level, and confirmed zero regressions against the existing test suites.

--- a/changelog.d/20260518_193907_claude_optimize_set_sadd.rst
+++ b/changelog.d/20260518_193907_claude_optimize_set_sadd.rst
@@ -6,8 +6,11 @@ Added
   ``field => value`` -- so it follows the established ``HashKey#update``/``merge!``
   convention (a single Hash argument) rather than the variadic splat used by the
   value-only ``UnsortedSet``/``ListKey``. Pass ``{member => score}`` to issue one
-  ``ZADD`` instead of one round-trip per member. Validates the argument is a Hash,
-  cascades expiration, and is a no-op returning ``0`` for empty input. The
+  ``ZADD`` instead of one round-trip per member. Validates the argument is a Hash
+  and that every score is ``Numeric`` (a missing/``nil`` score raises a clear
+  ``ArgumentError`` instead of a low-level client error -- unlike single-value
+  ``#add``, the bulk path does not default a missing score to ``Familia.now``).
+  Cascades expiration, and is a no-op returning ``0`` for empty input. The
   single-value ``SortedSet#add`` (and its array-as-single-member contract) is
   unchanged. PR #269
 

--- a/changelog.d/20260518_193907_claude_optimize_set_sadd.rst
+++ b/changelog.d/20260518_193907_claude_optimize_set_sadd.rst
@@ -1,3 +1,16 @@
+Added
+-----
+
+- ``SortedSet#update`` (aliased ``merge!``) for bulk member insertion. A sorted
+  set is ``member => score`` -- the same pair shape as ``HashKey``'s
+  ``field => value`` -- so it follows the established ``HashKey#update``/``merge!``
+  convention (a single Hash argument) rather than the variadic splat used by the
+  value-only ``UnsortedSet``/``ListKey``. Pass ``{member => score}`` to issue one
+  ``ZADD`` instead of one round-trip per member. Validates the argument is a Hash,
+  cascades expiration, and is a no-op returning ``0`` for empty input. The
+  single-value ``SortedSet#add`` (and its array-as-single-member contract) is
+  unchanged. PR #269
+
 Changed
 -------
 
@@ -15,4 +28,8 @@ AI Assistance
 - AI investigated all collection ``DataType`` classes for the same per-element
   loop anti-pattern, identified the three affected methods, verified
   behavior-preservation (ordering, edge cases, chainability) at the Redis wire
-  level, and confirmed zero regressions against the existing test suites.
+  level, and confirmed zero regressions against the existing test suites. The
+  ``SortedSet#update`` API shape was chosen by priority order: existing Familia
+  conventions first (the ``HashKey#update``/``merge!`` precedent for keyed
+  collections), then the upstream redis-rb bulk ``ZADD`` form, then Ruby
+  ``Hash#merge!`` semantics as confirmation.

--- a/docs/guides/datatype-collections.md
+++ b/docs/guides/datatype-collections.md
@@ -3,9 +3,40 @@
 
 # DataType - Collection classes
 
-UnsortedSet, Sorted Set, List, and Hash data types all include the `Collection` module, which provides two main iteration methods: `each` and `each_record`. Both methods are designed to efficiently handle large collections by paginating through Valkey/Redis data structures, but they serve different purposes and yield different results.
+UnsortedSet, Sorted Set, List, and Hash data types all include the `Collection` module. This guide covers two performance-sensitive concerns: writing many elements efficiently (a single bulk command instead of one round-trip per element), and iterating large collections efficiently via `each` and `each_record`.
 
-Here's how the two methods iterate, using `ModelClass.instances` (a `SortedSet` with `reference: true`) as the running example.
+## Bulk writes — single round-trip mutations
+
+Collection mutations are **immediate** — every call hits Valkey/Redis right away, unlike scalar `field` setters which are deferred until `save`. Each call also runs `warn_if_dirty!` and cascades expiration. (See the write-model notes in `CLAUDE.md` for the deferred-vs-immediate split.)
+
+Multi-element adds issue **one** command for the whole batch, not one per element. Populating a large collection is therefore a single round-trip even without an explicit pipeline.
+
+The argument shape follows the collection's structure, and is consistent across the codebase:
+
+- **Value-only** collections (`UnsortedSet`, `ListKey`) take a **variadic splat**; arguments are flattened and `nil`-compacted.
+- **Keyed/pair** collections (`HashKey` is `field => value`, `SortedSet` is `member => score`) take a **single Hash** via `update` (aliased `merge!`), raising `ArgumentError` on a non-Hash.
+
+| Type | Bulk method | Call shape | Redis command |
+|---|---|---|---|
+| `UnsortedSet` | `add(*values)` | `tags.add(:a, :b, :c)` | one `SADD` |
+| `ListKey` | `push(*values)` / `unshift(*values)` | `log.push(1, 2, 3)` | one `RPUSH` / `LPUSH` |
+| `HashKey` | `update(hash)` / `merge!` | `cfg.update(a: 1, b: 2)` | one `HMSET` |
+| `SortedSet` | `update(hash)` / `merge!` | `board.update("alice" => 1000, "bob" => 850)` | one `ZADD` |
+
+```ruby
+tags.add(:ruby, :redis, :valkey)              # 1 SADD, returns self
+log.push("a", "b", "c")                        # 1 RPUSH → [a, b, c]
+board.update("alice" => 1000, "bob" => 850)    # 1 ZADD, returns new-member count (2)
+board.merge!("alice" => 1200)                  # 1 ZADD, score updated → returns 0
+```
+
+Behavior notes:
+
+- **Ordering**: `push` preserves argument order; `unshift` prepends each element in turn, so `unshift(a, b, c)` leaves the list head as `c, b, a` (Redis `LPUSH` semantics — unchanged from the prior per-element implementation). Sets are unordered; sorted sets order by score.
+- **Empty input is a no-op**: `add()` / `push()` / `update({})` issue no command. Set/list adds return `self`; `SortedSet#update` returns `0`.
+- **`SortedSet#add(val, score, …)` is unchanged and not bulk** — it takes a single member plus score and the conditional ZADD options (`nx:`, `xx:`, `gt:`, `lt:`, `ch:`). An Array passed as `val` is stored as one JSON-encoded member, not exploded into many. Use `update`/`merge!` for bulk insertion.
+
+The iteration methods `each` and `each_record` efficiently handle large collections by paginating through Valkey/Redis data structures, but they serve different purposes and yield different results. Here's how the two iterate, using `ModelClass.instances` (a `SortedSet` with `reference: true`) as the running example.
 
 ## `each` — yields **members** (identifiers, raw strings)
 

--- a/lib/familia/data_type/types/listkey.rb
+++ b/lib/familia/data_type/types/listkey.rb
@@ -25,7 +25,8 @@ module Familia
     def push *values
       warn_if_dirty!
       echo :push, Familia.pretty_stack(limit: 1) if Familia.debug
-      values.flatten.compact.each { |v| dbclient.rpush dbkey, serialize_value(v) }
+      serialized = values.flatten.compact.map { |v| serialize_value(v) }
+      dbclient.rpush(dbkey, serialized) unless serialized.empty?
       dbclient.ltrim dbkey, -@opts[:maxlength], -1 if @opts[:maxlength]
       update_expiration
       self
@@ -43,7 +44,8 @@ module Familia
     #   scalar field changes, consider calling save first to avoid split-brain state.
     def unshift *values
       warn_if_dirty!
-      values.flatten.compact.each { |v| dbclient.lpush dbkey, serialize_value(v) }
+      serialized = values.flatten.compact.map { |v| serialize_value(v) }
+      dbclient.lpush(dbkey, serialized) unless serialized.empty?
       # TODO: test maxlength
       dbclient.ltrim dbkey, 0, @opts[:maxlength] - 1 if @opts[:maxlength]
       update_expiration

--- a/lib/familia/data_type/types/sorted_set.rb
+++ b/lib/familia/data_type/types/sorted_set.rb
@@ -135,6 +135,39 @@ module Familia
     end
     alias add_element add
 
+    # Bulk-adds or updates multiple members in a single ZADD.
+    #
+    # Mirrors HashKey#update/merge! -- the established Familia pattern for
+    # bulk-setting keyed collections. A sorted set is member => score, the
+    # same pair shape as HashKey's field => value, so it takes a Hash rather
+    # than the variadic splat used by the value-only UnsortedSet/ListKey.
+    #
+    # Issues exactly one ZADD instead of one round-trip per member, which is
+    # what makes populating a large sorted set fast.
+    #
+    # @param hsh [Hash] Mapping of member => score (Object => Numeric)
+    # @return [Integer] Number of new members added (members whose score was
+    #   merely updated are not counted), per redis-rb's bulk ZADD return value
+    # @raise [ArgumentError] If the argument is not a Hash
+    #
+    # @example
+    #   board.update("alice" => 1000, "bob" => 850)  #=> 2
+    #   board.merge!("alice" => 1200)                 #=> 0 (score updated)
+    #
+    # @note Like #add, this executes immediately (not deferred) and cascades
+    #   expiration. Empty input is a no-op returning 0.
+    def update(hsh = {})
+      warn_if_dirty!
+      raise ArgumentError, 'Argument to bulk add must be a hash' unless hsh.is_a?(Hash)
+      return 0 if hsh.empty?
+
+      pairs = hsh.map { |member, score| [score, serialize_value(member)] }
+      ret = dbclient.zadd(dbkey, pairs)
+      update_expiration
+      ret
+    end
+    alias merge! update
+
     def score(val)
       ret = dbclient.zscore dbkey, serialize_value(val)
       ret&.to_f

--- a/lib/familia/data_type/types/sorted_set.rb
+++ b/lib/familia/data_type/types/sorted_set.rb
@@ -148,11 +148,17 @@ module Familia
     # @param hsh [Hash] Mapping of member => score (Object => Numeric)
     # @return [Integer] Number of new members added (members whose score was
     #   merely updated are not counted), per redis-rb's bulk ZADD return value
-    # @raise [ArgumentError] If the argument is not a Hash
+    # @raise [ArgumentError] If the argument is not a Hash, or any score is
+    #   not Numeric
     #
     # @example
     #   board.update("alice" => 1000, "bob" => 850)  #=> 2
     #   board.merge!("alice" => 1200)                 #=> 0 (score updated)
+    #
+    # @note Unlike single-value #add, scores are required: this bulk path does
+    #   not default a missing score to Familia.now. A non-Numeric score (e.g.
+    #   nil) raises ArgumentError rather than surfacing a low-level client
+    #   error.
     #
     # @note Like #add, this executes immediately (not deferred) and cascades
     #   expiration. Empty input is a no-op returning 0.
@@ -161,7 +167,13 @@ module Familia
       raise ArgumentError, 'Argument to bulk add must be a hash' unless hsh.is_a?(Hash)
       return 0 if hsh.empty?
 
-      pairs = hsh.map { |member, score| [score, serialize_value(member)] }
+      pairs = hsh.map do |member, score|
+        unless score.is_a?(Numeric)
+          raise ArgumentError, "SortedSet#update score for #{member.inspect} must be Numeric, got #{score.class}"
+        end
+
+        [score, serialize_value(member)]
+      end
       ret = dbclient.zadd(dbkey, pairs)
       update_expiration
       ret

--- a/lib/familia/data_type/types/unsorted_set.rb
+++ b/lib/familia/data_type/types/unsorted_set.rb
@@ -26,7 +26,8 @@ module Familia
     #   scalar field changes, consider calling save first to avoid split-brain state.
     def add *values
       warn_if_dirty!
-      values.flatten.compact.each { |v| dbclient.sadd? dbkey, serialize_value(v) }
+      serialized = values.flatten.compact.map { |v| serialize_value(v) }
+      dbclient.sadd?(dbkey, serialized) unless serialized.empty?
       update_expiration
       self
     end

--- a/try/unit/data_types/sorted_set_try.rb
+++ b/try/unit/data_types/sorted_set_try.rb
@@ -69,4 +69,35 @@ require_relative '../../support/helpers/test_helpers'
 @a.metrics.members
 #=> ['metric2']
 
+## Familia::SortedSet#update bulk-adds a Hash of member => score in one ZADD, returns new count
+@u = Bone.new 'zset_bulk_update'
+@u.metrics.update(alpha: 1, gamma: 3, beta: 2)
+#=> 3
+
+## Familia::SortedSet#update orders members by their given scores
+@u.metrics.members
+#=> ['alpha', 'beta', 'gamma']
+
+## Familia::SortedSet#merge! is an alias and updates existing scores (0 new members)
+@u.metrics.merge!(alpha: 10)
+#=> 0
+
+## Familia::SortedSet#merge! re-scored member moves position
+@u.metrics.members
+#=> ['beta', 'gamma', 'alpha']
+
+## Familia::SortedSet#update with empty Hash is a no-op returning 0
+@u.metrics.update({})
+#=> 0
+
+## Familia::SortedSet#update raises ArgumentError on non-Hash argument
+begin
+  @u.metrics.update([:not, :a, :hash])
+  :no_error
+rescue ArgumentError => e
+  e.message
+end
+#=> 'Argument to bulk add must be a hash'
+
+@u.metrics.delete!
 @a.metrics.delete!

--- a/try/unit/data_types/sorted_set_try.rb
+++ b/try/unit/data_types/sorted_set_try.rb
@@ -99,5 +99,18 @@ rescue ArgumentError => e
 end
 #=> 'Argument to bulk add must be a hash'
 
+## Familia::SortedSet#update raises a clear ArgumentError on a non-Numeric score (not auto-defaulted like #add)
+begin
+  @u.metrics.update('alice' => 1000, 'bob' => nil)
+  :no_error
+rescue ArgumentError => e
+  e.message
+end
+#=> 'SortedSet#update score for "bob" must be Numeric, got NilClass'
+
+## Familia::SortedSet#update rejects a bad score before issuing the ZADD (alice not added)
+@u.metrics.member?('alice')
+#=> false
+
 @u.metrics.delete!
 @a.metrics.delete!


### PR DESCRIPTION
Closes #269.

## Summary

This PR optimizes bulk write operations across collection types by issuing a single Redis command instead of one per element, significantly improving performance when populating large collections.

## Key Changes

- **`SortedSet#update` (aliased `merge!`)**: New method for bulk member insertion following the `HashKey#update`/`merge!` convention. Takes a Hash of `member => score` pairs and issues a single `ZADD` command. Returns the count of newly added members (score updates don't increment the count).

- **`UnsortedSet#add`**: Refactored to serialize all values and issue a single `SADD` command instead of looping with one command per element.

- **`ListKey#push` and `ListKey#unshift`**: Refactored to serialize all values and issue a single `RPUSH`/`LPUSH` command instead of looping with one command per element.

## Implementation Details

- All three collection methods maintain backward compatibility: element ordering, `nil` compaction, nested array flattening, return values, dirty-write warnings, and expiration cascading are unchanged.
- Empty calls remain no-ops returning `0` or `self` as appropriate.
- `SortedSet#update` validates that the argument is a Hash and raises `ArgumentError` otherwise.
- The `SortedSet#update` API shape follows Familia conventions (keyed collections use Hash arguments like `HashKey#update`) rather than the variadic splat used by value-only collections.

## Testing

Comprehensive test cases added to `sorted_set_try.rb` covering:
- Bulk insertion with score ordering
- Score updates (returning 0 new members)
- Empty Hash handling
- ArgumentError on non-Hash input
- Alias verification (`merge!`)

https://claude.ai/code/session_01XBxnGGuBK7Hb6iTkjxeNBg