### PR TITLE
Allow fast writers in transaction/pipeline contexts

### DIFF
--- a/lib/familia/data_type/types/json_stringkey.rb
+++ b/lib/familia/data_type/types/json_stringkey.rb
@@ -108,7 +108,7 @@ module Familia
     #
     def del
       ret = dbclient.del dbkey
-      ret.positive?
+      Familia.positive?(ret)
     end
 
     # Checks if the value is nil (key does not exist or has no value).

--- a/lib/familia/data_type/types/listkey.rb
+++ b/lib/familia/data_type/types/listkey.rb
@@ -230,7 +230,7 @@ module Familia
               raise ArgumentError, "position must be :before or :after, got #{position.inspect}"
             end
       result = dbclient.linsert dbkey, pos, serialize_value(pivot), serialize_value(value)
-      update_expiration if result.positive?
+      update_expiration if Familia.positive?(result) == true
       result
     end
     alias linsert insert
@@ -267,7 +267,7 @@ module Familia
 
       warn_if_dirty!
       result = dbclient.rpushx(dbkey, serialized_values)
-      update_expiration if result.positive?
+      update_expiration if Familia.positive?(result) == true
       result
     end
     alias rpushx pushx
@@ -283,7 +283,7 @@ module Familia
 
       warn_if_dirty!
       result = dbclient.lpushx(dbkey, serialized_values)
-      update_expiration if result.positive?
+      update_expiration if Familia.positive?(result) == true
       result
     end
     alias lpushx unshiftx

--- a/lib/familia/data_type/types/stringkey.rb
+++ b/lib/familia/data_type/types/stringkey.rb
@@ -233,7 +233,7 @@ module Familia
 
     def del
       ret = dbclient.del dbkey
-      ret.positive?
+      Familia.positive?(ret)
     end
 
     # Class methods for multi-key operations

--- a/lib/familia/features/encrypted_fields/encrypted_field_type.rb
+++ b/lib/familia/features/encrypted_fields/encrypted_field_type.rb
@@ -108,25 +108,7 @@ module Familia
         klass.define_method fast_method_name do |val|
           raise ArgumentError, "#{fast_method_name} requires a value" if val.nil?
 
-          # Prevent fast writer within transaction/pipeline - the return value
-          # would be Redis::Future which doesn't support zero?/positive? checks
-          if Fiber[:familia_transaction]
-            Familia.trace :FAST_WRITER_BLOCKED, dbkey,
-                         "#{fast_method_name} blocked by active transaction context"
-            raise Familia::OperationModeError, <<~ERROR_MESSAGE.chomp
-              Cannot call fast writer #{fast_method_name} within a transaction.
-              Use multi_field_update or commit_fields instead.
-            ERROR_MESSAGE
-          elsif Fiber[:familia_pipeline]
-            Familia.trace :FAST_WRITER_BLOCKED, dbkey,
-                         "#{fast_method_name} blocked by active pipeline context"
-            raise Familia::OperationModeError, <<~ERROR_MESSAGE.chomp
-              Cannot call fast writer #{fast_method_name} within a pipeline.
-              Restructure to call fast writers outside the pipeline.
-            ERROR_MESSAGE
-          end
-
-          # UnsortedSet via the setter method to get proper ConcealedString wrapping
+          # Use via the setter method to get proper ConcealedString wrapping
           send(:"#{method_name}=", val) if method_name
 
           # Get the ConcealedString and extract encrypted data for storage
@@ -136,7 +118,7 @@ module Familia
           return false if encrypted_data.nil?
 
           ret = hset(field_name, encrypted_data)
-          ret.zero? || ret.positive?
+          ret.is_a?(Redis::Future) ? ret : (ret.zero? || ret.positive?)
         end
       end
     end

--- a/lib/familia/features/encrypted_fields/encrypted_field_type.rb
+++ b/lib/familia/features/encrypted_fields/encrypted_field_type.rb
@@ -118,7 +118,7 @@ module Familia
           return false if encrypted_data.nil?
 
           ret = hset(field_name, encrypted_data)
-          ret.is_a?(Redis::Future) ? ret : (ret.zero? || ret.positive?)
+          Familia.success?(ret)
         end
       end
     end

--- a/lib/familia/features/expiration.rb
+++ b/lib/familia/features/expiration.rb
@@ -342,7 +342,7 @@ module Familia
       # @return [Boolean] true if TTL is set, false if data persists indefinitely
       #
       def expires?
-        ttl.positive?
+        Familia.positive?(ttl)
       end
 
       # Check if this object's data has expired or will expire soon
@@ -377,7 +377,7 @@ module Familia
       #
       def extend_expiration(duration)
         current_ttl = ttl
-        return false unless current_ttl.positive? # no current expiration set
+        return false unless Familia.positive?(current_ttl) == true # no current expiration set
 
         new_ttl = current_ttl + duration.to_f
         expire(new_ttl)

--- a/lib/familia/field_type.rb
+++ b/lib/familia/field_type.rb
@@ -174,7 +174,7 @@ module Familia
 
             clear_dirty!(field_name) if respond_to?(:clear_dirty!)
 
-            ret.is_a?(Redis::Future) ? ret : (ret.zero? || ret.positive?)
+            Familia.success?(ret)
           rescue Familia::Problem => e
             raise "#{fast_method_name} method failed: #{e.message}", e.backtrace
           end

--- a/lib/familia/field_type.rb
+++ b/lib/familia/field_type.rb
@@ -154,24 +154,6 @@ module Familia
           # Handle Redis::Future objects during transactions
           return hget(field_name) if val.nil? || val.is_a?(Redis::Future)
 
-          # Prevent fast writer within transaction/pipeline - the return value
-          # would be Redis::Future which doesn't support zero?/positive? checks
-          if Fiber[:familia_transaction]
-            Familia.trace :FAST_WRITER_BLOCKED, dbkey,
-                         "#{fast_method_name} blocked by active transaction context"
-            raise Familia::OperationModeError, <<~ERROR_MESSAGE.chomp
-              Cannot call fast writer #{fast_method_name} within a transaction.
-              Use multi_field_update or commit_fields instead.
-            ERROR_MESSAGE
-          elsif Fiber[:familia_pipeline]
-            Familia.trace :FAST_WRITER_BLOCKED, dbkey,
-                         "#{fast_method_name} blocked by active pipeline context"
-            raise Familia::OperationModeError, <<~ERROR_MESSAGE.chomp
-              Cannot call fast writer #{fast_method_name} within a pipeline.
-              Restructure to call fast writers outside the pipeline.
-            ERROR_MESSAGE
-          end
-
           begin
             # Trace the operation if debugging is enabled
             Familia.trace :FAST_WRITER, nil, "#{field_name}: #{val.inspect}" if Familia.debug?
@@ -192,7 +174,7 @@ module Familia
 
             clear_dirty!(field_name) if respond_to?(:clear_dirty!)
 
-            ret.zero? || ret.positive?
+            ret.is_a?(Redis::Future) ? ret : (ret.zero? || ret.positive?)
           rescue Familia::Problem => e
             raise "#{fast_method_name} method failed: #{e.message}", e.backtrace
           end

--- a/lib/familia/horreum/definition.rb
+++ b/lib/familia/horreum/definition.rb
@@ -500,7 +500,7 @@ module Familia
 
               clear_dirty!(field_name) if respond_to?(:clear_dirty!)
 
-              ret.is_a?(Redis::Future) ? ret : (ret.zero? || ret.positive?)
+              Familia.success?(ret)
             rescue Familia::Problem => e
               # Raise a custom error message if an exception occurs during the execution of the method.
               raise "#{fast_method_name} method failed: #{e.message}", e.backtrace

--- a/lib/familia/horreum/definition.rb
+++ b/lib/familia/horreum/definition.rb
@@ -480,24 +480,6 @@ module Familia
             # Handle Redis::Future objects during transactions
             return hget field_name if val.nil? || val.is_a?(Redis::Future)
 
-            # Prevent fast writer within transaction/pipeline - the return value
-            # would be Redis::Future which doesn't support zero?/positive? checks
-            if Fiber[:familia_transaction]
-              Familia.trace :FAST_WRITER_BLOCKED, dbkey,
-                           "#{fast_method_name} blocked by active transaction context"
-              raise Familia::OperationModeError, <<~ERROR_MESSAGE.chomp
-                Cannot call fast writer #{fast_method_name} within a transaction.
-                Use multi_field_update or commit_fields instead.
-              ERROR_MESSAGE
-            elsif Fiber[:familia_pipeline]
-              Familia.trace :FAST_WRITER_BLOCKED, dbkey,
-                           "#{fast_method_name} blocked by active pipeline context"
-              raise Familia::OperationModeError, <<~ERROR_MESSAGE.chomp
-                Cannot call fast writer #{fast_method_name} within a pipeline.
-                Restructure to call fast writers outside the pipeline.
-              ERROR_MESSAGE
-            end
-
             begin
               # Trace the operation if debugging is enabled.
               Familia.trace :FAST_WRITER, nil, "#{field_name}: #{val.inspect}" if Familia.debug?
@@ -518,7 +500,7 @@ module Familia
 
               clear_dirty!(field_name) if respond_to?(:clear_dirty!)
 
-              ret.zero? || ret.positive?
+              ret.is_a?(Redis::Future) ? ret : (ret.zero? || ret.positive?)
             rescue Familia::Problem => e
               # Raise a custom error message if an exception occurs during the execution of the method.
               raise "#{fast_method_name} method failed: #{e.message}", e.backtrace

--- a/lib/familia/horreum/management.rb
+++ b/lib/familia/horreum/management.rb
@@ -158,7 +158,7 @@ module Familia
           # Safe mode: Check existence first (original behavior)
           # We use a lower-level method here b/c we're working with the
           # full key and not just the identifier.
-          does_exist = dbclient.exists(objkey).positive?
+          does_exist = Familia.positive?(dbclient.exists(objkey))
 
           Familia.debug "[find_by_key] #{self} from key #{objkey} (exists: #{does_exist})"
           Familia.trace :FIND_BY_DBKEY_KEY, nil, objkey

--- a/lib/familia/utils.rb
+++ b/lib/familia/utils.rb
@@ -8,6 +8,54 @@ module Familia
   module Utils
     using Familia::Refinements::TimeLiterals
 
+    # Future-aware success check for Redis command return values.
+    #
+    # Redis commands like HSET return 0 (updated existing) or 1 (created new).
+    # Both are success states. Inside a pipeline or transaction, the return
+    # value is a Redis::Future which cannot be inspected until the block
+    # completes.
+    #
+    # @param ret [Integer, Redis::Future] The return value from a Redis command
+    # @return [Boolean, Redis::Future] true/false for concrete values,
+    #   passthrough for Futures
+    #
+    # @example Normal usage
+    #   ret = dbclient.hset(key, field, value)
+    #   Familia.success?(ret)  #=> true (for 0 or 1)
+    #
+    # @example Inside pipeline
+    #   pipelined do
+    #     ret = dbclient.hset(key, field, value)
+    #     Familia.success?(ret)  #=> Redis::Future (passthrough)
+    #   end
+    #
+    def success?(ret)
+      ret.is_a?(Redis::Future) ? ret : (ret.zero? || ret.positive?)
+    end
+
+    # Future-aware positive check for Redis command return values.
+    #
+    # For commands where 0 means "nothing happened" and positive means
+    # "something happened" (e.g., EXISTS, DEL, LINSERT, TTL checks).
+    #
+    # @param ret [Integer, Redis::Future] The return value from a Redis command
+    # @return [Boolean, Redis::Future] true/false for concrete values,
+    #   passthrough for Futures
+    #
+    # @example Check if key exists
+    #   ret = dbclient.exists(key)
+    #   Familia.positive?(ret)  #=> true if key exists
+    #
+    # @example Check TTL inside pipeline
+    #   pipelined do
+    #     ret = dbclient.ttl(key)
+    #     Familia.positive?(ret)  #=> Redis::Future (passthrough)
+    #   end
+    #
+    def positive?(ret)
+      ret.is_a?(Redis::Future) ? ret : ret.positive?
+    end
+
     # Joins array elements with Familia delimiter
     # @param val [Array] elements to join
     # @return [String] joined string

--- a/try/edge_cases/fast_writer_pipeline_support_try.rb
+++ b/try/edge_cases/fast_writer_pipeline_support_try.rb
@@ -1,0 +1,80 @@
+require_relative '../support/helpers/test_helpers'
+
+Familia.debug = false
+
+# Test class for fast writer pipeline/transaction support
+class FastWriterPipelineTest < Familia::Horreum
+  identifier_field :testid
+  field :testid
+  field :name
+  field :planid
+  field :region
+end
+
+# Clean slate
+@obj = FastWriterPipelineTest.new(testid: 'fw-pipeline-test', name: 'initial', planid: 'old_plan')
+@obj.destroy!
+@obj.save
+
+## Fast writer inside pipeline returns Redis::Future
+result = nil
+@obj.pipelined do
+  result = @obj.planid!('new_plan_v1')
+end
+result.is_a?(Redis::Future)
+#=> true
+
+## Fast writer value is persisted after pipeline completes
+@obj.refresh!
+@obj.planid
+#=> 'new_plan_v1'
+
+## Multiple fast writers inside single pipeline all return Futures
+results = []
+@obj.pipelined do
+  results << @obj.planid!('plan_v2')
+  results << @obj.region!('ca-east-1')
+end
+results.all? { |r| r.is_a?(Redis::Future) }
+#=> true
+
+## Multiple fast writer values persisted after pipeline
+@obj.refresh!
+[@obj.planid, @obj.region]
+#=> ['plan_v2', 'ca-east-1']
+
+## Fast writer inside transaction returns Redis::Future
+result = nil
+@obj.transaction do
+  result = @obj.name!('tx-updated')
+end
+result.is_a?(Redis::Future)
+#=> true
+
+## Fast writer value is persisted after transaction completes
+@obj.refresh!
+@obj.name
+#=> 'tx-updated'
+
+## touch_instances! is called during pipelined fast writer
+@obj.class.instances.remove(@obj)
+raise "Setup failed: should not be member" if @obj.class.instances.member?(@obj.identifier)
+@obj.pipelined do
+  @obj.planid!('plan_v3')
+end
+@obj.class.instances.member?(@obj.identifier)
+#=> true
+
+## touch_instances! is called during transaction fast writer
+@obj.class.instances.remove(@obj)
+raise "Setup failed: should not be member" if @obj.class.instances.member?(@obj.identifier)
+@obj.transaction do
+  @obj.name!('tx-touch-test')
+end
+@obj.class.instances.member?(@obj.identifier)
+#=> true
+
+## Cleanup
+@obj.destroy!
+true
+#=> true

--- a/try/edge_cases/fast_writer_transaction_guard_try.rb
+++ b/try/edge_cases/fast_writer_transaction_guard_try.rb
@@ -8,7 +8,7 @@ test_keys = { v1: Base64.strict_encode64('a' * 32) }
 Familia.config.encryption_keys = test_keys
 Familia.config.current_key_version = :v1
 
-# Test class for fast writer transaction/pipeline guards
+# Test class for fast writer transaction/pipeline behavior
 class FastWriterGuardTest < Familia::Horreum
   identifier_field :testid
   field :testid
@@ -16,7 +16,7 @@ class FastWriterGuardTest < Familia::Horreum
   field :value
 end
 
-# Test class for encrypted fast writer guards
+# Test class for encrypted fast writer behavior
 class EncryptedFastWriterGuardTest < Familia::Horreum
   feature :encrypted_fields
   identifier_field :testid
@@ -29,61 +29,43 @@ end
 @testobj.destroy!
 @testobj.save
 
-## Fast writer raises OperationModeError inside transaction
-begin
-  @testobj.transaction do
-    @testobj.name!('inside-transaction')
-  end
-  :should_have_raised
-rescue Familia::OperationModeError => e
-  e.message.include?('Cannot call fast writer')
+## Fast writer inside transaction returns Redis::Future
+result = nil
+@testobj.transaction do
+  result = @testobj.name!('inside-transaction')
 end
+result.is_a?(Redis::Future)
 #=> true
 
-## Fast writer raises OperationModeError inside pipeline
-begin
-  @testobj.pipelined do
-    @testobj.name!('inside-pipeline')
-  end
-  :should_have_raised
-rescue Familia::OperationModeError => e
-  e.message.include?('Cannot call fast writer')
+## Fast writer value is persisted after transaction completes
+@testobj.refresh
+@testobj.name
+#=> 'inside-transaction'
+
+## Fast writer inside pipeline returns Redis::Future
+result = nil
+@testobj.pipelined do
+  result = @testobj.value!('inside-pipeline')
 end
+result.is_a?(Redis::Future)
 #=> true
 
-## Transaction error message suggests multi_field_update or commit_fields
-begin
-  @testobj.transaction do
-    @testobj.name!('inside-transaction')
-  end
-  :should_have_raised
-rescue Familia::OperationModeError => e
-  e.message.include?('multi_field_update') && e.message.include?('commit_fields')
-end
-#=> true
-
-## Pipeline error message suggests restructuring (not multi_field_update)
-begin
-  @testobj.pipelined do
-    @testobj.name!('inside-pipeline')
-  end
-  :should_have_raised
-rescue Familia::OperationModeError => e
-  e.message.include?('Restructure') && !e.message.include?('multi_field_update')
-end
-#=> true
-
-## Fast writer works normally outside transaction
-@testobj.value!('direct-write')
+## Fast writer value is persisted after pipeline completes
+@testobj.refresh
 @testobj.value
-#=> 'direct-write'
+#=> 'inside-pipeline'
+
+## Fast writer works normally outside transaction (returns boolean)
+result = @testobj.name!('direct-write')
+[true, false].include?(result)
+#=> true
 
 ## Fast writer as getter works inside transaction (returns Future)
 result = nil
 @testobj.transaction do
   result = @testobj.value!
 end
-result.is_a?(Redis::Future) || result == 'direct-write'
+result.is_a?(Redis::Future) || result == 'inside-pipeline'
 #=> true
 
 ## Fast writer works after transaction completes
@@ -94,29 +76,28 @@ end
 @testobj.value
 #=> 'after-transaction'
 
-## Encrypted fast writer raises OperationModeError inside transaction
+## Encrypted fast writer inside transaction returns Redis::Future
 @encrypted = EncryptedFastWriterGuardTest.new(testid: 'enc-fw-guard-test')
 @encrypted.destroy!
 @encrypted.save
-begin
-  @encrypted.transaction do
-    @encrypted.secret!('sensitive-data')
-  end
-  :should_have_raised
-rescue Familia::OperationModeError => e
-  e.message.include?('Cannot call fast writer')
+result = nil
+@encrypted.transaction do
+  result = @encrypted.secret!('sensitive-data')
 end
+result.is_a?(Redis::Future)
 #=> true
 
-## Encrypted fast writer raises OperationModeError inside pipeline
-begin
-  @encrypted.pipelined do
-    @encrypted.secret!('sensitive-data')
-  end
-  :should_have_raised
-rescue Familia::OperationModeError => e
-  e.message.include?('Cannot call fast writer')
+## Encrypted fast writer value is persisted after transaction
+@encrypted.refresh
+@encrypted.secret.to_s.length > 0
+#=> true
+
+## Encrypted fast writer inside pipeline returns Redis::Future
+result = nil
+@encrypted.pipelined do
+  result = @encrypted.secret!('updated-secret')
 end
+result.is_a?(Redis::Future)
 #=> true
 
 ## Cleanup

--- a/try/unit/horreum/destroy_related_fields_cleanup_try.rb
+++ b/try/unit/horreum/destroy_related_fields_cleanup_try.rb
@@ -314,19 +314,19 @@ class TestModelWithInit < Familia::Horreum
 end
 
 # Create object - init should set region based on user_id
-init_obj = TestModelWithInit.new(user_id: "us-west-123")
+init_obj = TestModelWithInit.new(user_id: "ca-west-123")
 init_obj.save
 init_obj.activities << "login"
 init_obj.activities << "purchase"
 
 # Verify init worked and region is set
-region_set_correctly = init_obj.region == "us"
+region_set_correctly = init_obj.region == "ca"
 
 # Verify related field key includes region (would be nil without fix)
 activities_key = init_obj.activities.dbkey
 
 # Destroy using class method - temp instance init should execute with identifier
-TestModelWithInit.destroy!("us-west-123")
+TestModelWithInit.destroy!("ca-west-123")
 
 # Verify all keys are cleaned up (including activities with correct key)
 activities_cleaned = TestModelWithInit.dbclient.exists(activities_key).zero?

--- a/try/unit/utils/future_aware_helpers_try.rb
+++ b/try/unit/utils/future_aware_helpers_try.rb
@@ -1,0 +1,128 @@
+# try/unit/utils/future_aware_helpers_try.rb
+#
+# frozen_string_literal: true
+
+# Direct unit tests for Familia.success? and Familia.positive? —
+# the Future-aware utility methods added to Familia::Utils.
+#
+# These methods handle two cases:
+#   1. Concrete Integer return values from Redis commands
+#   2. Redis::Future objects inside pipelines/transactions (passthrough)
+#
+# Call sites include fast writers, DEL operations, EXISTS checks,
+# LINSERT results, and TTL comparisons.
+
+require_relative '../../support/helpers/test_helpers'
+
+Familia.debug = false
+
+@test_key = 'familia:test:future_aware_helpers'
+
+##
+## Familia.success? — concrete values
+##
+
+## success? returns true for positive integer (new key created)
+Familia.success?(1)
+#=> true
+
+## success? returns true for zero (existing key updated)
+Familia.success?(0)
+#=> true
+
+## success? returns false for negative integer
+Familia.success?(-1)
+#=> false
+
+## success? returns false for large negative
+Familia.success?(-100)
+#=> false
+
+##
+## Familia.positive? — concrete values
+##
+
+## positive? returns true for positive integer
+Familia.positive?(1)
+#=> true
+
+## positive? returns true for large positive integer
+Familia.positive?(5)
+#=> true
+
+## positive? returns false for zero (nothing happened)
+Familia.positive?(0)
+#=> false
+
+## positive? returns false for negative integer
+Familia.positive?(-1)
+#=> false
+
+##
+## Redis::Future passthrough — inside a pipeline
+##
+
+## success? returns the Future unchanged inside a pipeline
+@success_future = nil
+Familia.dbclient.pipelined do |pipe|
+  fut = pipe.hset(@test_key, 'field', 'val')
+  @success_future = Familia.success?(fut)
+end
+@success_future.is_a?(Redis::Future)
+#=> true
+
+## success? Future resolves to a truthy result after pipeline completes
+@success_future.value.zero? || @success_future.value.positive?
+#=> true
+
+## positive? returns the Future unchanged inside a pipeline
+@positive_future = nil
+Familia.dbclient.pipelined do |pipe|
+  fut = pipe.exists(@test_key)
+  @positive_future = Familia.positive?(fut)
+end
+@positive_future.is_a?(Redis::Future)
+#=> true
+
+## positive? Future resolves to truthy for an existing key after pipeline
+@positive_future.value.positive?
+#=> true
+
+##
+## Edge cases — nil and non-numeric raise NoMethodError
+##
+
+## success? raises for nil input (no guard — explicit contract)
+begin
+  Familia.success?(nil)
+rescue NoMethodError => e
+  e.class
+end
+#=> NoMethodError
+
+## positive? raises for nil input
+begin
+  Familia.positive?(nil)
+rescue NoMethodError => e
+  e.class
+end
+#=> NoMethodError
+
+## success? raises for string input
+begin
+  Familia.success?('ok')
+rescue NoMethodError => e
+  e.class
+end
+#=> NoMethodError
+
+## positive? raises for string input
+begin
+  Familia.positive?('ok')
+rescue NoMethodError => e
+  e.class
+end
+#=> NoMethodError
+
+# Teardown
+Familia.dbclient.del(@test_key)


### PR DESCRIPTION
Fast writers previously blocked inside transactions and pipelines to prevent NoMethodError from calling .zero?/.positive? on Redis::Future.

Instead of blocking, now return Future passthrough when in transaction/pipeline mode, boolean otherwise:
  ret.is_a?(Redis::Future) ? ret : (ret.zero? || ret.positive?)

This enables housekeeping chores and batch operations to use fast writers inside pipelined blocks while preserving the useful boolean return value for normal (non-batched) usage.

touch_instances! already documented as transaction/pipeline-safe, so no changes needed there.