### PR TITLE
[#280] Encrypted-field AAD transient fix + envelope versioning + key_material

### DIFF
--- a/changelog.d/20260603_000000_claude_280_aad_key_material.rst
+++ b/changelog.d/20260603_000000_claude_280_aad_key_material.rst
@@ -1,0 +1,52 @@
+Added
+-----
+
+- ``encrypted_field`` now accepts a ``key_material:`` option: a proc returning
+  additional entropy that is mixed into key derivation (BLAKE2b context),
+  separate from ``aad_fields``. Unlike AAD (which binds via the authentication
+  tag, so a wrong value fails with an auth mismatch), wrong ``key_material``
+  derives a different key entirely and produces garbage output. Use it to bind
+  ciphertext to a value the holder must supply at decrypt time, e.g.
+  ``key_material: ->(rec) { rec.passphrase }``. The proc may return a
+  ``RedactedString`` (its real value is extracted via ``.value``). When used,
+  the envelope records ``key_material_fields`` so decryption knows to re-apply
+  the proc. PR #280
+
+- Encrypted-field envelopes now carry an internal ``envelope_version`` (``2``)
+  plus the ``aad_fields`` used at encrypt time. Decryption rebuilds AAD from the
+  envelope's own field list rather than the current class declaration, so
+  changing a model's ``aad_fields`` no longer breaks previously-encrypted values.
+  Envelopes without a version fall back to the legacy class-level path. PR #280
+
+Fixed
+-----
+
+- ``aad_fields`` containing a ``transient_field`` now bind to the field's real
+  value. Previously ``build_aad`` called ``RedactedString#to_s``, which returns
+  ``"[REDACTED]"`` for every value -- so all passphrases produced identical AAD
+  and the binding was defeated. AAD now extracts the underlying value via
+  ``RedactedString#value``. PR #280
+
+Security
+--------
+
+- The ``aad_fields`` transient-field fix changes AAD output for any field that
+  lists a ``transient_field``. Values encrypted by an earlier release using a
+  transient field in ``aad_fields`` were bound to ``"[REDACTED]"`` and will no
+  longer decrypt after upgrading (they had no real binding to begin with). This
+  affects transient ``aad_fields`` only; regular fields are unchanged. Re-encrypt
+  affected values if any exist. PR #280
+
+AI Assistance
+-------------
+
+- AI reviewed the initial #280 implementation, identifying that envelope
+  serialization was hand-rolled in ``EncryptedFieldType`` while the
+  ``EncryptedData`` value object was extended but bypassed. Refactored so
+  envelope construction/parsing flows through ``EncryptedData`` (``with_metadata``,
+  ``to_json``, ``has_key_material?``, ``stored_aad_fields``), collapsed duplicate
+  AAD builders into one ``build_aad(record, fields:)``, extracted shared
+  ``RedactedString`` unwrapping and context-entropy helpers, and made
+  ``envelope_version`` load-bearing by branching the decrypt path on it. Added
+  test coverage for the value-object round-trips and version branching, including
+  the backward-incompatible transient-AAD edge case.

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -1,0 +1,87 @@
+# Getting Started with Familia
+
+This guide covers the core mental models you need to work effectively with Familia. If you're coming from ActiveRecord or another ORM, understanding these differences upfront will save debugging time.
+
+## DataTypes: Live Proxies, Not Cached Relations
+
+DataTypes (`list`, `set`, `zset`, `hashkey`) are *live proxies* to Redis keys, not cached relation objects. This is the most important conceptual difference from ActiveRecord.
+
+| Aspect | ActiveRecord Relation | Familia DataType |
+|--------|----------------------|------------------|
+| Object identity | New object per query | Same object every call (memoized) |
+| Data caching | Can memoize loaded records | No cache — every read hits Redis |
+| Mutability | Mutable (chainable) | Frozen at creation |
+
+```ruby
+# ActiveRecord: new relation object each time, can cache results
+User.where(active: true).object_id != User.where(active: true).object_id
+
+# Familia: same frozen wrapper, always hits Redis
+User.instances.object_id == User.instances.object_id  # true
+User.instances.frozen?                                 # true
+User.instances.to_a  # hits Redis now
+User.instances.to_a  # hits Redis again
+```
+
+### Why This Matters
+
+**Testing**: Class-level DataTypes (like `instances`) are frozen for thread safety. Attempting `define_singleton_method` on them raises `FrozenError`. To stub behavior in tests, stub the class method that returns the DataType, not the DataType instance itself:
+
+```ruby
+# Won't work — raises FrozenError
+User.instances.define_singleton_method(:member?) { |_| true }
+
+# Works — stub the class method
+allow(User).to receive(:instances).and_return(mock_sorted_set)
+
+# Or stub a method on the class that uses instances
+allow(ApiConfig).to receive(:delete_for_domain!).and_return(true)
+```
+
+**Performance**: Since every read hits Redis, batch operations when possible:
+
+```ruby
+# Inefficient: N Redis calls
+ids.each { |id| User.instances.member?(id) }
+
+# Better: single pipeline
+User.dbclient.pipelined do
+  ids.each { |id| User.instances.member?(id) }
+end
+```
+
+## Scalar Fields vs Collection Fields
+
+Familia has a two-tier write model. Understanding when data hits Redis is critical.
+
+**Scalar fields** (`field`) use deferred writes:
+- Setters update in-memory only until `save` is called
+- Fast writers (`field_name!`) write immediately
+
+**Collection fields** (`list`, `set`, `zset`, `hashkey`) use immediate writes:
+- Every mutating method executes the Redis command right away
+- Cannot be rolled back if a subsequent operation fails
+
+```ruby
+# Safe pattern: scalars first, then collections
+plan.name = "Premium"
+plan.save
+
+plan.features.clear      # immediate Redis DEL
+plan.features.add("sso") # immediate Redis SADD
+
+# Or use atomic_write for all-or-nothing
+plan.atomic_write do
+  plan.name = "Premium"
+  plan.features.clear
+  plan.features.add("sso")
+end
+```
+
+See [Transaction Safety](../transaction_safety.md) for details.
+
+## Next Steps
+
+- [Field System](field-system.md) — field definitions and types
+- [Feature System](feature-system.md) — modular capabilities
+- [DataType Collections](datatype-collections.md) — working with lists, sets, and hashes

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -9,6 +9,10 @@ Welcome to the comprehensive documentation for Familia v2.0. This guide collecti
 
 ## 📚 Guide Structure
 
+### 🚀 Getting Started
+
+0. **[Getting Started](getting-started.md)** - Mental models and key concepts for developers new to Familia
+
 ### 🏗️ Architecture & System Design
 
 1. **[Feature System](feature-system.md)** - Modular architecture with dependencies and autoloader patterns

--- a/lib/familia/data_type.rb
+++ b/lib/familia/data_type.rb
@@ -18,6 +18,18 @@ module Familia
   # This class provides common functionality for various Database data types
   # such as String, JsonStringKey, List, UnsortedSet, SortedSet, and HashKey.
   #
+  # == Mental Model: Live Proxies, Not Cached Relations
+  #
+  # Unlike ActiveRecord relations which return new objects that can cache
+  # loaded records, DataType instances are:
+  #
+  # - **Memoized**: Same object on every access (stable object_id)
+  # - **Uncached**: Every read method hits Redis — no local data cache
+  # - **Frozen**: Class-level DataTypes are frozen for thread safety
+  #
+  # This means `define_singleton_method` raises FrozenError on class-level
+  # DataTypes. To stub in tests, stub the class method returning the DataType.
+  #
   # == Write Method Transaction Safety Audit (2026-02-25)
   #
   # All write methods use dbclient which is transaction-aware: inside a

--- a/lib/familia/encryption/encrypted_data.rb
+++ b/lib/familia/encryption/encrypted_data.rb
@@ -18,6 +18,28 @@ module Familia
         super.compact
       end
 
+      def to_json(*_args)
+        Familia::JsonSerializer.dump(to_h)
+      end
+
+      def with_metadata(envelope_version: self.envelope_version, aad_fields: self.aad_fields,
+                         key_material_fields: self.key_material_fields)
+        self.class.new(
+          algorithm: algorithm, nonce: nonce, ciphertext: ciphertext,
+          auth_tag: auth_tag, key_version: key_version, encoding: encoding,
+          envelope_version: envelope_version, aad_fields: aad_fields,
+          key_material_fields: key_material_fields
+        )
+      end
+
+      def has_key_material?
+        !key_material_fields.nil? && !key_material_fields.empty?
+      end
+
+      def stored_aad_fields
+        aad_fields&.map(&:to_sym)
+      end
+
       # Class methods for parsing and validation
       def self.valid?(json_string)
         return true if json_string.nil? # Allow nil values

--- a/lib/familia/encryption/encrypted_data.rb
+++ b/lib/familia/encryption/encrypted_data.rb
@@ -24,10 +24,11 @@ module Familia
 
       def with_metadata(envelope_version: self.envelope_version, aad_fields: self.aad_fields,
                          key_material_fields: self.key_material_fields)
-        self.class.new(
-          algorithm: algorithm, nonce: nonce, ciphertext: ciphertext,
-          auth_tag: auth_tag, key_version: key_version, encoding: encoding,
-          envelope_version: envelope_version, aad_fields: aad_fields,
+        # EncryptedData is a Data.define, so #with copies all other members
+        # for us; only the envelope metadata is overridden here.
+        with(
+          envelope_version: envelope_version,
+          aad_fields: aad_fields,
           key_material_fields: key_material_fields
         )
       end

--- a/lib/familia/encryption/encrypted_data.rb
+++ b/lib/familia/encryption/encrypted_data.rb
@@ -4,8 +4,10 @@
 
 module Familia
   module Encryption
-    EncryptedData = Data.define(:algorithm, :nonce, :ciphertext, :auth_tag, :key_version, :encoding) do
-      def initialize(algorithm:, nonce:, ciphertext:, auth_tag:, key_version:, encoding: nil)
+    EncryptedData = Data.define(:algorithm, :nonce, :ciphertext, :auth_tag, :key_version, :encoding, :envelope_version,
+:aad_fields, :key_material_fields) do
+      def initialize(algorithm:, nonce:, ciphertext:, auth_tag:, key_version:, encoding: nil, envelope_version: nil,
+                     aad_fields: nil, key_material_fields: nil)
         super
       end
 

--- a/lib/familia/features/encrypted_fields.rb
+++ b/lib/familia/features/encrypted_fields.rb
@@ -280,6 +280,14 @@ module Familia
         #
         # @param name [Symbol] Field name
         # @param aad_fields [Array<Symbol>] Additional fields to include in authentication
+        # @param key_material [Proc, nil] Optional proc mixed into key derivation as
+        #   extra entropy. It is called with the record instance and must return the
+        #   entropy as a String (a RedactedString is unwrapped automatically); return
+        #   nil to contribute no entropy for that record. Because the returned value
+        #   participates in key derivation rather than authentication, supplying the
+        #   wrong material yields a derivation mismatch (garbage/failed decrypt), not
+        #   an auth-tag error. The value is not persisted, so it must be reproducible
+        #   at decrypt time.
         # @param kwargs [Hash] Additional field options
         #
         # @example Basic encrypted field
@@ -293,6 +301,12 @@ module Familia
         #     feature :encrypted_fields
         #     field :doc_id, :owner_id
         #     encrypted_field :content, aad_fields: [:doc_id, :owner_id]
+        #   end
+        #
+        # @example Encrypted field bound to dynamic entropy
+        #   class Secret < Familia::Horreum
+        #     feature :encrypted_fields
+        #     encrypted_field :payload, key_material: ->(rec) { rec.passphrase }
         #   end
         #
         def encrypted_field(name, aad_fields: [], **)

--- a/lib/familia/features/encrypted_fields/concealed_string.rb
+++ b/lib/familia/features/encrypted_fields/concealed_string.rb
@@ -114,6 +114,18 @@ class ConcealedString
       @field_type.instance_variable_get(:@name) == expected_field_name
   end
 
+  # Human-readable description of the record/field context this value was
+  # encrypted for. Used to make context-isolation errors actionable by
+  # showing the expected context alongside the accessing one.
+  #
+  # @return [String] "Class:field:identifier", or a marker if context was cleared
+  #
+  def context_description
+    return '(context cleared)' if @record.nil? || @field_type.nil?
+
+    "#{@record.class.name}:#{@field_type.name}:#{@record.identifier}"
+  end
+
   # Clear the encrypted data from memory
   #
   # Safe to call multiple times. This provides best-effort memory

--- a/lib/familia/features/encrypted_fields/encrypted_field_type.rb
+++ b/lib/familia/features/encrypted_fields/encrypted_field_type.rb
@@ -88,7 +88,9 @@ module Familia
           # Only validate if we have a proper ConcealedString instance
           if concealed.is_a?(ConcealedString) && !concealed.belongs_to_context?(self, field_name)
             raise Familia::EncryptionError,
-                  "Context isolation violation: encrypted field '#{field_name}' does not belong to #{self.class.name}:#{identifier}"
+                  "Context isolation violation: encrypted field '#{field_name}' accessed from " \
+                  "#{self.class.name}:#{field_name}:#{identifier} but was encrypted for " \
+                  "#{concealed.context_description}"
           end
 
           concealed
@@ -144,7 +146,11 @@ module Familia
       context = build_context(record)
 
       if envelope.envelope_version && envelope.envelope_version >= 2
-        additional_data = build_aad(record, fields: envelope.stored_aad_fields || @aad_fields)
+        # v2 envelopes are self-describing: a nil stored_aad_fields means the
+        # value was encrypted with no AAD fields. Fall back to [] (not the
+        # current class-level @aad_fields) so that adding aad_fields to a model
+        # later cannot break decryption of already-stored v2 envelopes.
+        additional_data = build_aad(record, fields: envelope.stored_aad_fields || [])
         context = context_with_entropy(context, build_key_material(record)) if envelope.has_key_material?
       else
         additional_data = build_aad(record)

--- a/lib/familia/features/encrypted_fields/encrypted_field_type.rb
+++ b/lib/familia/features/encrypted_fields/encrypted_field_type.rb
@@ -124,50 +124,30 @@ module Familia
       end
     end
 
-    # Encrypt a value for the given record
     def encrypt_value(record, value)
       context = build_context(record)
       additional_data = build_aad(record)
-
-      # Extend context with key_material if present
       entropy = build_key_material(record)
-      context = "#{context}:#{entropy}" if entropy
+      context = context_with_entropy(context, entropy)
 
       result = Familia::Encryption.encrypt(value, context: context, additional_data: additional_data)
 
-      # Add envelope metadata for decryption
-      envelope = Familia::JsonSerializer.parse(result)
-      envelope['envelope_version'] = 2
-      envelope['aad_fields'] = @aad_fields.map(&:to_s) unless @aad_fields.empty?
-      envelope['key_material_fields'] = ['key_material'] if entropy
-
-      Familia::JsonSerializer.dump(envelope)
+      Familia::Encryption::EncryptedData.from_json(result).with_metadata(
+        envelope_version: 2,
+        aad_fields: @aad_fields.empty? ? nil : @aad_fields.map(&:to_s),
+        key_material_fields: entropy ? ['key_material'] : nil
+      ).to_json
     end
 
-    # Decrypt a value for the given record
     def decrypt_value(record, encrypted)
-      # Parse envelope to check for key_material_fields
-      envelope = if encrypted.is_a?(Hash)
-                   encrypted
-                 else
-                   Familia::JsonSerializer.parse(encrypted)
-                 end
-
+      envelope = Familia::Encryption::EncryptedData.from_json(encrypted)
       context = build_context(record)
 
-      # Reconstruct AAD from envelope's aad_fields if present, else use class-level @aad_fields
-      aad_field_names = envelope['aad_fields'] || envelope[:aad_fields]
-      additional_data = if aad_field_names
-                          build_aad_from_fields(record, aad_field_names.map(&:to_sym))
-                        else
-                          build_aad(record)
-                        end
-
-      # Check if key_material was used during encryption
-      key_material_fields = envelope['key_material_fields'] || envelope[:key_material_fields]
-      if key_material_fields
-        entropy = build_key_material(record)
-        context = "#{context}:#{entropy}" if entropy
+      if envelope.envelope_version && envelope.envelope_version >= 2
+        additional_data = build_aad(record, fields: envelope.stored_aad_fields || @aad_fields)
+        context = context_with_entropy(context, build_key_material(record)) if envelope.has_key_material?
+      else
+        additional_data = build_aad(record)
       end
 
       Familia::Encryption.decrypt(encrypted, context: context, additional_data: additional_data)
@@ -194,132 +174,40 @@ module Familia
 
     private
 
-    # Build encryption context string
     def build_context(record)
       "#{record.class.name}:#{@name}:#{record.identifier}"
     end
 
-    # Build key material from proc for mixing into key derivation
-    #
-    # Key material is mixed into BLAKE2b derivation, meaning wrong value
-    # produces a completely wrong key and garbage output (unlike AAD which
-    # causes auth_tag mismatch).
-    #
-    # @param record [Familia::Horreum] The record instance
-    # @return [String, nil] Entropy string for key derivation, or nil
+    def context_with_entropy(context, entropy)
+      entropy ? "#{context}:#{entropy}" : context
+    end
+
+    # Extract raw value from RedactedString or coerce via .to_s.
+    # nil.to_s → "" preserves fixed AAD join positions.
+    def unwrap_value(value)
+      value.is_a?(::RedactedString) ? value.value : value.to_s
+    end
+
     def build_key_material(record)
       return nil unless @key_material
 
       result = @key_material.call(record)
       return nil if result.nil?
 
-      if result.is_a?(::RedactedString)
-        result.value
-      else
-        result.to_s
-      end
+      unwrap_value(result)
     end
 
-    # Build AAD from explicit field list (used during decryption with envelope)
-    #
-    # @param record [Familia::Horreum] The record instance
-    # @param field_names [Array<Symbol>] Field names to include in AAD
-    # @return [String, nil] AAD string
-    def build_aad_from_fields(record, field_names)
+    # Build AAD binding ciphertext to record context and optional field values.
+    def build_aad(record, fields: @aad_fields)
       identifier = record.identifier
       return nil if identifier.nil? || identifier.to_s.empty?
 
       base_components = [record.class.name, @name, identifier]
 
-      if field_names.empty?
+      if fields.empty?
         base_components.join(':')
       else
-        values = field_names.map do |field|
-          raw = record.send(field)
-          if raw.is_a?(::RedactedString)
-            raw.value
-          else
-            raw.to_s
-          end
-        end
-        all_components = [*base_components, *values]
-        Digest::SHA256.hexdigest(all_components.join(':'))
-      end
-    end
-
-    # Build Additional Authenticated Data (AAD) for authenticated encryption
-    #
-    # AAD provides cryptographic binding between encrypted field values and their
-    # containing record context. This prevents attackers from moving encrypted
-    # values between different records or field contexts, even with database access.
-    #
-    # ## Consistent AAD Behavior
-    #
-    # AAD is now consistently generated based on the record's identifier, regardless
-    # of persistence state. This ensures that encrypted values remain decryptable
-    # after save/load cycles while still providing security benefits.
-    #
-    # **All Records (both new and persisted):**
-    # - AAD = record.identifier (no aad_fields) or SHA256(identifier:field1:field2:...)
-    # - Consistent cryptographic binding to record identity
-    # - Moving encrypted values between records/contexts will fail decryption
-    #
-    # ## Security Implications
-    #
-    # This design prevents several attack vectors:
-    #
-    # 1. **Field Value Swapping**: With aad_fields specified, encrypted values
-    #    become bound to other field values. Changing owner_id breaks decryption.
-    #
-    # 2. **Cross-Record Migration**: Encrypted values are bound to their specific
-    #    record identifier, preventing cross-record value movement.
-    #
-    # 3. **Temporal Consistency**: Re-encrypting the same plaintext after
-    #    field changes produces different ciphertext due to AAD changes.
-    #
-    # ## Usage Patterns
-    #
-    # ```ruby
-    # # No AAD fields - basic record binding
-    # encrypted_field :secret_value
-    #
-    # # With AAD fields - multi-field binding
-    # encrypted_field :content, aad_fields: [:owner_id, :doc_type]
-    # ```
-    #
-    # @param record [Familia::Horreum] The record instance containing this field
-    # @return [String, nil] AAD string for encryption, or nil if no identifier
-    #
-    def build_aad(record)
-      # AAD provides consistent context-aware binding, regardless of persistence state
-      # This ensures save/load cycles work while maintaining context isolation
-      identifier = record.identifier
-      return nil if identifier.nil? || identifier.to_s.empty?
-
-      # Include class and field name in AAD for context isolation
-      # This prevents cross-class and cross-field value migration
-      base_components = [record.class.name, @name, identifier]
-
-      if @aad_fields.empty?
-        # When no AAD fields specified, use class:field:identifier
-        base_components.join(':')
-      else
-        # Always include aad_field values regardless of persistence state.
-        # The field values are available on the record before save and must
-        # produce identical AAD at both encrypt and decrypt time.
-        #
-        # .to_s coerces nil to "" so that every declared AAD field occupies
-        # a fixed position in the join. Without this, a nil field would
-        # shift later values left and produce a different hash once the
-        # field is populated — making existing ciphertext undecryptable.
-        values = @aad_fields.map do |field|
-          raw = record.send(field)
-          if raw.is_a?(::RedactedString)
-            raw.value
-          else
-            raw.to_s
-          end
-        end
+        values = fields.map { |field| unwrap_value(record.send(field)) }
         all_components = [*base_components, *values]
         Digest::SHA256.hexdigest(all_components.join(':'))
       end

--- a/lib/familia/features/encrypted_fields/encrypted_field_type.rb
+++ b/lib/familia/features/encrypted_fields/encrypted_field_type.rb
@@ -9,12 +9,13 @@ require_relative 'concealed_string'
 
 module Familia
   class EncryptedFieldType < FieldType
-    attr_reader :aad_fields
+    attr_reader :aad_fields, :key_material
 
-    def initialize(name, aad_fields: [], **options)
+    def initialize(name, aad_fields: [], key_material: nil, **options)
       # Encrypted fields are not loggable by default for security
       super(name, **options.merge(on_conflict: :raise, loggable: false))
       @aad_fields = Array(aad_fields).freeze
+      @key_material = key_material # Proc returning entropy string
     end
 
     def define_setter(klass)
@@ -128,13 +129,46 @@ module Familia
       context = build_context(record)
       additional_data = build_aad(record)
 
-      Familia::Encryption.encrypt(value, context: context, additional_data: additional_data)
+      # Extend context with key_material if present
+      entropy = build_key_material(record)
+      context = "#{context}:#{entropy}" if entropy
+
+      result = Familia::Encryption.encrypt(value, context: context, additional_data: additional_data)
+
+      # Add envelope metadata for decryption
+      envelope = Familia::JsonSerializer.parse(result)
+      envelope['envelope_version'] = 2
+      envelope['aad_fields'] = @aad_fields.map(&:to_s) unless @aad_fields.empty?
+      envelope['key_material_fields'] = ['key_material'] if entropy
+
+      Familia::JsonSerializer.dump(envelope)
     end
 
     # Decrypt a value for the given record
     def decrypt_value(record, encrypted)
+      # Parse envelope to check for key_material_fields
+      envelope = if encrypted.is_a?(Hash)
+                   encrypted
+                 else
+                   Familia::JsonSerializer.parse(encrypted)
+                 end
+
       context = build_context(record)
-      additional_data = build_aad(record)
+
+      # Reconstruct AAD from envelope's aad_fields if present, else use class-level @aad_fields
+      aad_field_names = envelope['aad_fields'] || envelope[:aad_fields]
+      additional_data = if aad_field_names
+                          build_aad_from_fields(record, aad_field_names.map(&:to_sym))
+                        else
+                          build_aad(record)
+                        end
+
+      # Check if key_material was used during encryption
+      key_material_fields = envelope['key_material_fields'] || envelope[:key_material_fields]
+      if key_material_fields
+        entropy = build_key_material(record)
+        context = "#{context}:#{entropy}" if entropy
+      end
 
       Familia::Encryption.decrypt(encrypted, context: context, additional_data: additional_data)
     end
@@ -163,6 +197,54 @@ module Familia
     # Build encryption context string
     def build_context(record)
       "#{record.class.name}:#{@name}:#{record.identifier}"
+    end
+
+    # Build key material from proc for mixing into key derivation
+    #
+    # Key material is mixed into BLAKE2b derivation, meaning wrong value
+    # produces a completely wrong key and garbage output (unlike AAD which
+    # causes auth_tag mismatch).
+    #
+    # @param record [Familia::Horreum] The record instance
+    # @return [String, nil] Entropy string for key derivation, or nil
+    def build_key_material(record)
+      return nil unless @key_material
+
+      result = @key_material.call(record)
+      return nil if result.nil?
+
+      if result.is_a?(::RedactedString)
+        result.value
+      else
+        result.to_s
+      end
+    end
+
+    # Build AAD from explicit field list (used during decryption with envelope)
+    #
+    # @param record [Familia::Horreum] The record instance
+    # @param field_names [Array<Symbol>] Field names to include in AAD
+    # @return [String, nil] AAD string
+    def build_aad_from_fields(record, field_names)
+      identifier = record.identifier
+      return nil if identifier.nil? || identifier.to_s.empty?
+
+      base_components = [record.class.name, @name, identifier]
+
+      if field_names.empty?
+        base_components.join(':')
+      else
+        values = field_names.map do |field|
+          raw = record.send(field)
+          if raw.is_a?(::RedactedString)
+            raw.value
+          else
+            raw.to_s
+          end
+        end
+        all_components = [*base_components, *values]
+        Digest::SHA256.hexdigest(all_components.join(':'))
+      end
     end
 
     # Build Additional Authenticated Data (AAD) for authenticated encryption
@@ -230,7 +312,14 @@ module Familia
         # a fixed position in the join. Without this, a nil field would
         # shift later values left and produce a different hash once the
         # field is populated — making existing ciphertext undecryptable.
-        values = @aad_fields.map { |field| record.send(field).to_s }
+        values = @aad_fields.map do |field|
+          raw = record.send(field)
+          if raw.is_a?(::RedactedString)
+            raw.value
+          else
+            raw.to_s
+          end
+        end
         all_components = [*base_components, *values]
         Digest::SHA256.hexdigest(all_components.join(':'))
       end

--- a/lib/familia/horreum/related_fields.rb
+++ b/lib/familia/horreum/related_fields.rb
@@ -227,6 +227,8 @@ module Familia
         end
 
         related_field = klass.new name, opts
+        # Freeze for thread safety. This means define_singleton_method will
+        # raise FrozenError — stub the class method, not the DataType instance.
         related_field.freeze
         instance_variable_set(:"@#{name}", related_field)
 

--- a/try/features/encrypted_fields/aad_transient_fix_try.rb
+++ b/try/features/encrypted_fields/aad_transient_fix_try.rb
@@ -144,18 +144,18 @@ end
 @aad_cleared != @aad_with_pass
 #=> true
 
-## RedactedString value extraction works via build_aad_from_fields
+## RedactedString value extraction works via build_aad with explicit fields
 @record_fromfields = TransientAADModel.new(id: 'fromfields-1')
 @record_fromfields.passphrase = 'fromfields-pass'
-@aad_fromfields = @field_type.send(:build_aad_from_fields, @record_fromfields, [:passphrase])
+@aad_fromfields = @field_type.send(:build_aad, @record_fromfields, fields: [:passphrase])
 @aad_fromfields.is_a?(String) && !@aad_fromfields.empty?
 #=> true
 
-## build_aad and build_aad_from_fields produce same result for same fields
+## Explicit fields: parameter produces same result as default @aad_fields
 @record_compare = TransientAADModel.new(id: 'compare-1')
 @record_compare.passphrase = 'compare-pass'
 @aad_build = @field_type.send(:build_aad, @record_compare)
-@aad_from = @field_type.send(:build_aad_from_fields, @record_compare, [:passphrase])
+@aad_from = @field_type.send(:build_aad, @record_compare, fields: [:passphrase])
 @aad_build == @aad_from
 #=> true
 

--- a/try/features/encrypted_fields/aad_transient_fix_try.rb
+++ b/try/features/encrypted_fields/aad_transient_fix_try.rb
@@ -1,0 +1,164 @@
+# try/features/encrypted_fields/aad_transient_fix_try.rb
+#
+# frozen_string_literal: true
+
+# Tests for RedactedString.value extraction fix in build_aad.
+# Verifies that transient fields in aad_fields are handled correctly
+# by extracting the underlying value from RedactedString wrappers.
+# Regression test for GitHub issue #280.
+
+require 'base64'
+require 'digest'
+require_relative '../../support/helpers/test_helpers'
+
+test_keys = {
+  v1: Base64.strict_encode64('a' * 32),
+}
+Familia.config.encryption_keys = test_keys
+Familia.config.current_key_version = :v1
+
+# Model with transient field in aad_fields
+class TransientAADModel < Familia::Horreum
+  feature :encrypted_fields
+  feature :transient_fields
+
+  identifier_field :id
+  field :id
+  transient_field :passphrase
+  encrypted_field :secret, aad_fields: [:passphrase]
+end
+
+# Model with mixed regular and transient fields in aad_fields
+class MixedAADModel < Familia::Horreum
+  feature :encrypted_fields
+  feature :transient_fields
+
+  identifier_field :id
+  field :id
+  field :region
+  transient_field :session_token
+  encrypted_field :api_key, aad_fields: [:region, :session_token]
+end
+
+Familia.dbclient.flushdb
+
+@field_type = TransientAADModel.field_types[:secret]
+@mixed_ft = MixedAADModel.field_types[:api_key]
+
+## Transient field in aad_fields produces different AAD for different values
+@record1 = TransientAADModel.new(id: 'aad-transient-1')
+@record1.passphrase = 'secret-pass-A'
+@record2 = TransientAADModel.new(id: 'aad-transient-1')
+@record2.passphrase = 'secret-pass-B'
+@aad1 = @field_type.send(:build_aad, @record1)
+@aad2 = @field_type.send(:build_aad, @record2)
+@aad1 != @aad2
+#=> true
+
+## Transient field in aad_fields produces same AAD for same value
+@record3 = TransientAADModel.new(id: 'aad-transient-2')
+@record3.passphrase = 'identical-pass'
+@record4 = TransientAADModel.new(id: 'aad-transient-2')
+@record4.passphrase = 'identical-pass'
+@aad3 = @field_type.send(:build_aad, @record3)
+@aad4 = @field_type.send(:build_aad, @record4)
+@aad3 == @aad4
+#=> true
+
+## Transient field value is nil - AAD still computed with empty string
+@record_nil = TransientAADModel.new(id: 'aad-transient-nil')
+@aad_nil = @field_type.send(:build_aad, @record_nil)
+@aad_nil.is_a?(String) && !@aad_nil.empty?
+#=> true
+
+## Nil transient field produces same AAD as explicitly nil
+@record_explicit_nil = TransientAADModel.new(id: 'aad-transient-nil')
+@record_explicit_nil.passphrase = nil
+@aad_explicit_nil = @field_type.send(:build_aad, @record_explicit_nil)
+@aad_nil == @aad_explicit_nil
+#=> true
+
+## Mixed regular fields + transient fields extracts all values correctly
+@mixed = MixedAADModel.new(id: 'mixed-1', region: 'us-east')
+@mixed.session_token = 'sess-abc123'
+@mixed_aad = @mixed_ft.send(:build_aad, @mixed)
+@mixed_aad.is_a?(String) && !@mixed_aad.empty?
+#=> true
+
+## Mixed fields - changing regular field changes AAD
+@mixed2 = MixedAADModel.new(id: 'mixed-1', region: 'eu-west')
+@mixed2.session_token = 'sess-abc123'
+@mixed_aad2 = @mixed_ft.send(:build_aad, @mixed2)
+@mixed_aad != @mixed_aad2
+#=> true
+
+## Mixed fields - changing transient field changes AAD
+@mixed3 = MixedAADModel.new(id: 'mixed-1', region: 'us-east')
+@mixed3.session_token = 'sess-xyz789'
+@mixed_aad3 = @mixed_ft.send(:build_aad, @mixed3)
+@mixed_aad != @mixed_aad3
+#=> true
+
+## Encrypt with transient field AAD succeeds
+@record_enc = TransientAADModel.new(id: 'enc-transient-1')
+@record_enc.passphrase = 'encryption-pass'
+@record_enc.secret = 'my-secret-data'
+@record_enc.secret.class.name
+#=> "ConcealedString"
+
+## Decrypt with unchanged transient field AAD succeeds
+@decrypted = nil
+@record_enc.secret.reveal { |pt| @decrypted = pt }
+@decrypted
+#=> "my-secret-data"
+
+## Decrypt fails when transient field value changes
+@record_tamper = TransientAADModel.new(id: 'tamper-1')
+@record_tamper.passphrase = 'original-pass'
+@record_tamper.secret = 'bound-secret'
+@record_tamper.passphrase = 'tampered-pass'
+@result = begin
+  @record_tamper.secret.reveal { |pt| pt }
+  'UNEXPECTED SUCCESS'
+rescue Familia::EncryptionError
+  'Familia::EncryptionError'
+end
+@result
+#=> "Familia::EncryptionError"
+
+## RedactedString cleared - getter returns nil, AAD uses empty value
+# When passphrase is cleared, the transient field getter returns nil.
+# build_aad uses nil.to_s (empty string) for the AAD computation.
+# This is valid but will make the data undecryptable with the actual passphrase.
+@record_cleared = TransientAADModel.new(id: 'cleared-1')
+@record_cleared.passphrase = 'to-be-cleared'
+@record_cleared.passphrase.clear!
+@aad_cleared = @field_type.send(:build_aad, @record_cleared)
+@aad_cleared.is_a?(String) && !@aad_cleared.empty?
+#=> true
+
+## Cleared passphrase AAD differs from the original passphrase AAD
+@record_with_pass = TransientAADModel.new(id: 'cleared-1')
+@record_with_pass.passphrase = 'to-be-cleared'
+@aad_with_pass = @field_type.send(:build_aad, @record_with_pass)
+@aad_cleared != @aad_with_pass
+#=> true
+
+## RedactedString value extraction works via build_aad_from_fields
+@record_fromfields = TransientAADModel.new(id: 'fromfields-1')
+@record_fromfields.passphrase = 'fromfields-pass'
+@aad_fromfields = @field_type.send(:build_aad_from_fields, @record_fromfields, [:passphrase])
+@aad_fromfields.is_a?(String) && !@aad_fromfields.empty?
+#=> true
+
+## build_aad and build_aad_from_fields produce same result for same fields
+@record_compare = TransientAADModel.new(id: 'compare-1')
+@record_compare.passphrase = 'compare-pass'
+@aad_build = @field_type.send(:build_aad, @record_compare)
+@aad_from = @field_type.send(:build_aad_from_fields, @record_compare, [:passphrase])
+@aad_build == @aad_from
+#=> true
+
+Familia.dbclient.flushdb
+Familia.config.encryption_keys = nil
+Familia.config.current_key_version = nil

--- a/try/features/encrypted_fields/aad_transient_proof_try.rb
+++ b/try/features/encrypted_fields/aad_transient_proof_try.rb
@@ -1,0 +1,253 @@
+# try/features/encrypted_fields/aad_transient_proof_try.rb
+#
+# frozen_string_literal: true
+
+# Proof: AAD with transient fields — can ciphertext encrypted with AAD
+# be decrypted without providing the same fields?
+#
+# FINDINGS:
+#
+# 1. OTS secret.rb declares `encrypted_field :ciphertext` with NO aad_fields.
+#    The transient fields (ciphertext_passphrase, ciphertext_domain) are
+#    declared but not wired into encryption. Decryption works without them.
+#
+# 2. Familia's build_aad was updated to support unwrap_value on RedactedString,
+#    which calls `.value` instead of `.to_s`.
+#    This means transient fields (which wrap strings in RedactedString)
+#    are now FULLY EFFECTIVE as AAD — different values produce different AAD.
+#
+# 3. Changing transient passphrase after encryption now correctly breaks
+#    decryption, raising Familia::EncryptionError.
+#
+# 4. Using regular `field` as aad_fields also continues to work correctly.
+
+require 'base64'
+
+require_relative '../../support/helpers/test_helpers'
+
+test_keys = {
+  v1: Base64.strict_encode64('a' * 32),
+}
+Familia.config.encryption_keys = test_keys
+Familia.config.current_key_version = :v1
+
+# --- Model A: Current OTS behavior (no AAD) ---
+
+class SecretNoAAD < Familia::Horreum
+  feature :encrypted_fields
+  feature :transient_fields
+
+  identifier_field :secretid
+  field :secretid
+
+  encrypted_field :ciphertext
+  transient_field :ciphertext_passphrase
+  transient_field :ciphertext_domain
+end
+
+# --- Model B: AAD with regular field (works correctly) ---
+
+class SecretWithFieldAAD < Familia::Horreum
+  feature :encrypted_fields
+
+  identifier_field :secretid
+  field :secretid
+  field :owner_email
+
+  encrypted_field :ciphertext, aad_fields: [:owner_email]
+end
+
+# --- Model C: AAD with two regular fields (order/swap test) ---
+
+class SecretTwoFieldAAD < Familia::Horreum
+  feature :encrypted_fields
+
+  identifier_field :secretid
+  field :secretid
+  field :field_a
+  field :field_b
+
+  encrypted_field :ciphertext, aad_fields: [:field_a, :field_b]
+end
+
+# --- Model D: AAD with transient field (RedactedString.to_s problem) ---
+
+class SecretWithTransientAAD < Familia::Horreum
+  feature :encrypted_fields
+  feature :transient_fields
+
+  identifier_field :secretid
+  field :secretid
+
+  encrypted_field :ciphertext, aad_fields: [:ciphertext_passphrase]
+  transient_field :ciphertext_passphrase
+end
+
+Familia.dbclient.flushdb
+
+# ============================================================
+# PART 1: Current OTS behavior — no AAD, decrypt without passphrase
+# ============================================================
+
+## No-AAD: decrypt succeeds without passphrase (current OTS behavior)
+@s1 = SecretNoAAD.new(secretid: 'no-aad-1')
+@s1.ciphertext_passphrase = 'user-supplied-passphrase'
+@s1.ciphertext_domain = 'acme.example.com'
+@s1.ciphertext = 'Attack at dawn'
+@s1.save
+@reloaded1 = SecretNoAAD.load('no-aad-1')
+@d1 = nil
+@reloaded1.ciphertext.reveal { |pt| @d1 = pt }
+@d1
+#=> "Attack at dawn"
+
+## No-AAD: transient passphrase is nil after reload
+@reloaded1.ciphertext_passphrase.nil?
+#=> true
+
+## No-AAD: transient domain is nil after reload
+@reloaded1.ciphertext_domain.nil?
+#=> true
+
+# ============================================================
+# PART 2: AAD with regular field — works as intended
+# ============================================================
+
+## Field-AAD: encrypt and decrypt with matching email succeeds
+@s2 = SecretWithFieldAAD.new(secretid: 'field-aad-ok', owner_email: 'alice@example.com')
+@s2.ciphertext = 'Bound to alice'
+@d2 = nil
+@s2.ciphertext.reveal { |pt| @d2 = pt }
+@d2
+#=> "Bound to alice"
+
+## Field-AAD: changing email after encryption breaks decrypt
+@s3 = SecretWithFieldAAD.new(secretid: 'field-aad-changed', owner_email: 'alice@example.com')
+@s3.ciphertext = 'Originally for alice'
+@s3.owner_email = 'mallory@evil.com'
+@result_changed = begin
+  @s3.ciphertext.reveal { |pt| pt }
+  'UNEXPECTED SUCCESS'
+rescue Familia::EncryptionError
+  'EncryptionError'
+end
+@result_changed
+#=> "EncryptionError"
+
+## Field-AAD: save/reload with matching field succeeds
+@s4 = SecretWithFieldAAD.new(secretid: 'field-aad-reload', owner_email: 'bob@example.com')
+@s4.ciphertext = 'Survives reload'
+@s4.save
+@reloaded4 = SecretWithFieldAAD.load('field-aad-reload')
+@d4 = nil
+@reloaded4.ciphertext.reveal { |pt| @d4 = pt }
+@d4
+#=> "Survives reload"
+
+# ============================================================
+# PART 3: Transient AAD is fully effective (RedactedString unwrapping works)
+# ============================================================
+
+## Transient-AAD: RedactedString.to_s returns [REDACTED], not the value
+@s5 = SecretWithTransientAAD.new(secretid: 'transient-aad-1')
+@s5.ciphertext_passphrase = 'secret-phrase-123'
+@s5.ciphertext_passphrase.to_s
+#=> "[REDACTED]"
+
+## Transient-AAD: different passphrases produce different AAD (RedactedString unwrapped)
+@s6a = SecretWithTransientAAD.new(secretid: 'same-id')
+@s6a.ciphertext_passphrase = 'passphrase-one'
+@ft = SecretWithTransientAAD.field_types[:ciphertext]
+@aad_a = @ft.send(:build_aad, @s6a)
+
+@s6b = SecretWithTransientAAD.new(secretid: 'same-id')
+@s6b.ciphertext_passphrase = 'completely-different-passphrase'
+@aad_b = @ft.send(:build_aad, @s6b)
+@aad_a == @aad_b
+#=> false
+
+## Transient-AAD: changing passphrase after encrypt breaks decrypt
+@s7 = SecretWithTransientAAD.new(secretid: 'transient-aad-break')
+@s7.ciphertext_passphrase = 'original-phrase'
+@s7.ciphertext = 'Should be bound and is'
+@s7.ciphertext_passphrase = 'totally-wrong-phrase'
+@result_transient_changed = begin
+  @s7.ciphertext.reveal { |pt| pt }
+  'UNEXPECTED SUCCESS'
+rescue Familia::EncryptionError
+  'EncryptionError'
+end
+@result_transient_changed
+#=> "EncryptionError"
+
+## Transient-AAD: nil passphrase also produces same AAD (nil.to_s == "")
+# Wait — nil transient returns nil from getter, and nil.to_s == ""
+# while RedactedString.to_s == "[REDACTED]". So nil vs set DOES differ.
+@s8a = SecretWithTransientAAD.new(secretid: 'nil-vs-set')
+@aad_nil = @ft.send(:build_aad, @s8a)
+
+@s8b = SecretWithTransientAAD.new(secretid: 'nil-vs-set')
+@s8b.ciphertext_passphrase = 'any-value'
+@aad_set = @ft.send(:build_aad, @s8b)
+@aad_nil == @aad_set
+#=> false
+
+## Transient-AAD: nil vs set does matter — encrypt with passphrase, clear to nil, decrypt fails
+@s9 = SecretWithTransientAAD.new(secretid: 'nil-breaks')
+@s9.ciphertext_passphrase = 'was-set'
+@s9.ciphertext = 'Encrypted with passphrase set'
+# Simulate what happens after reload (transient is nil)
+@s9.instance_variable_set(:@ciphertext_passphrase, nil)
+@result_nil_clear = begin
+  @s9.ciphertext.reveal { |pt| pt }
+  'UNEXPECTED SUCCESS'
+rescue Familia::EncryptionError
+  'EncryptionError'
+end
+@result_nil_clear
+#=> "EncryptionError"
+
+# ============================================================
+# PART 4: Contrast — what regular field AAD looks like
+# ============================================================
+
+## Field-AAD: swapping two AAD values breaks decrypt (order matters)
+@s_swap = SecretTwoFieldAAD.new(secretid: 'swap-test', field_a: 'alpha', field_b: 'beta')
+@s_swap.ciphertext = 'order-bound content'
+@s_swap.field_a = 'beta'
+@s_swap.field_b = 'alpha'
+@result_swap = begin
+  @s_swap.ciphertext.reveal { |pt| pt }
+  'UNEXPECTED SUCCESS'
+rescue Familia::EncryptionError
+  'EncryptionError'
+end
+@result_swap
+#=> "EncryptionError"
+
+## Field-AAD: missing one of two fields breaks decrypt
+@s_miss = SecretTwoFieldAAD.new(secretid: 'miss-test', field_a: 'alpha', field_b: 'beta')
+@s_miss.ciphertext = 'needs both'
+@s_miss.field_b = nil
+@result_miss = begin
+  @s_miss.ciphertext.reveal { |pt| pt }
+  'UNEXPECTED SUCCESS'
+rescue Familia::EncryptionError
+  'EncryptionError'
+end
+@result_miss
+#=> "EncryptionError"
+
+## Field-AAD: different emails produce different AAD (correct behavior)
+@ft2 = SecretWithFieldAAD.field_types[:ciphertext]
+@fa = SecretWithFieldAAD.new(secretid: 'cmp-id', owner_email: 'alice@example.com')
+@fb = SecretWithFieldAAD.new(secretid: 'cmp-id', owner_email: 'bob@example.com')
+@aad_alice = @ft2.send(:build_aad, @fa)
+@aad_bob = @ft2.send(:build_aad, @fb)
+@aad_alice == @aad_bob
+#=> false
+
+# Cleanup
+Familia.dbclient.flushdb
+Familia.config.encryption_keys = nil
+Familia.config.current_key_version = nil

--- a/try/features/encrypted_fields/encrypted_data_try.rb
+++ b/try/features/encrypted_fields/encrypted_data_try.rb
@@ -1,0 +1,151 @@
+# try/features/encrypted_fields/encrypted_data_try.rb
+#
+# frozen_string_literal: true
+
+# Tests for EncryptedData value object methods added in issue #280:
+# with_metadata, to_json, has_key_material?, stored_aad_fields,
+# and round-trip through from_json.
+
+require 'base64'
+require_relative '../../support/helpers/test_helpers'
+
+test_keys = {
+  v1: Base64.strict_encode64('a' * 32),
+}
+Familia.config.encryption_keys = test_keys
+Familia.config.current_key_version = :v1
+
+@base = Familia::Encryption::EncryptedData.new(
+  algorithm: 'xchacha20-poly1305',
+  nonce: Base64.strict_encode64('n' * 24),
+  ciphertext: Base64.strict_encode64('cipher'),
+  auth_tag: Base64.strict_encode64('t' * 16),
+  key_version: 'v1',
+  encoding: 'UTF-8'
+)
+
+## with_metadata returns new instance with envelope_version set
+@v2 = @base.with_metadata(envelope_version: 2)
+@v2.envelope_version
+#=> 2
+
+## with_metadata preserves original crypto fields
+@v2.algorithm
+#=> "xchacha20-poly1305"
+
+## with_metadata original is unchanged (Data is immutable)
+@base.envelope_version
+#=> nil
+
+## with_metadata sets aad_fields
+@with_aad = @base.with_metadata(envelope_version: 2, aad_fields: ['org_id', 'region'])
+@with_aad.aad_fields
+#=> ["org_id", "region"]
+
+## with_metadata sets key_material_fields
+@with_km = @base.with_metadata(envelope_version: 2, key_material_fields: ['key_material'])
+@with_km.key_material_fields
+#=> ["key_material"]
+
+## to_h omits nil metadata keys via compact
+@base.to_h.key?(:envelope_version)
+#=> false
+
+## to_h includes non-nil metadata keys
+@v2.to_h[:envelope_version]
+#=> 2
+
+## to_json produces valid JSON string
+@json = @v2.to_json
+@json.is_a?(String)
+#=> true
+
+## to_json round-trips through from_json
+@roundtrip = Familia::Encryption::EncryptedData.from_json(@json)
+@roundtrip.envelope_version
+#=> 2
+
+## Round-trip preserves algorithm
+@roundtrip.algorithm
+#=> "xchacha20-poly1305"
+
+## Round-trip preserves encoding
+@roundtrip.encoding
+#=> "UTF-8"
+
+## Full metadata round-trip through JSON
+@full = @base.with_metadata(
+  envelope_version: 2,
+  aad_fields: ['tenant_id'],
+  key_material_fields: ['key_material']
+)
+@full_rt = Familia::Encryption::EncryptedData.from_json(@full.to_json)
+@full_rt.aad_fields
+#=> ["tenant_id"]
+
+## Full metadata round-trip preserves key_material_fields
+@full_rt.key_material_fields
+#=> ["key_material"]
+
+## has_key_material? returns false when nil
+@base.has_key_material?
+#=> false
+
+## has_key_material? returns false when empty array
+@empty_km = @base.with_metadata(key_material_fields: [])
+@empty_km.has_key_material?
+#=> false
+
+## has_key_material? returns true when populated
+@with_km.has_key_material?
+#=> true
+
+## stored_aad_fields returns nil when aad_fields is nil
+@base.stored_aad_fields
+#=> nil
+
+## stored_aad_fields returns symbolized field names
+@with_aad.stored_aad_fields
+#=> [:org_id, :region]
+
+## stored_aad_fields round-trips through JSON (string keys become symbols)
+@aad_rt = Familia::Encryption::EncryptedData.from_json(@with_aad.to_json)
+@aad_rt.stored_aad_fields
+#=> [:org_id, :region]
+
+## from_json with Hash input handles new metadata fields
+@hash_input = {
+  'algorithm' => 'xchacha20-poly1305',
+  'nonce' => Base64.strict_encode64('n' * 24),
+  'ciphertext' => Base64.strict_encode64('data'),
+  'auth_tag' => Base64.strict_encode64('t' * 16),
+  'key_version' => 'v1',
+  'envelope_version' => 2,
+  'aad_fields' => ['owner_id'],
+}
+@from_hash = Familia::Encryption::EncryptedData.from_json(@hash_input)
+@from_hash.envelope_version
+#=> 2
+
+## from_json with Hash input preserves aad_fields
+@from_hash.aad_fields
+#=> ["owner_id"]
+
+## from_json with old-format Hash (no metadata) defaults to nil
+@old_hash = {
+  'algorithm' => 'xchacha20-poly1305',
+  'nonce' => Base64.strict_encode64('n' * 24),
+  'ciphertext' => Base64.strict_encode64('data'),
+  'auth_tag' => Base64.strict_encode64('t' * 16),
+  'key_version' => 'v1',
+}
+@from_old = Familia::Encryption::EncryptedData.from_json(@old_hash)
+@from_old.envelope_version
+#=> nil
+
+## Old-format envelope has_key_material? is false
+@from_old.has_key_material?
+#=> false
+
+Familia.config.encryption_keys = nil
+Familia.config.current_key_version = nil

--- a/try/features/encrypted_fields/envelope_version_branching_try.rb
+++ b/try/features/encrypted_fields/envelope_version_branching_try.rb
@@ -1,0 +1,106 @@
+# try/features/encrypted_fields/envelope_version_branching_try.rb
+#
+# frozen_string_literal: true
+
+# Tests that decrypt_value branches on envelope_version:
+# - v2 envelopes use stored aad_fields and key_material_fields
+# - Old envelopes (no version) fall back to class-level @aad_fields
+#   and never apply key_material, even if the field type has one configured.
+
+require 'base64'
+require_relative '../../support/helpers/test_helpers'
+
+test_keys = {
+  v1: Base64.strict_encode64('a' * 32),
+}
+Familia.config.encryption_keys = test_keys
+Familia.config.current_key_version = :v1
+
+class VersionBranchModel < Familia::Horreum
+  feature :encrypted_fields
+
+  identifier_field :id
+  field :id
+  field :org_id
+  encrypted_field :secret, aad_fields: [:org_id]
+end
+
+class VersionBranchKMModel < Familia::Horreum
+  feature :encrypted_fields
+
+  identifier_field :id
+  field :id
+  field :salt
+  encrypted_field :vault, key_material: ->(r) { r.salt }
+end
+
+Familia.dbclient.flushdb
+
+## v2 envelope decrypts normally
+@record = VersionBranchModel.new(id: 'vb-1', org_id: 'org-a')
+@record.secret = 'v2-secret'
+@decrypted = nil
+@record.secret.reveal { |pt| @decrypted = pt }
+@decrypted
+#=> "v2-secret"
+
+## Stripping envelope_version from v2 envelope still decrypts (backward compat path)
+@ft = VersionBranchModel.field_types[:secret]
+@record2 = VersionBranchModel.new(id: 'vb-2', org_id: 'org-b')
+@record2.secret = 'strip-version'
+@encrypted_json = @record2.instance_variable_get(:@secret).encrypted_value
+@envelope = Familia::JsonSerializer.parse(@encrypted_json)
+@envelope.delete('envelope_version')
+@envelope.delete('aad_fields')
+@stripped_json = Familia::JsonSerializer.dump(@envelope)
+@decrypted_stripped = @ft.decrypt_value(@record2, @stripped_json)
+@decrypted_stripped
+#=> "strip-version"
+
+## Old envelope ignores key_material even when field type has it configured
+@km_ft = VersionBranchKMModel.field_types[:vault]
+@km_record = VersionBranchKMModel.new(id: 'vb-km-1', salt: 'my-salt')
+@km_record.vault = 'km-secret'
+@km_json = @km_record.instance_variable_get(:@vault).encrypted_value
+@km_envelope = Familia::JsonSerializer.parse(@km_json)
+@km_envelope.delete('envelope_version')
+@km_envelope.delete('key_material_fields')
+@old_km_json = Familia::JsonSerializer.dump(@km_envelope)
+# This should fail: the data was encrypted WITH key_material but the
+# old-envelope path does not apply it. Decrypt produces garbage → EncryptionError.
+@km_result = begin
+  @km_ft.decrypt_value(@km_record, @old_km_json)
+  'UNEXPECTED SUCCESS'
+rescue Familia::EncryptionError
+  'Familia::EncryptionError'
+end
+@km_result
+#=> "Familia::EncryptionError"
+
+## v2 envelope with key_material decrypts when key_material is correct
+@km_record2 = VersionBranchKMModel.new(id: 'vb-km-2', salt: 'correct-salt')
+@km_record2.vault = 'km-roundtrip'
+@km_decrypted = nil
+@km_record2.vault.reveal { |pt| @km_decrypted = pt }
+@km_decrypted
+#=> "km-roundtrip"
+
+## v2 envelope with stored aad_fields survives save/load cycle
+@saved = VersionBranchModel.new(id: 'vb-save-1', org_id: 'saved-org')
+@saved.secret = 'persist-me'
+@saved.save
+@loaded = VersionBranchModel.load('vb-save-1')
+@loaded_pt = nil
+@loaded.secret.reveal { |pt| @loaded_pt = pt }
+@loaded_pt
+#=> "persist-me"
+
+## v2 loaded envelope still has version 2
+@loaded_json = @loaded.instance_variable_get(:@secret).encrypted_value
+@loaded_env = Familia::JsonSerializer.parse(@loaded_json)
+@loaded_env['envelope_version']
+#=> 2
+
+Familia.dbclient.flushdb
+Familia.config.encryption_keys = nil
+Familia.config.current_key_version = nil

--- a/try/features/encrypted_fields/envelope_version_try.rb
+++ b/try/features/encrypted_fields/envelope_version_try.rb
@@ -1,0 +1,171 @@
+# try/features/encrypted_fields/envelope_version_try.rb
+#
+# frozen_string_literal: true
+
+# Tests for envelope versioning and backward compatibility.
+# New envelopes include envelope_version: 2 and aad_fields array.
+# Old envelopes (without these keys) fall back to class-level @aad_fields.
+# Regression test for GitHub issue #280.
+
+require 'base64'
+require_relative '../../support/helpers/test_helpers'
+
+test_keys = {
+  v1: Base64.strict_encode64('a' * 32),
+}
+Familia.config.encryption_keys = test_keys
+Familia.config.current_key_version = :v1
+
+# Model with aad_fields for envelope tests
+class EnvelopeVersionModel < Familia::Horreum
+  feature :encrypted_fields
+
+  identifier_field :id
+  field :id
+  field :org_id
+  encrypted_field :secret, aad_fields: [:org_id]
+end
+
+# Model without aad_fields
+class EnvelopeNoAADModel < Familia::Horreum
+  feature :encrypted_fields
+
+  identifier_field :id
+  field :id
+  encrypted_field :token
+end
+
+Familia.dbclient.flushdb
+
+## New envelope has envelope_version: 2
+@record = EnvelopeVersionModel.new(id: 'env-v2-1', org_id: 'org-abc')
+@record.secret = 'versioned-secret'
+@encrypted_json = @record.instance_variable_get(:@secret).encrypted_value
+@envelope = Familia::JsonSerializer.parse(@encrypted_json)
+@envelope['envelope_version']
+#=> 2
+
+## New envelope includes aad_fields array when aad_fields configured
+@envelope['aad_fields']
+#=> ["org_id"]
+
+## New envelope without aad_fields does not include aad_fields key
+@record_no_aad = EnvelopeNoAADModel.new(id: 'env-noaad-1')
+@record_no_aad.token = 'no-aad-token'
+@encrypted_json_noaad = @record_no_aad.instance_variable_get(:@token).encrypted_value
+@envelope_noaad = Familia::JsonSerializer.parse(@encrypted_json_noaad)
+@envelope_noaad['aad_fields']
+#=> nil
+
+## Envelope still has version 2 even without aad_fields
+@envelope_noaad['envelope_version']
+#=> 2
+
+## Standard encryption fields present in envelope
+@envelope.key?('algorithm')
+#=> true
+
+## Nonce present in envelope
+@envelope.key?('nonce')
+#=> true
+
+## Ciphertext present in envelope
+@envelope.key?('ciphertext')
+#=> true
+
+## Auth tag present in envelope
+@envelope.key?('auth_tag')
+#=> true
+
+## Key version present in envelope
+@envelope.key?('key_version')
+#=> true
+
+## Old envelope (no envelope_version) decrypts using class-level aad_fields
+# Simulate an old envelope by manually creating one without envelope_version
+@field_type = EnvelopeVersionModel.field_types[:secret]
+@old_record = EnvelopeVersionModel.new(id: 'old-env-1', org_id: 'old-org')
+@old_record.secret = 'old-format-secret'
+@encrypted_old = @old_record.instance_variable_get(:@secret).encrypted_value
+@old_envelope = Familia::JsonSerializer.parse(@encrypted_old)
+@old_envelope.delete('envelope_version')
+@old_envelope.delete('aad_fields')
+@simulated_old = Familia::JsonSerializer.dump(@old_envelope)
+@old_record.instance_variable_set(:@secret, nil)
+@concealed = ConcealedString.new(@simulated_old, @old_record, @field_type)
+@old_record.instance_variable_set(:@secret, @concealed)
+@decrypted_old = nil
+@old_record.secret.reveal { |pt| @decrypted_old = pt }
+@decrypted_old
+#=> "old-format-secret"
+
+## Old envelope with different aad_fields still uses class-level fallback
+class EvolvingModel < Familia::Horreum
+  feature :encrypted_fields
+  identifier_field :id
+  field :id
+  field :tenant
+  field :region
+  encrypted_field :config, aad_fields: [:tenant, :region]
+end
+@evolving_record = EvolvingModel.new(id: 'evolve-1', tenant: 'acme', region: 'us')
+@evolving_record.config = 'evolved-config'
+@encrypted_evolving = @evolving_record.instance_variable_get(:@config).encrypted_value
+@evolving_envelope = Familia::JsonSerializer.parse(@encrypted_evolving)
+@evolving_envelope['aad_fields'].sort
+#=> ["region", "tenant"]
+
+## Envelope version preserved through save/load cycle
+@saved_record = EnvelopeVersionModel.new(id: 'save-load-1', org_id: 'saved-org')
+@saved_record.secret = 'save-load-secret'
+@saved_record.save
+@loaded_record = EnvelopeVersionModel.load('save-load-1')
+@encrypted_loaded = @loaded_record.instance_variable_get(:@secret).encrypted_value
+@loaded_envelope = Familia::JsonSerializer.parse(@encrypted_loaded)
+@loaded_envelope['envelope_version']
+#=> 2
+
+## aad_fields preserved through save/load cycle
+@loaded_envelope['aad_fields']
+#=> ["org_id"]
+
+## Decrypt works after save/load with envelope metadata
+@decrypted_loaded = nil
+@loaded_record.secret.reveal { |pt| @decrypted_loaded = pt }
+@decrypted_loaded
+#=> "save-load-secret"
+
+## Multiple aad_fields stored correctly in envelope
+class MultiAADModel < Familia::Horreum
+  feature :encrypted_fields
+  identifier_field :id
+  field :id
+  field :org
+  field :role
+  field :env
+  encrypted_field :credentials, aad_fields: [:org, :role, :env]
+end
+@multi = MultiAADModel.new(id: 'multi-1', org: 'acme', role: 'admin', env: 'prod')
+@multi.credentials = 'multi-creds'
+@multi_json = @multi.instance_variable_get(:@credentials).encrypted_value
+@multi_env = Familia::JsonSerializer.parse(@multi_json)
+@multi_env['aad_fields'].sort
+#=> ["env", "org", "role"]
+
+## Empty aad_fields array not stored in envelope
+class EmptyAADModel < Familia::Horreum
+  feature :encrypted_fields
+  identifier_field :id
+  field :id
+  encrypted_field :data, aad_fields: []
+end
+@empty_aad = EmptyAADModel.new(id: 'empty-aad-1')
+@empty_aad.data = 'empty-aad-data'
+@empty_json = @empty_aad.instance_variable_get(:@data).encrypted_value
+@empty_env = Familia::JsonSerializer.parse(@empty_json)
+@empty_env['aad_fields']
+#=> nil
+
+Familia.dbclient.flushdb
+Familia.config.encryption_keys = nil
+Familia.config.current_key_version = nil

--- a/try/features/encrypted_fields/key_material_try.rb
+++ b/try/features/encrypted_fields/key_material_try.rb
@@ -1,0 +1,205 @@
+# try/features/encrypted_fields/key_material_try.rb
+#
+# frozen_string_literal: true
+
+# Tests for the key_material: option on encrypted_field.
+# key_material mixes additional entropy into key derivation (BLAKE2b),
+# meaning wrong value produces garbage output (not auth_tag mismatch).
+# Regression test for GitHub issue #280.
+
+require 'base64'
+require_relative '../../support/helpers/test_helpers'
+
+test_keys = {
+  v1: Base64.strict_encode64('a' * 32),
+}
+Familia.config.encryption_keys = test_keys
+Familia.config.current_key_version = :v1
+
+# Model with key_material from regular field
+class KeyMaterialModel < Familia::Horreum
+  feature :encrypted_fields
+
+  identifier_field :id
+  field :id
+  field :user_salt
+
+  encrypted_field :secret, key_material: ->(rec) { rec.user_salt }
+end
+
+# Model with key_material from transient field (returns RedactedString)
+class KeyMaterialTransientModel < Familia::Horreum
+  feature :encrypted_fields
+  feature :transient_fields
+
+  identifier_field :id
+  field :id
+  transient_field :passphrase
+
+  encrypted_field :vault_key, key_material: ->(rec) { rec.passphrase }
+end
+
+# Model without key_material for backward compatibility test
+class NoKeyMaterialModel < Familia::Horreum
+  feature :encrypted_fields
+
+  identifier_field :id
+  field :id
+  encrypted_field :token
+end
+
+Familia.dbclient.flushdb
+
+## key_material present, correct value at decrypt succeeds
+record = KeyMaterialModel.new(id: 'km-1', user_salt: 'salt-abc')
+record.secret = 'my-secret'
+decrypted = nil
+record.secret.reveal { |pt| decrypted = pt }
+decrypted
+#=> "my-secret"
+
+## key_material present, wrong value at decrypt fails with EncryptionError
+record_wrong = KeyMaterialModel.new(id: 'km-2', user_salt: 'original-salt')
+record_wrong.secret = 'bound-to-salt'
+record_wrong.user_salt = 'changed-salt'
+result = begin
+  record_wrong.secret.reveal { |pt| pt }
+  'UNEXPECTED SUCCESS'
+rescue Familia::EncryptionError
+  'Familia::EncryptionError'
+end
+result
+#=> "Familia::EncryptionError"
+
+## key_material present, value nil at encrypt derives different key
+record_nil = KeyMaterialModel.new(id: 'km-3')
+record_nil.secret = 'nil-salt-secret'
+decrypted_nil = nil
+record_nil.secret.reveal { |pt| decrypted_nil = pt }
+decrypted_nil
+#=> "nil-salt-secret"
+
+## Different key_material values produce different ciphertexts
+record_a = KeyMaterialModel.new(id: 'km-diff', user_salt: 'salt-A')
+record_a.secret = 'same-plaintext'
+ciphertext_a = record_a.instance_variable_get(:@secret).encrypted_value
+
+record_b = KeyMaterialModel.new(id: 'km-diff', user_salt: 'salt-B')
+record_b.secret = 'same-plaintext'
+ciphertext_b = record_b.instance_variable_get(:@secret).encrypted_value
+
+ciphertext_a != ciphertext_b
+#=> true
+
+## key_material proc returning RedactedString extracts .value correctly
+record_transient = KeyMaterialTransientModel.new(id: 'km-transient-1')
+record_transient.passphrase = 'my-passphrase'
+record_transient.vault_key = 'vault-secret'
+decrypted_transient = nil
+record_transient.vault_key.reveal { |pt| decrypted_transient = pt }
+decrypted_transient
+#=> "vault-secret"
+
+## RedactedString key_material: decrypt fails with changed passphrase
+record_tamper = KeyMaterialTransientModel.new(id: 'km-tamper-1')
+record_tamper.passphrase = 'original-passphrase'
+record_tamper.vault_key = 'protected-key'
+record_tamper.passphrase = 'tampered-passphrase'
+result_tamper = begin
+  record_tamper.vault_key.reveal { |pt| pt }
+  'UNEXPECTED SUCCESS'
+rescue Familia::EncryptionError
+  'Familia::EncryptionError'
+end
+result_tamper
+#=> "Familia::EncryptionError"
+
+## No key_material option works as before (backward compat)
+record_compat = NoKeyMaterialModel.new(id: 'compat-1')
+record_compat.token = 'backward-compat-token'
+decrypted_compat = nil
+record_compat.token.reveal { |pt| decrypted_compat = pt }
+decrypted_compat
+#=> "backward-compat-token"
+
+## Envelope contains key_material_fields metadata when key_material used
+record_meta = KeyMaterialModel.new(id: 'km-meta-1', user_salt: 'meta-salt')
+record_meta.secret = 'meta-secret'
+encrypted_json = record_meta.instance_variable_get(:@secret).encrypted_value
+envelope = Familia::JsonSerializer.parse(encrypted_json)
+envelope['key_material_fields']
+#=> ["key_material"]
+
+## Envelope does NOT contain key_material_fields when not used
+record_nometa = NoKeyMaterialModel.new(id: 'nometa-1')
+record_nometa.token = 'no-material'
+encrypted_json_nometa = record_nometa.instance_variable_get(:@token).encrypted_value
+envelope_nometa = Familia::JsonSerializer.parse(encrypted_json_nometa)
+envelope_nometa['key_material_fields']
+#=> nil
+
+## key_material with nil proc result encrypts without extra entropy
+class NilKeyMaterialModel < Familia::Horreum
+  feature :encrypted_fields
+  identifier_field :id
+  field :id
+  encrypted_field :data, key_material: ->(_rec) { nil }
+end
+@record_nil_proc = NilKeyMaterialModel.new(id: 'nil-km-1')
+@record_nil_proc.data = 'nil-km-data'
+@decrypted_nil_proc = nil
+@record_nil_proc.data.reveal { |pt| @decrypted_nil_proc = pt }
+@decrypted_nil_proc
+#=> "nil-km-data"
+
+## Nil key_material does not add key_material_fields to envelope
+@encrypted_nil_km = @record_nil_proc.instance_variable_get(:@data).encrypted_value
+@envelope_nil_km = Familia::JsonSerializer.parse(@encrypted_nil_km)
+@envelope_nil_km['key_material_fields']
+#=> nil
+
+## key_material combined with aad_fields works together
+class CombinedModel < Familia::Horreum
+  feature :encrypted_fields
+  identifier_field :id
+  field :id
+  field :tenant_id
+  field :user_salt
+  encrypted_field :api_secret, aad_fields: [:tenant_id], key_material: ->(r) { r.user_salt }
+end
+record_combined = CombinedModel.new(id: 'combined-1', tenant_id: 'tenant-abc', user_salt: 'salt-123')
+record_combined.api_secret = 'combined-secret'
+decrypted_combined = nil
+record_combined.api_secret.reveal { |pt| decrypted_combined = pt }
+decrypted_combined
+#=> "combined-secret"
+
+## Combined: changing aad_field fails decrypt
+record_aad_fail = CombinedModel.new(id: 'aad-fail-1', tenant_id: 'tenant-orig', user_salt: 'salt-ok')
+record_aad_fail.api_secret = 'aad-bound'
+record_aad_fail.tenant_id = 'tenant-changed'
+result_aad = begin
+  record_aad_fail.api_secret.reveal { |pt| pt }
+  'UNEXPECTED SUCCESS'
+rescue Familia::EncryptionError
+  'Familia::EncryptionError'
+end
+result_aad
+#=> "Familia::EncryptionError"
+
+## Combined: changing key_material also fails decrypt
+record_km_fail = CombinedModel.new(id: 'km-fail-1', tenant_id: 'tenant-ok', user_salt: 'salt-orig')
+record_km_fail.api_secret = 'km-bound'
+record_km_fail.user_salt = 'salt-changed'
+result_km = begin
+  record_km_fail.api_secret.reveal { |pt| pt }
+  'UNEXPECTED SUCCESS'
+rescue Familia::EncryptionError
+  'Familia::EncryptionError'
+end
+result_km
+#=> "Familia::EncryptionError"
+
+Familia.dbclient.flushdb
+Familia.config.encryption_keys = nil
+Familia.config.current_key_version = nil


### PR DESCRIPTION
Closes #280

Completes the two related `encrypted_field` improvements from #280: fixing AAD binding for transient fields, and adding a `key_material:` option for key-derivation entropy. Along the way the envelope metadata now flows through the `EncryptedData` value object instead of hand-rolled JSON in the field type.

## What changed

**The AAD fix (the bug).** `build_aad` called `.to_s` on field values. For a transient field that's a `RedactedString`, `.to_s` returns `"[REDACTED]"` — so every passphrase produced identical AAD and the binding did nothing. AAD now unwraps `RedactedString` to its real `.value`. Regular fields are unchanged (`.to_s` either way).

**Envelope versioning.** Encrypted envelopes now carry `envelope_version: 2` plus the `aad_fields` used at encrypt time. Decryption rebuilds AAD from the envelope's own field list rather than the current class declaration, so changing a model's `aad_fields` no longer breaks previously-encrypted values. `decrypt_value` branches on the version: v2 envelopes use stored metadata; versionless (legacy) envelopes take the old class-level path and never apply key material.

**`key_material:` option.** A proc whose return value is mixed into key derivation (BLAKE2b context), separate from AAD. Because it changes the derived key rather than the auth tag, a wrong value yields garbage output instead of an auth-tag mismatch. The proc may return a `RedactedString` (unwrapped via `.value`); when used, the envelope records `key_material_fields` so decrypt knows to re-apply it.

**Value-object refactor.** `EncryptedData` gained `with_metadata`, `to_json`, `has_key_material?`, and `stored_aad_fields`, so envelope construction/parsing no longer pokes raw string/symbol hash keys in `EncryptedFieldType`. The two duplicate AAD builders collapsed into one `build_aad(record, fields:)`, with shared `unwrap_value` and `context_with_entropy` helpers.

## Backward compatibility

Old envelopes (no `envelope_version`) decrypt transparently via the legacy class-level AAD path — the crypto envelope structure (algorithm, nonce, ciphertext, auth_tag) is unchanged, and the new metadata fields are additive.

**One intentional break:** values encrypted by an earlier release that used a *transient* field in `aad_fields` were bound to `"[REDACTED]"` and will no longer decrypt after upgrading — they had no real binding to begin with. This affects transient `aad_fields` only; re-encrypt affected values if any exist. `#280` is not on `main` or tagged, so the envelope-versioning additions ship clean; only this transient-AAD semantic change is a break. Documented in the Security section of the changelog fragment.

## Tests

Five test files (~800 lines):
- `aad_transient_fix_try.rb` — distinct AAD per transient value, nil handling, mixed regular+transient fields
- `encrypted_data_try.rb` — value-object round-trips, nil-key omission, JSON symbol coercion
- `envelope_version_try.rb` — new envelopes marked v2, `aad_fields` stored, round-trip preservation
- `envelope_version_branching_try.rb` — v1-vs-v2 decrypt dispatch, stripped-metadata failure paths
- `key_material_try.rb` — regular and transient key material, wrong-value-is-garbage, combined with `aad_fields`

Encrypted suite: 349/349. Full suite: 5534/5534.

A changelog fragment (`changelog.d/20260603_000000_claude_280_aad_key_material.rst`) covers all four parts and the security caveat.