### PR TITLE
Fix each_record on unique_index by making hashkeys reference types

### DIFF
--- a/changelog.d/20260603_010000_claude_276_unique_index_each_record.rst
+++ b/changelog.d/20260603_010000_claude_276_unique_index_each_record.rst
@@ -1,0 +1,44 @@
+Fixed
+-----
+
+- ``each_record`` now works on ``unique_index`` hashkeys. Previously it raised
+  ``Familia::Problem`` ("each_record requires a reference DataType with a
+  :class option that responds to load_multi") because ``unique_index`` created
+  its backing hashkey without the ``class:`` option. The index hashkey is now
+  declared as a proper reference type (``class: indexed_class,
+  reference: true``), matching the ``instances`` collection, so iteration loads
+  the indexed records via ``load_multi``. Applies to both class-level
+  (``unique_index :email, :email_lookup``) and instance-scoped
+  (``unique_index :badge, :badge_index, within: Company``) indexes. Issue #276
+
+- ``each_record`` extracts the stored identifier (the hash *value*) from a
+  HashKey instead of the indexed field (the hash *key*). A ``unique_index``
+  maps ``field_value => identifier``, so the value is the record identifier
+  passed to ``load_multi``. List/Set/SortedSet behaviour is unchanged (their
+  members are already identifiers). Issue #276
+
+Changed
+-------
+
+- ``unique_index`` hashkeys now store object identifiers as raw strings
+  (reference semantics) rather than JSON-encoded strings. A value previously
+  stored as ``"\"u1\""`` is now stored as ``"u1"``. Reads through
+  ``find_by_*``/``hgetall``/``get`` are unaffected (they round-trip to the same
+  identifier), but the on-disk format differs. After upgrading, rebuild
+  existing unique indexes to convert legacy entries, e.g.
+  ``User.rebuild_email_lookup`` (class-level) or
+  ``company.rebuild_badge_index`` (instance-scoped). This also removes a latent
+  inconsistency where the auto-index mutation path wrote JSON-encoded values
+  while ``rebuild_*`` wrote raw identifiers. Issue #276
+
+AI Assistance
+-------------
+
+- AI diagnosed the root cause, confirmed it with reproduction scripts against a
+  live database (showing the raised error, the JSON-vs-raw storage format, and
+  that a naive ``class:``-only fix would break ``find_by_*`` and silently yield
+  zero records from ``each_record``), implemented the reference-type fix across
+  the class-level and instance-scoped generators, corrected the ``each_record``
+  field-vs-value extraction, updated audit/repair test fixtures that pinned the
+  old storage format, and added focused regression coverage in
+  ``try/features/relationships/unique_index_each_record_try.rb``. Issue #276

--- a/docs/migrating/v2.9.2.md
+++ b/docs/migrating/v2.9.2.md
@@ -1,0 +1,74 @@
+# Migrating to Familia 2.9.2
+
+This version fixes `each_record` on `unique_index` hashkeys (issue #276). As part
+of the fix, the on-disk storage format for unique-index values changes. Reads
+through the public API are unaffected, but existing indexes should be rebuilt so
+their stored values match the new format.
+
+## What changed
+
+`unique_index` declarations now back their lookup with a **reference-type**
+hashkey (`class: <indexed class>, reference: true`), the same shape already used
+by the class-level `instances` collection. This lets `each_record` iterate the
+index and load the indexed records via `load_multi`:
+
+```ruby
+class User < Familia::Horreum
+  feature :relationships
+  field :email
+  unique_index :email, :email_lookup
+end
+
+# Before 2.9.2: raised Familia::Problem
+#   "each_record requires a reference DataType with a :class option..."
+# 2.9.2+: yields each indexed User
+User.email_lookup.each_record { |user| user.notify! }
+```
+
+Two pieces moved together:
+
+- The index hashkey carries `class:`/`reference: true`, so stored identifiers
+  round-trip as raw strings.
+- `each_record` extracts the hash **value** (the stored identifier) from a
+  HashKey rather than the hash **key** (the indexed field). A `unique_index`
+  maps `field_value => identifier`, so the value is what `load_multi` needs.
+
+## Storage format change
+
+Unique-index values are now stored as **raw identifier strings** instead of
+JSON-encoded strings:
+
+```
+# Before: redis-cli HGET user:email_lookup alice@example.com
+"\"u1\""
+
+# After:
+"u1"
+```
+
+Public reads are unchanged — `User.find_by_email`, `email_lookup.get`,
+`email_lookup.hgetall`, and `email_lookup.values` all still return the
+identifier `"u1"`. Only the byte format stored in Redis differs.
+
+### Action required: rebuild existing indexes
+
+Values written by an earlier release (JSON-encoded) will not resolve correctly
+when read by 2.9.2 as a reference type. Rebuild each unique index once after
+upgrading:
+
+```ruby
+# Class-level unique_index
+User.rebuild_email_lookup
+
+# Instance-scoped unique_index (within: Company) — rebuild per scope instance
+company.rebuild_badge_index
+```
+
+Rebuilds read from the source of truth (`instances` and scanned object hashes)
+and rewrite the index in the new format via an atomic swap, so there is no
+downtime. If you maintain indexes only via auto-indexing on `save`, you can
+alternatively re-save the affected records.
+
+> Note: this also removes a latent inconsistency where the auto-index mutation
+> path wrote JSON-encoded values while `rebuild_*` already wrote raw
+> identifiers. After 2.9.2 both paths agree.

--- a/lib/familia/data_type/collection_base.rb
+++ b/lib/familia/data_type/collection_base.rb
@@ -109,8 +109,10 @@ module Familia
 
         # Iterate using the type's each method with any filters
         each(**filters) do |member|
-          # HashKey yields [field, value] pairs; extract field as identifier
-          identifier = member.is_a?(Array) ? member.first : member
+          # HashKey yields [field, value] pairs where the value is the stored
+          # object identifier (e.g. unique_index maps field_value => identifier),
+          # so extract the value. List/Set/SortedSet yield the identifier directly.
+          identifier = member.is_a?(Array) ? member.last : member
           buffer << identifier
 
           if buffer.size >= batch_size

--- a/lib/familia/features/relationships/indexing.rb
+++ b/lib/familia/features/relationships/indexing.rb
@@ -139,10 +139,14 @@ module Familia
 
           # Ensure proper DataType field is declared for index
           # Similar to ensure_collection_field in participation system
-          def ensure_index_field(scope_class, index_name, field_type)
+          #
+          # @param opts [Hash] Options forwarded to the DataType declaration
+          #   (e.g. +class:+ and +reference: true+ so the index hashkey is a
+          #   proper reference type that works with +each_record+).
+          def ensure_index_field(scope_class, index_name, field_type, opts = {})
             return if scope_class.method_defined?(index_name) || scope_class.respond_to?(index_name)
 
-            scope_class.send(field_type, index_name)
+            scope_class.send(field_type, index_name, opts)
           end
         end
 

--- a/lib/familia/features/relationships/indexing/unique_index_generators.rb
+++ b/lib/familia/features/relationships/indexing/unique_index_generators.rb
@@ -84,7 +84,16 @@ module Familia
               generate_mutation_methods_self(indexed_class, field, scope_class, index_name)
             when :class
               # Class-level index (no within:)
-              indexed_class.send(:ensure_index_field, indexed_class, index_name, :class_hashkey)
+              #
+              # Declare the backing hashkey as a reference type pointing at the
+              # indexed class. The index maps field_value => object identifier,
+              # so `class: indexed_class, reference: true` lets the stored
+              # identifiers round-trip as raw strings and enables `each_record`
+              # to load the indexed records via load_multi.
+              indexed_class.send(
+                :ensure_index_field, indexed_class, index_name, :class_hashkey,
+                class: indexed_class, reference: true
+              )
               generate_query_methods_class(field, index_name, indexed_class) if query
               generate_mutation_methods_class(field, index_name, indexed_class)
             end
@@ -105,8 +114,14 @@ module Familia
             # Resolve scope class using Familia pattern
             actual_scope_class = Familia.resolve_class(scope_class)
 
-            # Ensure the index field is declared (creates accessor that returns DataType)
-            actual_scope_class.send(:ensure_index_field, actual_scope_class, index_name, :hashkey)
+            # Ensure the index field is declared (creates accessor that returns DataType).
+            # The hashkey lives on the scope class but maps field_value => identifier
+            # of the indexed class, so declare it as a reference type pointing at
+            # indexed_class (raw identifier round-trip + each_record support).
+            actual_scope_class.send(
+              :ensure_index_field, actual_scope_class, index_name, :hashkey,
+              class: indexed_class, reference: true
+            )
 
             # Get scope_class_config for method naming (needed for rebuild methods)
             scope_class_config = actual_scope_class.config_name

--- a/try/audit/audit_cross_references_try.rb
+++ b/try/audit/audit_cross_references_try.rb
@@ -188,7 +188,7 @@ ACRIndexedUser.email_index.clear
 @u1.save
 @u2 = ACRIndexedUser.new(user_id: 'cr-sb-2', email: 'bob@example.com', name: 'Bob')
 @u2.save
-Familia.dbclient.hset(ACRIndexedUser.email_index.dbkey, 'alice@example.com', '"cr-sb-2"')
+Familia.dbclient.hset(ACRIndexedUser.email_index.dbkey, 'alice@example.com', 'cr-sb-2')
 @result = ACRIndexedUser.audit_cross_references
 @result[:index_points_to_wrong_identifier].any? { |r| r[:expected_id] == 'cr-sb-1' }
 #=> true
@@ -200,7 +200,7 @@ ACRIndexedUser.email_index.clear
 @u1.save
 @u2 = ACRIndexedUser.new(user_id: 'cr-sb-2', email: 'bob@example.com', name: 'Bob')
 @u2.save
-Familia.dbclient.hset(ACRIndexedUser.email_index.dbkey, 'alice@example.com', '"cr-sb-2"')
+Familia.dbclient.hset(ACRIndexedUser.email_index.dbkey, 'alice@example.com', 'cr-sb-2')
 @entry = ACRIndexedUser.audit_cross_references[:index_points_to_wrong_identifier].find { |r| r[:expected_id] == 'cr-sb-1' }
 [@entry[:expected_id], @entry[:index_id]]
 #=> ['cr-sb-1', 'cr-sb-2']
@@ -212,7 +212,7 @@ ACRIndexedUser.email_index.clear
 @u1.save
 @u2 = ACRIndexedUser.new(user_id: 'cr-sb-2', email: 'bob@example.com', name: 'Bob')
 @u2.save
-Familia.dbclient.hset(ACRIndexedUser.email_index.dbkey, 'alice@example.com', '"cr-sb-2"')
+Familia.dbclient.hset(ACRIndexedUser.email_index.dbkey, 'alice@example.com', 'cr-sb-2')
 @entry = ACRIndexedUser.audit_cross_references[:index_points_to_wrong_identifier].find { |r| r[:expected_id] == 'cr-sb-1' }
 @entry[:field_value]
 #=> 'alice@example.com'
@@ -224,7 +224,7 @@ ACRIndexedUser.email_index.clear
 @u1.save
 @u2 = ACRIndexedUser.new(user_id: 'cr-sb-2', email: 'bob@example.com', name: 'Bob')
 @u2.save
-Familia.dbclient.hset(ACRIndexedUser.email_index.dbkey, 'alice@example.com', '"cr-sb-2"')
+Familia.dbclient.hset(ACRIndexedUser.email_index.dbkey, 'alice@example.com', 'cr-sb-2')
 @entry = ACRIndexedUser.audit_cross_references[:index_points_to_wrong_identifier].find { |r| r[:expected_id] == 'cr-sb-1' }
 @entry[:index_name]
 #=> :email_index
@@ -236,7 +236,7 @@ ACRIndexedUser.email_index.clear
 @u1.save
 @u2 = ACRIndexedUser.new(user_id: 'cr-sb-2', email: 'bob@example.com', name: 'Bob')
 @u2.save
-Familia.dbclient.hset(ACRIndexedUser.email_index.dbkey, 'alice@example.com', '"cr-sb-2"')
+Familia.dbclient.hset(ACRIndexedUser.email_index.dbkey, 'alice@example.com', 'cr-sb-2')
 ACRIndexedUser.audit_cross_references[:status]
 #=> :issues_found
 
@@ -457,7 +457,7 @@ ACRIndexedUser.email_index.clear
 @u_wrong = ACRIndexedUser.new(user_id: 'cb-wrong', email: 'wrong@example.com', name: 'Wrong')
 @u_wrong.save
 Familia.dbclient.hdel(ACRIndexedUser.email_index.dbkey, 'miss@example.com')
-Familia.dbclient.hset(ACRIndexedUser.email_index.dbkey, 'wrong@example.com', '"other-id"')
+Familia.dbclient.hset(ACRIndexedUser.email_index.dbkey, 'wrong@example.com', 'other-id')
 @combined = ACRIndexedUser.audit_cross_references
 [@combined[:in_instances_missing_unique_index].any? { |r| r[:identifier] == 'cb-miss' },
  @combined[:index_points_to_wrong_identifier].any? { |r| r[:expected_id] == 'cb-wrong' && r[:index_id] == 'other-id' },

--- a/try/audit/audit_unique_indexes_try.rb
+++ b/try/audit/audit_unique_indexes_try.rb
@@ -52,7 +52,8 @@ AuditIndexedUser.audit_unique_indexes.is_a?(Array)
 #=> :email_lookup
 
 ## Stale entry: manually inject wrong value via raw Redis
-AuditIndexedUser.dbclient.hset(AuditIndexedUser.email_lookup.dbkey, 'old@test.com', '"au-999"')
+# unique_index hashkeys are reference types: stored values are raw identifiers
+AuditIndexedUser.dbclient.hset(AuditIndexedUser.email_lookup.dbkey, 'old@test.com', 'au-999')
 @result = AuditIndexedUser.audit_unique_indexes
 @result.first[:stale].any? { |s| s[:field_value] == 'old@test.com' }
 #=> true
@@ -75,7 +76,7 @@ AuditIndexedUser.email_lookup.clear
 AuditIndexedUser.email_lookup.clear
 @u1.save  # re-indexes
 @u2.save
-AuditIndexedUser.dbclient.hset(AuditIndexedUser.email_lookup.dbkey, 'alice@test.com', '"au-2"')
+AuditIndexedUser.dbclient.hset(AuditIndexedUser.email_lookup.dbkey, 'alice@test.com', 'au-2')
 @result = AuditIndexedUser.audit_unique_indexes
 @stale = @result.first[:stale].find { |s| s[:field_value] == 'alice@test.com' }
 @stale[:reason]

--- a/try/audit/repair_all_integration_try.rb
+++ b/try/audit/repair_all_integration_try.rb
@@ -56,7 +56,8 @@ IntegrationItem.instances.member?('int-1')
 #=> false
 
 ## Introduce corruption in unique index: add stale entry for non-existent object
-IntegrationItem.dbclient.hset(IntegrationItem.email_lookup.dbkey, 'stale@test.com', '"int-999"')
+# unique_index hashkeys are reference types: stored values are raw identifiers
+IntegrationItem.dbclient.hset(IntegrationItem.email_lookup.dbkey, 'stale@test.com', 'int-999')
 IntegrationItem.audit_unique_indexes.first[:stale].size
 #=> 1
 

--- a/try/audit/repair_indexes_try.rb
+++ b/try/audit/repair_indexes_try.rb
@@ -37,7 +37,8 @@ RepairIdxUser.audit_unique_indexes.first[:stale].size
 #=> 0
 
 ## Corrupt index by adding stale entry via raw Redis
-RepairIdxUser.dbclient.hset(RepairIdxUser.email_lookup.dbkey, 'gone@test.com', '"ri-999"')
+# unique_index hashkeys are reference types: stored values are raw identifiers
+RepairIdxUser.dbclient.hset(RepairIdxUser.email_lookup.dbkey, 'gone@test.com', 'ri-999')
 RepairIdxUser.audit_unique_indexes.first[:stale].size
 #=> 1
 

--- a/try/features/relationships/unique_index_each_record_try.rb
+++ b/try/features/relationships/unique_index_each_record_try.rb
@@ -1,0 +1,143 @@
+# try/features/relationships/unique_index_each_record_try.rb
+#
+# frozen_string_literal: true
+
+# Tests for issue #276: unique_index hashkeys were created without the
+# `class:` option, so `each_record` raised Familia::Problem ("requires a
+# reference DataType with a :class option that responds to load_multi").
+#
+# The fix declares unique_index hashkeys as proper reference types
+# (`class: indexed_class, reference: true`), matching the `instances`
+# collection pattern, and teaches `each_record` to extract the stored
+# identifier (the hash value) rather than the indexed field (the hash key).
+
+require_relative '../../support/helpers/test_helpers'
+
+class UIERUser < Familia::Horreum
+  feature :relationships
+
+  identifier_field :user_id
+  field :user_id
+  field :email
+
+  unique_index :email, :email_lookup
+end
+
+class UIERCompany < Familia::Horreum
+  feature :relationships
+
+  identifier_field :company_id
+  field :company_id
+end
+
+class UIEREmployee < Familia::Horreum
+  feature :relationships
+
+  identifier_field :emp_id
+  field :emp_id
+  field :badge_number
+
+  unique_index :badge_number, :badge_index, within: UIERCompany
+end
+
+# Setup
+UIERUser.email_lookup.clear
+UIERUser.instances.clear
+@u0 = UIERUser.new(user_id: 'u0', email: 'u0@example.com')
+@u0.save
+@u1 = UIERUser.new(user_id: 'u1', email: 'u1@example.com')
+@u1.save
+@u2 = UIERUser.new(user_id: 'u2', email: 'u2@example.com')
+@u2.save
+
+# ============================================================
+# The index hashkey is a proper reference type
+# ============================================================
+
+## Class-level unique_index hashkey carries the indexed class
+UIERUser.email_lookup.opts[:class]
+#=> UIERUser
+
+## Class-level unique_index hashkey is a reference type
+UIERUser.email_lookup.opts[:reference]
+#=> true
+
+## Stored values are raw identifiers (not JSON-encoded)
+UIERUser.dbclient.hget(UIERUser.email_lookup.dbkey, 'u1@example.com')
+#=> "u1"
+
+## find_by_<field> still resolves the record
+UIERUser.find_by_email('u1@example.com')&.user_id
+#=> "u1"
+
+# ============================================================
+# each_record on a class-level unique_index (issue #276)
+# ============================================================
+
+## each_record no longer raises and yields Horreum records
+records = []
+UIERUser.email_lookup.each_record { |r| records << r }
+records.all? { |r| r.is_a?(UIERUser) }
+#=> true
+
+## each_record yields every indexed record (by identifier, not field)
+records = []
+UIERUser.email_lookup.each_record { |r| records << r }
+records.map(&:user_id).sort
+#=> ["u0", "u1", "u2"]
+
+## each_record returns an Enumerator when no block is given
+UIERUser.email_lookup.each_record.class
+#=> Enumerator
+
+## each_record Enumerator composes with Enumerable
+UIERUser.email_lookup.each_record.map(&:email).sort
+#=> ["u0@example.com", "u1@example.com", "u2@example.com"]
+
+## each_record honors batch_size
+records = []
+UIERUser.email_lookup.each_record(batch_size: 1) { |r| records << r }
+records.map(&:user_id).sort
+#=> ["u0", "u1", "u2"]
+
+## each_record skips ghost entries (value points at a deleted record)
+UIERUser.dbclient.hset(UIERUser.email_lookup.dbkey, 'ghost@example.com', 'u-ghost')
+records = []
+UIERUser.email_lookup.each_record { |r| records << r }
+result = records.map(&:user_id).sort
+UIERUser.email_lookup.remove('ghost@example.com')
+result
+#=> ["u0", "u1", "u2"]
+
+# ============================================================
+# each_record on an instance-scoped unique_index
+# ============================================================
+
+## Instance-scoped unique_index hashkey is also a reference type
+@company = UIERCompany.new(company_id: 'c1')
+@company.badge_index.opts[:class]
+#=> UIEREmployee
+
+## Instance-scoped unique_index hashkey carries reference: true
+@company.badge_index.opts[:reference]
+#=> true
+
+## each_record on the instance-scoped index yields the indexed employees
+@company.badge_index.clear
+@e1 = UIEREmployee.new(emp_id: 'e1', badge_number: 'B1')
+@e1.save
+@e2 = UIEREmployee.new(emp_id: 'e2', badge_number: 'B2')
+@e2.save
+@e1.add_to_uier_company_badge_index(@company)
+@e2.add_to_uier_company_badge_index(@company)
+records = []
+@company.badge_index.each_record { |r| records << r }
+records.map(&:emp_id).sort
+#=> ["e1", "e2"]
+
+# Teardown
+UIERUser.email_lookup.clear
+UIERUser.instances.clear
+[@u0, @u1, @u2].each { |u| u.destroy! rescue nil }
+@company.badge_index.clear rescue nil
+[@e1, @e2].each { |e| e.destroy! rescue nil }


### PR DESCRIPTION
## Summary

Fixes issue #276: `each_record` now works on `unique_index` hashkeys. Previously it raised `Familia::Problem` because unique indexes created their backing hashkeys without the `class:` option needed for `load_multi` support.

The fix declares unique_index hashkeys as proper reference types (`class: indexed_class, reference: true`), matching the existing `instances` collection pattern. This enables `each_record` to iterate indexes and load indexed records correctly.

## Key Changes

- **Unique index hashkey declaration** (`lib/familia/features/relationships/indexing/unique_index_generators.rb`):
  - Class-level indexes now declare backing hashkeys with `class: indexed_class, reference: true`
  - Instance-scoped indexes (within: scope) also declare their hashkeys as reference types pointing to the indexed class
  - Updated `ensure_index_field` to accept and forward options to the DataType declaration

- **Storage format change** (`lib/familia/data_type/collection_base.rb`):
  - Unique index values now stored as raw identifier strings (reference semantics) instead of JSON-encoded strings
  - `each_record` now extracts the hash **value** (stored identifier) instead of the hash **key** (indexed field) for HashKey types
  - List/Set/SortedSet behavior unchanged (members are already identifiers)

- **Test fixtures updated** (`try/audit/` files):
  - Updated audit and repair test fixtures to use raw identifier format (`'u1'` instead of `'"u1"'`)
  - Added comments clarifying that unique_index hashkeys are reference types

- **Documentation** (`docs/migrating/v2.9.2.md`):
  - Migration guide explaining the storage format change and rebuild requirements
  - Instructions for rebuilding existing indexes after upgrade

- **Regression test** (`try/features/relationships/unique_index_each_record_try.rb`):
  - Comprehensive test coverage for `each_record` on both class-level and instance-scoped unique indexes
  - Validates that indexes are proper reference types with correct storage format
  - Tests batch processing, Enumerator composition, and ghost entry handling

## Implementation Details

The fix aligns unique_index backing hashkeys with the existing `instances` collection pattern:
- Both now use `class: <target_class>, reference: true` declarations
- Both store raw identifier strings for round-trip consistency
- Both support `each_record` iteration via `load_multi`

A unique_index maps `field_value => identifier`, so `each_record` must extract the hash **value** (the identifier) rather than the key (the indexed field). This is the inverse of how other HashKey uses work, but correct for this semantic.

Existing indexes must be rebuilt after upgrade to convert legacy JSON-encoded values to the new raw format. Rebuilds are atomic and non-disruptive.

https://claude.ai/code/session_01CkfHyueYPqPtwwushaTkne