### PR TITLE
Distinguish new, unsaved parents in dirty-write warnings (#278)

### DIFF
--- a/changelog.d/20260603_120000_claude_278_new_unsaved_dirty_write.rst
+++ b/changelog.d/20260603_120000_claude_278_new_unsaved_dirty_write.rst
@@ -1,17 +1,29 @@
 Changed
 -------
 
-- Dirty-write warnings now treat a *new, unsaved* parent as a distinct case.
-  When a collection (``list``/``set``/``zset``/``hashkey``) is mutated while its
-  parent Horreum has uncommitted scalar changes, ``warn_if_dirty!`` distinguishes
-  a parent that has never been persisted (no hash key exists in the database yet)
-  from one that was saved before and merely has pending changes. The former is
-  the more dangerous case -- the collection write lands in Redis while *none* of
-  the parent's scalar data exists, orphaning the collection if the process never
-  saves -- so it now emits a distinct, stronger message ("... is a new, unsaved
-  object (no hash key exists yet) ...") and, under ``Familia.strict_write_order``,
-  raises with that same message. Previously-saved-but-dirty parents keep the
-  original wording and behaviour. Issue #278
+- Mutating a collection (``list``/``set``/``zset``/``hashkey``) while its parent
+  Horreum is a *new, unsaved* object -- one whose hash key does not exist in the
+  database yet -- now **raises** ``Familia::Problem`` by default, independently of
+  ``Familia.strict_write_order``. This is the most dangerous dirty-write case: the
+  collection write would land in Redis while *none* of the parent's scalar data
+  exists, orphaning the collection if the parent is never saved. The guard fires
+  *before* the collection command runs, so no orphaned data is written. Previously
+  this path only emitted a warning unless ``strict_write_order`` was enabled. Save
+  the parent before mutating its collections (the recommended fix), or set
+  ``Familia.raise_on_unsaved_parent_write = false`` to keep the old warn-only
+  behaviour. A previously-saved parent with uncommitted scalar changes is
+  unaffected -- it still only warns (or raises under ``strict_write_order``), and
+  now with a message that no longer conflates the two cases. Issue #278
+
+Added
+-----
+
+- ``Familia.raise_on_unsaved_parent_write`` (default ``true``) controls whether a
+  collection write on a new, unsaved, dirty parent raises or merely warns. Set it
+  to ``false`` via ``Familia.configure`` to downgrade the new-object case to a
+  distinct, strongly-worded warning instead of an exception.
+  ``Familia.strict_write_order`` continues to raise for every dirty write and
+  overrides this setting. Issue #278
 
 AI Assistance
 -------------
@@ -19,6 +31,10 @@ AI Assistance
 - AI investigated how persistence state is (and is not) tracked on Horreum
   instances, implemented the new-object detection as a guarded ``exists?`` probe
   that short-circuits inside transactions/pipelines (so it never queues a stray
-  EXISTS into an open MULTI/EXEC) and falls back safely when the parent has no
-  identifier yet, and added tryout coverage for the new-vs-saved distinction in
-  both warning and strict modes. Issue #278
+  EXISTS into an open MULTI/EXEC), falls back safely when the parent has no
+  identifier yet, and traces that swallowed problem only when ``Familia.debug?``
+  is set. Added the ``raise_on_unsaved_parent_write`` setting and tryout coverage
+  for the full raise/warn matrix across new-vs-saved parents and both global
+  settings. Two existing tryouts that mutated collections on unsaved dirty parents
+  were updated to save the parent first, matching the guard's own guidance.
+  Issue #278

--- a/changelog.d/20260603_120000_claude_278_new_unsaved_dirty_write.rst
+++ b/changelog.d/20260603_120000_claude_278_new_unsaved_dirty_write.rst
@@ -1,0 +1,24 @@
+Changed
+-------
+
+- Dirty-write warnings now treat a *new, unsaved* parent as a distinct case.
+  When a collection (``list``/``set``/``zset``/``hashkey``) is mutated while its
+  parent Horreum has uncommitted scalar changes, ``warn_if_dirty!`` distinguishes
+  a parent that has never been persisted (no hash key exists in the database yet)
+  from one that was saved before and merely has pending changes. The former is
+  the more dangerous case -- the collection write lands in Redis while *none* of
+  the parent's scalar data exists, orphaning the collection if the process never
+  saves -- so it now emits a distinct, stronger message ("... is a new, unsaved
+  object (no hash key exists yet) ...") and, under ``Familia.strict_write_order``,
+  raises with that same message. Previously-saved-but-dirty parents keep the
+  original wording and behaviour. Issue #278
+
+AI Assistance
+-------------
+
+- AI investigated how persistence state is (and is not) tracked on Horreum
+  instances, implemented the new-object detection as a guarded ``exists?`` probe
+  that short-circuits inside transactions/pipelines (so it never queues a stray
+  EXISTS into an open MULTI/EXEC) and falls back safely when the parent has no
+  identifier yet, and added tryout coverage for the new-vs-saved distinction in
+  both warning and strict modes. Issue #278

--- a/lib/familia/data_type.rb
+++ b/lib/familia/data_type.rb
@@ -160,6 +160,19 @@ module Familia
     # scalar fields are saved, the collection data is persisted but the
     # scalar data is lost, creating an inconsistent state.
     #
+    # Two flavours of this hazard are distinguished:
+    #
+    # 1. **New, unsaved parent** — the parent has never been persisted, so no
+    #    hash key exists in Redis yet. This is the worst case: the collection
+    #    write creates a key while *none* of the scalar data exists, leaving an
+    #    orphaned collection with no parent hash if the process never saves.
+    # 2. **Dirty after save** — the parent was persisted before and merely has
+    #    uncommitted scalar changes. The parent hash already exists, so the
+    #    inconsistency is a partial update rather than a fully orphaned record.
+    #
+    # The new-object case gets a distinct, stronger message so it is not lost
+    # in the noise of ordinary dirty-write warnings.
+    #
     # @return [void]
     # @raise [Familia::Problem] if Familia.strict_write_order is true
     #
@@ -171,8 +184,16 @@ module Familia
       return unless @parent_ref.respond_to?(:dirty?) && @parent_ref.dirty?
 
       dirty = @parent_ref.dirty_fields
-      message = "Writing to #{self.class.name} #{dbkey} while parent " \
-                "#{@parent_ref.class.name} has unsaved scalar fields: #{dirty.join(', ')}"
+      message =
+        if parent_new_record?
+          "Writing to #{self.class.name} #{dbkey} while parent " \
+            "#{@parent_ref.class.name} is a new, unsaved object (no hash key " \
+            "exists yet) with unsaved scalar fields: #{dirty.join(', ')}. Save " \
+            'the parent before mutating its collections to avoid orphaned data.'
+        else
+          "Writing to #{self.class.name} #{dbkey} while parent " \
+            "#{@parent_ref.class.name} has unsaved scalar fields: #{dirty.join(', ')}"
+        end
 
       if Familia.strict_write_order
         raise Familia::Problem, message
@@ -180,6 +201,37 @@ module Familia
         Familia.warn message
       end
     end
+
+    # Best-effort detection of whether the parent Horreum instance has never
+    # been persisted — i.e. its hash key does not exist in Redis yet. This is
+    # the most dangerous dirty-write scenario surfaced by #warn_if_dirty!:
+    # mutating a collection now writes a Redis key while *none* of the parent's
+    # scalar data exists, so a crash before #save orphans the collection with
+    # no parent hash to anchor it.
+    #
+    # Only consulted from #warn_if_dirty!, which already guarantees @parent_ref
+    # is a dirty Horreum instance. Conservative by design — returns false
+    # (treat as "already persisted", the milder warning) whenever the state
+    # cannot be cheaply and safely determined:
+    #
+    # * inside a transaction/pipeline, where an EXISTS probe would be queued
+    #   into the caller's MULTI/EXEC and return a Redis::Future rather than a
+    #   boolean;
+    # * when the parent cannot answer #exists? (e.g. it has no identifier yet),
+    #   which raises a Familia::Problem during the probe.
+    #
+    # @return [Boolean] true only when we can positively confirm the parent has
+    #   no hash key in the database.
+    #
+    def parent_new_record?
+      return false if Fiber[:familia_transaction] || Fiber[:familia_pipeline]
+      return false unless @parent_ref.respond_to?(:exists?)
+
+      !@parent_ref.exists?(check_size: false)
+    rescue Familia::Problem
+      false
+    end
+    private :parent_new_record?
 
     # Override the default_expiration instance method to inherit from the
     # parent Horreum when this DataType doesn't have its own explicit

--- a/lib/familia/data_type.rb
+++ b/lib/familia/data_type.rb
@@ -170,11 +170,15 @@ module Familia
     #    uncommitted scalar changes. The parent hash already exists, so the
     #    inconsistency is a partial update rather than a fully orphaned record.
     #
-    # The new-object case gets a distinct, stronger message so it is not lost
-    # in the noise of ordinary dirty-write warnings.
+    # The new-object case gets a distinct, stronger message and, by default,
+    # *raises* regardless of Familia.strict_write_order — the orphaned-record
+    # hazard is rarely intended. Set Familia.raise_on_unsaved_parent_write to
+    # false to downgrade it to a warning instead.
     #
     # @return [void]
-    # @raise [Familia::Problem] if Familia.strict_write_order is true
+    # @raise [Familia::Problem] when Familia.strict_write_order is true, or when
+    #   the parent is a new, unsaved object and
+    #   Familia.raise_on_unsaved_parent_write is true (the default)
     #
     def warn_if_dirty!
       # Suppress warnings while parent is inside atomic_write — scalar setters in the block
@@ -184,8 +188,9 @@ module Familia
       return unless @parent_ref.respond_to?(:dirty?) && @parent_ref.dirty?
 
       dirty = @parent_ref.dirty_fields
+      new_record = parent_new_record?
       message =
-        if parent_new_record?
+        if new_record
           "Writing to #{self.class.name} #{dbkey} while parent " \
             "#{@parent_ref.class.name} is a new, unsaved object (no hash key " \
             "exists yet) with unsaved scalar fields: #{dirty.join(', ')}. Save " \
@@ -195,7 +200,10 @@ module Familia
             "#{@parent_ref.class.name} has unsaved scalar fields: #{dirty.join(', ')}"
         end
 
-      if Familia.strict_write_order
+      # A new, unsaved parent raises by default — orphaning a collection with no
+      # parent hash is almost never intended. Familia.raise_on_unsaved_parent_write
+      # downgrades that to a warning. strict_write_order raises every dirty write.
+      if Familia.strict_write_order || (new_record && Familia.raise_on_unsaved_parent_write)
         raise Familia::Problem, message
       else
         Familia.warn message
@@ -228,7 +236,12 @@ module Familia
       return false unless @parent_ref.respond_to?(:exists?)
 
       !@parent_ref.exists?(check_size: false)
-    rescue Familia::Problem
+    rescue Familia::Problem => e
+      # Could not determine the parent's persistence state (e.g. it has no
+      # identifier yet); fall back to the milder "dirty after save" warning.
+      # Surface the swallowed problem under debug only, so production pays just
+      # one cheap boolean check (Familia.debug?) while real issues stay visible.
+      Familia.trace :NEW_RECORD_PROBE, nil, @parent_ref.class, "#{e.class}: #{e.message}" if Familia.debug?
       false
     end
     private :parent_new_record?

--- a/lib/familia/settings.rb
+++ b/lib/familia/settings.rb
@@ -15,6 +15,7 @@ module Familia
   @encryption_personalization = 'FamilialMatters'.freeze
   @pipelined_mode = :warn
   @strict_write_order = false
+  @raise_on_unsaved_parent_write = true
 
   # Schema validation configuration
   @schema_path = nil      # Directory containing schema files (String or Pathname)
@@ -26,7 +27,8 @@ module Familia
   module Settings
     attr_writer :delim, :suffix, :default_expiration, :logical_database, :prefix, :encryption_keys,
                 :current_key_version, :encryption_personalization, :transaction_mode,
-                :schema_path, :schemas, :schema_validator, :strict_write_order
+                :schema_path, :schemas, :schema_validator, :strict_write_order,
+                :raise_on_unsaved_parent_write
 
     def delim(val = nil)
       @delim = val if val
@@ -164,6 +166,37 @@ module Familia
     def strict_write_order(val = nil)
       @strict_write_order = val unless val.nil?
       @strict_write_order || false
+    end
+
+    # Controls whether a collection write on a DataType raises when the parent
+    # Horreum is a *new, unsaved* object — one whose hash key does not exist in
+    # the database yet. This is the most dangerous dirty-write scenario: the
+    # collection lands in Redis while none of the parent's scalar data exists,
+    # orphaning the collection if the parent is never saved.
+    #
+    # Defaults to true (raise) independently of #strict_write_order, because an
+    # orphaned-record bug is rarely what the caller intends. Set to false to
+    # downgrade to a (still distinct, still strong) warning emitted via
+    # Familia.warn instead.
+    #
+    # Note: #strict_write_order, when true, raises for *every* dirty write and
+    # therefore still raises the new-object case even if this is set to false.
+    #
+    # @param val [Boolean, nil] The setting value, or nil to get current value
+    # @return [Boolean] Current raise_on_unsaved_parent_write setting
+    #
+    # @example Downgrade the new, unsaved parent case to a warning
+    #   Familia.configure do |config|
+    #     config.raise_on_unsaved_parent_write = false
+    #   end
+    #
+    def raise_on_unsaved_parent_write(val = nil)
+      @raise_on_unsaved_parent_write = val unless val.nil?
+      # Defaults to true: an unset (nil) value means "raise". Cannot use
+      # `|| true` here -- that would coerce an explicit `false` back to true.
+      return true if @raise_on_unsaved_parent_write.nil?
+
+      @raise_on_unsaved_parent_write
     end
 
     # Directory containing schema files for JSON Schema validation.

--- a/try/features/dirty_write_new_object_try.rb
+++ b/try/features/dirty_write_new_object_try.rb
@@ -8,7 +8,9 @@
 # A parent Horreum that has never been persisted (no hash key in Redis yet) is
 # strictly more dangerous than a previously-saved parent with uncommitted
 # scalar changes: mutating a collection orphans the collection data with no
-# parent hash to anchor it. The warning system must distinguish the two.
+# parent hash to anchor it. The warning system must distinguish the two, and a
+# new, unsaved parent RAISES by default (regardless of strict_write_order). The
+# Familia.raise_on_unsaved_parent_write setting downgrades that to a warning.
 
 require_relative '../support/helpers/test_helpers'
 require 'stringio'
@@ -36,57 +38,70 @@ def capture_familia_warnings
   buffer.string
 end
 
-## A freshly built, never-dirtied parent emits no warning at all
+## The new setting defaults to true (raise)
+Familia.raise_on_unsaved_parent_write
+#=> true
+
+## A freshly built, never-dirtied parent emits no warning and does not raise
 @clean = DirtyWriteWidget.new(widget_id: 'dww_clean', name: 'Clean')
 @clean_output = capture_familia_warnings { @clean.tags.add('alpha') }
 @clean_output.include?('Writing to')
 #=> false
 
-## New, unsaved + dirty parent: warning flags it as a new, unsaved object
+## New, unsaved + dirty parent RAISES by default, with the distinct new-object message
 @new_widget = DirtyWriteWidget.new(widget_id: 'dww_new', name: 'Original')
 @new_widget.name = 'Changed'   # mutate AFTER construction -> dirty
-@new_output = capture_familia_warnings { @new_widget.tags.add('beta') }
-@new_output.include?('new, unsaved object')
+@new_outcome =
+  begin
+    @new_widget.tags.add('beta')
+    [:no_raise]
+  rescue Familia::Problem => e
+    [:raised, e.message.include?('new, unsaved object'),
+     e.message.include?('unsaved scalar fields: name'),
+     e.message.include?('orphaned data')]
+  ensure
+    @new_widget.clear_dirty!
+  end
+@new_outcome
+#=> [:raised, true, true, true]
+
+## The raise prevents the collection write, so no orphaned data is left behind
+@new_widget.tags.members.empty?
 #=> true
 
-## The new-object warning still names the dirty scalar fields
-@new_output.include?('unsaved scalar fields: name')
-#=> true
+## raise_on_unsaved_parent_write=false downgrades the new-object case to a warning
+@warn_widget = DirtyWriteWidget.new(widget_id: 'dww_warn', name: 'Original')
+@warn_widget.name = 'Changed'
+Familia.raise_on_unsaved_parent_write = false
+@warn_output =
+  begin
+    capture_familia_warnings { @warn_widget.tags.add('gamma') }
+  ensure
+    Familia.raise_on_unsaved_parent_write = true
+    @warn_widget.clear_dirty!
+  end
+[@warn_output.include?('new, unsaved object'), @warn_output.include?('orphaned data')]
+#=> [true, true]
 
-## The new-object warning points at the orphaned-data hazard
-@new_output.include?('orphaned data')
-#=> true
+## With the downgrade, the collection write actually goes through (only warned)
+@warn_widget.tags.members
+#=> ['gamma']
 
-## Saved-but-dirty parent: warning uses the milder, standard message
+## Saved-but-dirty parent only WARNS (no raise) and uses the milder message
 @saved_widget = DirtyWriteWidget.new(widget_id: 'dww_saved', name: 'Original')
 @saved_widget.save
 @saved_widget.name = 'Changed'  # dirty again, but parent hash now exists
-@saved_output = capture_familia_warnings { @saved_widget.tags.add('gamma') }
-@saved_output.include?('unsaved scalar fields: name')
-#=> true
+@saved_output =
+  begin
+    capture_familia_warnings { @saved_widget.tags.add('delta') }
+  ensure
+    @saved_widget.clear_dirty!
+  end
+[@saved_output.include?('unsaved scalar fields: name'),
+ @saved_output.include?('new, unsaved object')]
+#=> [true, false]
 
-## Saved-but-dirty parent is NOT labelled a new, unsaved object
-@saved_output.include?('new, unsaved object')
-#=> false
-
-## Under strict_write_order, a new, unsaved parent raises with the new-object message
-@strict_new = DirtyWriteWidget.new(widget_id: 'dww_strict_new', name: 'Original')
-@strict_new.name = 'Changed'
-Familia.strict_write_order = true
-begin
-  @strict_new.tags.add('delta')
-  @strict_new_outcome = [:no_raise]
-rescue Familia::Problem => e
-  @strict_new_outcome = [:raised, e.message.include?('new, unsaved object'),
-                         e.message.include?('name')]
-ensure
-  Familia.strict_write_order = false
-  @strict_new.clear_dirty!
-end
-@strict_new_outcome
-#=> [:raised, true, true]
-
-## Under strict_write_order, a saved-but-dirty parent raises with the standard message
+## Under strict_write_order, a saved-but-dirty parent raises the standard message
 @strict_saved = DirtyWriteWidget.new(widget_id: 'dww_strict_saved', name: 'Original')
 @strict_saved.save
 @strict_saved.name = 'Changed'
@@ -104,21 +119,40 @@ end
 @strict_saved_outcome
 #=> [:raised, false, true]
 
-## Once the new object is saved, later dirty writes drop the new-object label
+## strict_write_order overrides raise_on_unsaved_parent_write=false (still raises)
+@override = DirtyWriteWidget.new(widget_id: 'dww_override', name: 'Original')
+@override.name = 'Changed'
+Familia.raise_on_unsaved_parent_write = false
+Familia.strict_write_order = true
+begin
+  @override.tags.add('zeta')
+  @override_outcome = [:no_raise]
+rescue Familia::Problem => e
+  @override_outcome = [:raised, e.message.include?('new, unsaved object')]
+ensure
+  Familia.strict_write_order = false
+  Familia.raise_on_unsaved_parent_write = true
+  @override.clear_dirty!
+end
+@override_outcome
+#=> [:raised, true]
+
+## Once the parent is saved, later dirty writes drop the new-object label and only warn
 @promote = DirtyWriteWidget.new(widget_id: 'dww_promote', name: 'Original')
-@promote.name = 'BeforeSave'
-@before_save_output = capture_familia_warnings { @promote.tags.add('one') }
 @promote.save
 @promote.name = 'AfterSave'
-@after_save_output = capture_familia_warnings { @promote.tags.add('two') }
-[@before_save_output.include?('new, unsaved object'),
- @after_save_output.include?('new, unsaved object')]
-#=> [true, false]
+@after_save_output =
+  begin
+    capture_familia_warnings { @promote.tags.add('two') }
+  ensure
+    @promote.clear_dirty!
+  end
+@after_save_output.include?('new, unsaved object')
+#=> false
 
-## A collection write inside a transaction queues no extra EXISTS probe,
-## even when the parent is a dirty new object. parent_new_record? short-circuits
-## inside a MULTI, so the dirty path must queue exactly the same commands as the
-## clean path (which never reaches the probe because it is not dirty).
+## A collection write inside a transaction queues no extra EXISTS probe and does
+## not raise: parent_new_record? short-circuits in a MULTI, so a dirty new parent
+## is treated as dirty-after-save (warn) and queues exactly the clean-path commands.
 @txn_clean = DirtyWriteWidget.new(widget_id: 'dww_txn_clean', name: 'Clean')
 @txn_clean_result = @txn_clean.transaction { |_c| @txn_clean.tags.add('v') }
 
@@ -134,12 +168,12 @@ end
  @txn_dirty_result.results.size == @txn_clean_result.results.size]
 #=> [true, true]
 
-# Teardown: remove the keys created above
-DirtyWriteWidget.new(widget_id: 'dww_clean').tags.delete! rescue nil
-DirtyWriteWidget.new(widget_id: 'dww_new').tags.delete! rescue nil
+# Teardown: restore defaults and remove the keys created above
+Familia.strict_write_order = false
+Familia.raise_on_unsaved_parent_write = true
 [
-  'dww_saved', 'dww_strict_new', 'dww_strict_saved', 'dww_promote',
-  'dww_txn_clean', 'dww_txn_dirty'
+  'dww_clean', 'dww_new', 'dww_warn', 'dww_saved', 'dww_strict_saved',
+  'dww_override', 'dww_promote', 'dww_txn_clean', 'dww_txn_dirty'
 ].each do |wid|
   w = DirtyWriteWidget.new(widget_id: wid)
   w.tags.delete! rescue nil

--- a/try/features/dirty_write_new_object_try.rb
+++ b/try/features/dirty_write_new_object_try.rb
@@ -1,0 +1,147 @@
+# try/features/dirty_write_new_object_try.rb
+#
+# frozen_string_literal: true
+
+# Tests for issue #278: detect a "new, unsaved object" as a distinct case in
+# the dirty-write warnings emitted by Familia::DataType#warn_if_dirty!.
+#
+# A parent Horreum that has never been persisted (no hash key in Redis yet) is
+# strictly more dangerous than a previously-saved parent with uncommitted
+# scalar changes: mutating a collection orphans the collection data with no
+# parent hash to anchor it. The warning system must distinguish the two.
+
+require_relative '../support/helpers/test_helpers'
+require 'stringio'
+
+class DirtyWriteWidget < Familia::Horreum
+  identifier_field :widget_id
+  field :widget_id
+  field :name
+  list  :events
+  set   :tags
+end
+
+# Capture everything Familia.warn emits during the block and return it as a
+# String. Swaps the logger directly because Familia.logger is memoized and
+# binds to its IO at first reference (reassigning $stderr would not work).
+def capture_familia_warnings
+  buffer = StringIO.new
+  original = Familia.logger
+  Familia.logger = Familia::FamiliaLogger.new(buffer)
+  begin
+    yield
+  ensure
+    Familia.logger = original
+  end
+  buffer.string
+end
+
+## A freshly built, never-dirtied parent emits no warning at all
+@clean = DirtyWriteWidget.new(widget_id: 'dww_clean', name: 'Clean')
+@clean_output = capture_familia_warnings { @clean.tags.add('alpha') }
+@clean_output.include?('Writing to')
+#=> false
+
+## New, unsaved + dirty parent: warning flags it as a new, unsaved object
+@new_widget = DirtyWriteWidget.new(widget_id: 'dww_new', name: 'Original')
+@new_widget.name = 'Changed'   # mutate AFTER construction -> dirty
+@new_output = capture_familia_warnings { @new_widget.tags.add('beta') }
+@new_output.include?('new, unsaved object')
+#=> true
+
+## The new-object warning still names the dirty scalar fields
+@new_output.include?('unsaved scalar fields: name')
+#=> true
+
+## The new-object warning points at the orphaned-data hazard
+@new_output.include?('orphaned data')
+#=> true
+
+## Saved-but-dirty parent: warning uses the milder, standard message
+@saved_widget = DirtyWriteWidget.new(widget_id: 'dww_saved', name: 'Original')
+@saved_widget.save
+@saved_widget.name = 'Changed'  # dirty again, but parent hash now exists
+@saved_output = capture_familia_warnings { @saved_widget.tags.add('gamma') }
+@saved_output.include?('unsaved scalar fields: name')
+#=> true
+
+## Saved-but-dirty parent is NOT labelled a new, unsaved object
+@saved_output.include?('new, unsaved object')
+#=> false
+
+## Under strict_write_order, a new, unsaved parent raises with the new-object message
+@strict_new = DirtyWriteWidget.new(widget_id: 'dww_strict_new', name: 'Original')
+@strict_new.name = 'Changed'
+Familia.strict_write_order = true
+begin
+  @strict_new.tags.add('delta')
+  @strict_new_outcome = [:no_raise]
+rescue Familia::Problem => e
+  @strict_new_outcome = [:raised, e.message.include?('new, unsaved object'),
+                         e.message.include?('name')]
+ensure
+  Familia.strict_write_order = false
+  @strict_new.clear_dirty!
+end
+@strict_new_outcome
+#=> [:raised, true, true]
+
+## Under strict_write_order, a saved-but-dirty parent raises with the standard message
+@strict_saved = DirtyWriteWidget.new(widget_id: 'dww_strict_saved', name: 'Original')
+@strict_saved.save
+@strict_saved.name = 'Changed'
+Familia.strict_write_order = true
+begin
+  @strict_saved.tags.add('epsilon')
+  @strict_saved_outcome = [:no_raise]
+rescue Familia::Problem => e
+  @strict_saved_outcome = [:raised, e.message.include?('new, unsaved object'),
+                           e.message.include?('unsaved scalar fields')]
+ensure
+  Familia.strict_write_order = false
+  @strict_saved.clear_dirty!
+end
+@strict_saved_outcome
+#=> [:raised, false, true]
+
+## Once the new object is saved, later dirty writes drop the new-object label
+@promote = DirtyWriteWidget.new(widget_id: 'dww_promote', name: 'Original')
+@promote.name = 'BeforeSave'
+@before_save_output = capture_familia_warnings { @promote.tags.add('one') }
+@promote.save
+@promote.name = 'AfterSave'
+@after_save_output = capture_familia_warnings { @promote.tags.add('two') }
+[@before_save_output.include?('new, unsaved object'),
+ @after_save_output.include?('new, unsaved object')]
+#=> [true, false]
+
+## A collection write inside a transaction queues no extra EXISTS probe,
+## even when the parent is a dirty new object. parent_new_record? short-circuits
+## inside a MULTI, so the dirty path must queue exactly the same commands as the
+## clean path (which never reaches the probe because it is not dirty).
+@txn_clean = DirtyWriteWidget.new(widget_id: 'dww_txn_clean', name: 'Clean')
+@txn_clean_result = @txn_clean.transaction { |_c| @txn_clean.tags.add('v') }
+
+@txn_dirty = DirtyWriteWidget.new(widget_id: 'dww_txn_dirty', name: 'Original')
+@txn_dirty.name = 'Changed'   # dirty AND never saved
+@txn_dirty_result =
+  begin
+    @txn_dirty.transaction { |_c| @txn_dirty.tags.add('v') }
+  ensure
+    @txn_dirty.clear_dirty!
+  end
+[@txn_dirty_result.successful?,
+ @txn_dirty_result.results.size == @txn_clean_result.results.size]
+#=> [true, true]
+
+# Teardown: remove the keys created above
+DirtyWriteWidget.new(widget_id: 'dww_clean').tags.delete! rescue nil
+DirtyWriteWidget.new(widget_id: 'dww_new').tags.delete! rescue nil
+[
+  'dww_saved', 'dww_strict_new', 'dww_strict_saved', 'dww_promote',
+  'dww_txn_clean', 'dww_txn_dirty'
+].each do |wid|
+  w = DirtyWriteWidget.new(widget_id: wid)
+  w.tags.delete! rescue nil
+  w.destroy! rescue nil
+end

--- a/try/features/encrypted_fields/encrypted_fields_integration_try.rb
+++ b/try/features/encrypted_fields/encrypted_fields_integration_try.rb
@@ -141,6 +141,9 @@ end
 
 @model4 = FullSecureModel4.new(model_id: 'secure-126')
 @model4.password = 'secure-pass'
+# Persist scalar fields before mutating collections (see #278): a new, unsaved
+# dirty parent raises on collection writes by default to avoid orphaned data.
+@model4.save
 @model4.activity_log << 'User logged in'
 @model4.metadata['last_login'] = Familia.now.to_i.to_s
 

--- a/try/unit/horreum/relations_try.rb
+++ b/try/unit/horreum/relations_try.rb
@@ -35,10 +35,15 @@ end
 @test_user = RelationsTestUser.new
 @test_user.userid = 'user123'
 @test_user.name = 'Test User'
+# Persist the parent before exercising its collections. As of #278, mutating a
+# collection on a new, unsaved (and dirty) parent raises by default to prevent
+# orphaning the collection data with no parent hash to anchor it.
+@test_user.save
 
 @test_product = RelationsTestProduct.new
 @test_product.productid = 'prod456'
 @test_product.title = 'Test Product'
+@test_product.save
 
 ## Class knows about Database type relationships
 RelationsTestUser.relations?


### PR DESCRIPTION
## Summary

Mutating a collection (list/set/zset/hashkey) while its parent Horreum is a **new, unsaved object** — one whose hash key does not exist in the database yet — now **raises** `Familia::Problem` by default. This is the most dangerous dirty-write scenario: the collection write would land in Redis while none of the parent's scalar data exists, orphaning the collection if the parent is never saved.

Previously, this case only emitted a warning unless `Familia.strict_write_order` was enabled. The new behavior treats new, unsaved parents as a distinct, more severe case and raises independently of `strict_write_order`.

## Key Changes

- **New setting `Familia.raise_on_unsaved_parent_write`** (default `true`): Controls whether collection writes on new, unsaved, dirty parents raise or warn. Set to `false` to downgrade to a distinct, strongly-worded warning instead of an exception. `strict_write_order` continues to override this and raise for every dirty write.

- **Enhanced `DataType#warn_if_dirty!`**: Now distinguishes between two dirty-write hazards:
  1. **New, unsaved parent** — raises by default with a message emphasizing the orphaned-data risk
  2. **Dirty after save** — warns (or raises under `strict_write_order`) with a milder message
  
  The guard fires *before* the collection command runs, so no orphaned data is written.

- **New `DataType#parent_new_record?` method**: Best-effort detection of whether the parent has never been persisted. Safely short-circuits inside transactions/pipelines (so it never queues a stray EXISTS into an open MULTI/EXEC) and falls back gracefully when the parent has no identifier yet.

- **Updated tryout coverage**: Added comprehensive `try/features/dirty_write_new_object_try.rb` covering the full raise/warn matrix across new-vs-saved parents and both global settings. Updated two existing tryouts that mutated collections on unsaved dirty parents to save the parent first, matching the guard's own guidance.

## Implementation Details

- The new-object detection uses a guarded `exists?` probe that respects transaction/pipeline context via `Fiber[:familia_transaction]` and `Fiber[:familia_pipeline]` to avoid queuing stray commands into an open MULTI/EXEC.
- When the parent cannot answer `exists?` (e.g., it has no identifier yet), the method falls back safely to the milder "dirty after save" warning and traces the swallowed problem only when `Familia.debug?` is set.
- The raise condition is: `strict_write_order || (new_record && raise_on_unsaved_parent_write)`, ensuring `strict_write_order` always takes precedence.

https://claude.ai/code/session_01YKgMAZrCkP7A6WTJsbx4wA