### PR TITLE
Add dirty_write_warnings mode control with per-signature deduplication

### DIFF
--- a/changelog.d/20260603_120000_claude_277_dirty_write_warnings.rst
+++ b/changelog.d/20260603_120000_claude_277_dirty_write_warnings.rst
@@ -1,0 +1,67 @@
+Added
+-----
+
+- ``dirty_write_warnings`` class method on every ``Familia::Horreum`` subclass,
+  mirroring ``Familia.strict_write_order`` but scoped to a single class. Accepts
+  ``:strict`` (raise), ``:warn`` (warn on every collection write), ``:once``
+  (warn once per dirty-field signature per window), or ``:off`` (suppress). The
+  setting inherits through the subclass chain, so seed scripts, bulk importers,
+  and known-safe call sites can opt down without touching the global. Issue #277
+
+- ``Familia.dirty_write_warnings`` global setting providing the default mode for
+  classes that do not set their own. ``Familia.dirty_write_warnings = :off``
+  temporarily and restorably silences dirty-write warnings across all such
+  classes. Issue #277
+
+Changed
+-------
+
+- Dirty-write warnings are now **deduplicated per dirty window** by default. A
+  collection write (``SADD``, ``RPUSH``, ``ZADD``, ``HSET``, ``SET``) on a
+  parent with unsaved scalar fields now warns once per distinct set of unsaved
+  fields, rather than once per write. Creating one object with several
+  collections previously emitted 7-10 identical warnings; it now emits one. The
+  warning fires again if the set of unsaved fields changes (genuinely new
+  information), and the window resets on ``clear_dirty!`` (which ``save``,
+  ``commit_fields``, ``batch_update``, and ``refresh`` already call). This
+  changes the **default mode from the old every-write behavior to ``:once``**;
+  set ``dirty_write_warnings :warn`` (per class) or
+  ``Familia.dirty_write_warnings = :warn`` (global) to restore the previous
+  output. ``Familia.strict_write_order = true`` is unaffected -- it still raises
+  (and is exempt from deduplication) for every class that has not opted out via
+  ``:off``. Issue #277
+
+- Dirty-write warning and strict-mode raise messages now append the remediation
+  hint ``(call #save first or wrap in atomic_write)``, so the fix is self-evident
+  without a round trip to the docs. Issue #277
+
+- ``dirty_write_warnings`` is a per-class severity dial that composes with the
+  ``raise_on_unsaved_parent_write`` safety raise added in #278. For a class that
+  has *not* opted out, the raise paths (global ``strict_write_order``, a class
+  ``:strict``, and a new/unsaved parent when ``raise_on_unsaved_parent_write`` is
+  true) fire independently of the warn level -- so a ``:once``/``:warn`` class
+  still raises on a new, unsaved parent by default. An explicit ``:off`` is
+  authoritative for the class, however: it suppresses the dirty-write guard
+  entirely (no warning **and** no raise) and overrides both global raise switches,
+  consistent with how an explicit "off"/"ignore" beats a global
+  warnings-as-errors escalation in other tools (ESLint, RuboCop, ``-Werror`` +
+  ``#pragma`` ignored, Python ``warnings``). All emitted messages carry the
+  remediation hint. Issue #277
+
+AI Assistance
+-------------
+
+- AI implemented the full change from the issue specification: the per-instance
+  deduplication primitive (``record_dirty_warning!`` backed by
+  ``Concurrent::Map#put_if_absent``, mirroring ``mark_dirty!``), the dedup-window
+  reset in ``clear_dirty!``, the resolution in ``DataType#warn_if_dirty!``
+  (atomic_write suppression and an explicit ``:off`` short-circuit first; then the
+  raise paths -- global strict, class ``:strict``, or a new/unsaved parent;
+  otherwise warn per ``:once``/``:warn``), and the class/global settings with
+  validation and subclass-chain inheritance. AI also authored the tryouts coverage in
+  ``try/features/dirty_write_warnings_try.rb`` (dedup, signature-change
+  re-emission, full and partial ``clear_dirty!`` resets, ``:warn``/``:once``/
+  ``:off``/``:strict`` modes, global precedence and fallback, and ``atomic_write``
+  priority over ``:strict``) and verified no regressions against the existing
+  ``atomic_write``, ``dirty_tracking``, ``list_commands``, and thread-safety
+  suites.

--- a/lib/familia/data_type.rb
+++ b/lib/familia/data_type.rb
@@ -102,6 +102,10 @@ module Familia
     @valid_options = %i[class parent default_expiration no_expiration default logical_database dbkey dbclient suffix prefix reference].freeze
     @logical_database = nil
 
+    # Remediation hint appended to every dirty-write warning/raise message so
+    # the fix is self-evident without a round trip back to the docs.
+    DIRTY_WRITE_HINT = '(call #save first or wrap in atomic_write)'
+
     feature :expiration
     feature :quantization
 
@@ -170,14 +174,25 @@ module Familia
     #    uncommitted scalar changes. The parent hash already exists, so the
     #    inconsistency is a partial update rather than a fully orphaned record.
     #
-    # The new-object case gets a distinct, stronger message and, by default,
-    # *raises* regardless of Familia.strict_write_order — the orphaned-record
-    # hazard is rarely intended. Set Familia.raise_on_unsaved_parent_write to
-    # false to downgrade it to a warning instead.
+    # The behavior splits into a raise path and a warning path:
+    #
+    # * Raise (exempt from dedup): when Familia.strict_write_order is true, when
+    #   the resolved class mode is :strict, or when the parent is new & unsaved
+    #   and Familia.raise_on_unsaved_parent_write is true (the default). The
+    #   new-object case gets a distinct, stronger message because orphaning a
+    #   record is rarely intended.
+    # * Warn: otherwise the resolved dirty_write_warnings mode governs emission
+    #   (see #resolve_dirty_warning_mode) -- :once (default) warns once per
+    #   distinct dirty-field signature within a dirty window (deduped via the
+    #   parent's #record_dirty_warning!), :warn warns on every collection write,
+    #   and :off suppresses entirely.
+    #
+    # An active +atomic_write+ block suppresses everything, taking priority over
+    # all of the above. Every message ends with the DIRTY_WRITE_HINT remediation.
     #
     # @return [void]
-    # @raise [Familia::Problem] when Familia.strict_write_order is true, or when
-    #   the parent is a new, unsaved object and
+    # @raise [Familia::Problem] when Familia.strict_write_order is true, when the
+    #   resolved mode is :strict, or when the parent is a new, unsaved object and
     #   Familia.raise_on_unsaved_parent_write is true (the default)
     #
     def warn_if_dirty!
@@ -187,28 +202,92 @@ module Familia
 
       return unless @parent_ref.respond_to?(:dirty?) && @parent_ref.dirty?
 
-      dirty = @parent_ref.dirty_fields
-      new_record = parent_new_record?
-      message =
-        if new_record
-          "Writing to #{self.class.name} #{dbkey} while parent " \
-            "#{@parent_ref.class.name} is a new, unsaved object (no hash key " \
-            "exists yet) with unsaved scalar fields: #{dirty.join(', ')}. Save " \
-            'the parent before mutating its collections to avoid orphaned data.'
-        else
-          "Writing to #{self.class.name} #{dbkey} while parent " \
-            "#{@parent_ref.class.name} has unsaved scalar fields: #{dirty.join(', ')}"
-        end
+      mode = resolve_dirty_warning_mode
+      # "Off means off": an explicit :off opts the class out of dirty-write
+      # diagnostics entirely -- no warning AND no raise. The class-level mode is
+      # the most specific signal, so it overrides both global raise switches
+      # (strict_write_order and raise_on_unsaved_parent_write), mirroring how a
+      # local "ignore" beats a global warnings-as-errors escalation elsewhere.
+      return if mode == :off
 
-      # A new, unsaved parent raises by default — orphaning a collection with no
-      # parent hash is almost never intended. Familia.raise_on_unsaved_parent_write
-      # downgrades that to a warning. strict_write_order raises every dirty write.
-      if Familia.strict_write_order || (new_record && Familia.raise_on_unsaved_parent_write)
-        raise Familia::Problem, message
+      new_record = parent_new_record?
+      dirty      = @parent_ref.dirty_fields
+      message    = dirty_write_message(new_record, dirty)
+
+      raise Familia::Problem, message if raise_on_dirty_write?(mode, new_record)
+
+      emit_dirty_warning(mode, message, dirty)
+    end
+
+    # Resolves the dirty-write warning mode for this DataType's parent.
+    #
+    # Reads the parent Horreum class's +dirty_write_warnings+ setting (which
+    # itself walks the subclass chain and falls back to the
+    # +Familia.dirty_write_warnings+ global). Older parents that predate the
+    # class setting fall back to the global directly.
+    #
+    # @return [Symbol] one of :strict, :warn, :once, :off
+    #
+    def resolve_dirty_warning_mode
+      parent_class = @parent_ref.class
+      if parent_class.respond_to?(:dirty_write_warnings)
+        parent_class.dirty_write_warnings
       else
-        Familia.warn message
+        Familia.dirty_write_warnings
       end
     end
+
+    # Whether a dirty collection write should raise instead of warn. Raise paths
+    # take priority over the warning mode and are exempt from dedup:
+    #   - strict_write_order raises every dirty write
+    #   - the class opted into :strict
+    #   - the parent is new & unsaved and raise_on_unsaved_parent_write is on
+    #     (the #278 safety net: orphaning a collection is almost never intended)
+    #
+    # @return [Boolean]
+    #
+    def raise_on_dirty_write?(mode, new_record)
+      Familia.strict_write_order || mode == :strict ||
+        (new_record && Familia.raise_on_unsaved_parent_write)
+    end
+
+    # Builds the dirty-write message. A new, unsaved parent gets a distinct,
+    # stronger message (the orphaned-data hazard); both variants end with the
+    # DIRTY_WRITE_HINT remediation.
+    #
+    # @return [String]
+    #
+    def dirty_write_message(new_record, dirty)
+      fields = dirty.join(', ')
+      if new_record
+        "Writing to #{self.class.name} #{dbkey} while parent " \
+          "#{@parent_ref.class.name} is a new, unsaved object (no hash key " \
+          "exists yet) with unsaved scalar fields: #{fields}. Save the parent " \
+          "before mutating its collections to avoid orphaned data. #{DIRTY_WRITE_HINT}"
+      else
+        "Writing to #{self.class.name} #{dbkey} while parent " \
+          "#{@parent_ref.class.name} has unsaved scalar fields: #{fields} #{DIRTY_WRITE_HINT}"
+      end
+    end
+
+    # Emits the dirty-write warning for a non-raising mode. :warn warns on every
+    # call; :once dedupes per distinct dirty signature within the window via the
+    # parent's #record_dirty_warning!. (:off is handled upstream in #warn_if_dirty!.)
+    #
+    # @return [void]
+    #
+    def emit_dirty_warning(mode, message, dirty)
+      return Familia.warn(message) if mode == :warn
+
+      # :once (default) -- warn once per distinct dirty-field signature per window
+      signature  = dirty.sort.freeze
+      first_time = !@parent_ref.respond_to?(:record_dirty_warning!) ||
+                   @parent_ref.record_dirty_warning!(signature)
+      Familia.warn message if first_time
+    end
+
+    private :resolve_dirty_warning_mode, :raise_on_dirty_write?,
+            :dirty_write_message, :emit_dirty_warning
 
     # Best-effort detection of whether the parent Horreum instance has never
     # been persisted — i.e. its hash key does not exist in Redis yet. This is

--- a/lib/familia/data_type.rb
+++ b/lib/familia/data_type.rb
@@ -266,7 +266,7 @@ module Familia
           "before mutating its collections to avoid orphaned data. #{DIRTY_WRITE_HINT}"
       else
         "Writing to #{self.class.name} #{dbkey} while parent " \
-          "#{@parent_ref.class.name} has unsaved scalar fields: #{fields} #{DIRTY_WRITE_HINT}"
+          "#{@parent_ref.class.name} has unsaved scalar fields: #{fields}. #{DIRTY_WRITE_HINT}"
       end
     end
 

--- a/lib/familia/horreum.rb
+++ b/lib/familia/horreum.rb
@@ -192,6 +192,7 @@ module Familia
     #
     def initialize(*args, **kwargs)
       @dirty_fields = Concurrent::Map.new
+      @warned_dirty_signatures = Concurrent::Map.new
       start_time = Familia.now_in_μs if Familia.debug?
       Familia.trace :INITIALIZE, nil, "Initializing #{self.class}" if Familia.debug?
       initialize_relatives

--- a/lib/familia/horreum/definition.rb
+++ b/lib/familia/horreum/definition.rb
@@ -35,6 +35,9 @@ module Familia
     @field_groups = nil
     @current_field_group = nil
 
+    # Dirty-write warning mode (nil = inherit from superclass / Familia default)
+    @dirty_write_warnings = nil
+
     # DefinitionMethods - Class-level DSL methods for defining Horreum model structure
     #
     # This module is extended into classes that include Familia::Horreum,
@@ -215,6 +218,49 @@ module Familia
         Familia.trace :LOGICAL_DATABASE_DEF, "instvar:#{@logical_database}", num if Familia.debug?
         @logical_database = num unless num.nil?
         @logical_database || parent&.logical_database
+      end
+
+      # Sets or retrieves how collection writes on this class's DataTypes react
+      # when the parent instance has unsaved scalar field changes.
+      #
+      # Mirrors +Familia.strict_write_order+ but is scoped to a single Horreum
+      # subclass, so seed scripts, bulk importers, and known-safe call sites can
+      # opt down without touching the global setting.
+      #
+      # Resolution order (highest precedence first):
+      # 1. +Familia.strict_write_order = true+ -- always raises, ignores this.
+      # 2. This class-level setting (inherited through the subclass chain).
+      # 3. +Familia.dirty_write_warnings+ global default (:once when unset).
+      #
+      # @param mode [Symbol, nil] one of :strict, :warn, :once, :off, or nil to read
+      # @return [Symbol] the resolved mode
+      #
+      # - :strict - raise Familia::Problem (overrides global strict_write_order=false)
+      # - :warn   - warn on every collection write (legacy behavior)
+      # - :once   - warn once per distinct dirty-field signature per window [default]
+      # - :off    - suppress entirely for this class
+      #
+      # @example Silence a seed subclass
+      #   class SeedPlan < Billing::Plan
+      #     dirty_write_warnings :off
+      #   end
+      #
+      def dirty_write_warnings(mode = nil)
+        unless mode.nil?
+          valid = %i[strict warn once off]
+          unless valid.include?(mode)
+            raise ArgumentError, "dirty_write_warnings must be one of #{valid.inspect}, got #{mode.inspect}"
+          end
+          return @dirty_write_warnings = mode
+        end
+
+        @dirty_write_warnings ||
+          (superclass.respond_to?(:dirty_write_warnings) ? superclass.dirty_write_warnings : nil) ||
+          Familia.dirty_write_warnings
+      end
+
+      def dirty_write_warnings=(mode)
+        dirty_write_warnings(mode)
       end
 
       # Returns the list of field names defined for the class in the order

--- a/lib/familia/horreum/definition.rb
+++ b/lib/familia/horreum/definition.rb
@@ -228,9 +228,14 @@ module Familia
       # opt down without touching the global setting.
       #
       # Resolution order (highest precedence first):
-      # 1. +Familia.strict_write_order = true+ -- always raises, ignores this.
-      # 2. This class-level setting (inherited through the subclass chain).
-      # 3. +Familia.dirty_write_warnings+ global default (:once when unset).
+      # 1. Active +atomic_write+ block -- suppresses everything.
+      # 2. Class-level +:off+ -- suppresses both warnings AND raises, overriding
+      #    +strict_write_order+ and +raise_on_unsaved_parent_write+. "Off means off."
+      # 3. Raise gates: +Familia.strict_write_order = true+, class +:strict+, or a
+      #    new/unsaved parent when +raise_on_unsaved_parent_write+ is true.
+      # 4. Otherwise warn per the resolved mode: this class-level setting
+      #    (inherited through the subclass chain), else
+      #    +Familia.dirty_write_warnings+ (:once when unset).
       #
       # @param mode [Symbol, nil] one of :strict, :warn, :once, :off, or nil to read
       # @return [Symbol] the resolved mode

--- a/lib/familia/horreum/dirty_tracking.rb
+++ b/lib/familia/horreum/dirty_tracking.rb
@@ -109,6 +109,31 @@ module Familia
         else
           field_names.each { |f| @dirty_fields.delete(f.to_sym) }
         end
+        # The dirty set just changed (full or partial clear); reset the dedup
+        # window so future signatures warn at least once. See record_dirty_warning!.
+        @warned_dirty_signatures&.clear
+      end
+
+      # Records that a dirty-write warning has been emitted for +signature+
+      # within the current dirty window, returning whether this is the first
+      # time that signature has been seen.
+      #
+      # A "dirty window" spans from the first +mark_dirty!+ to the next
+      # +clear_dirty!+ (called by save, commit_fields, batch_update, refresh).
+      # +Familia::DataType#warn_if_dirty!+ uses this to dedupe warnings in
+      # :once mode -- warning once per distinct set of unsaved fields rather
+      # than once per collection write.
+      #
+      # @param signature [Object] a value-equal, hashable key for the dirty set
+      #   (typically the sorted, frozen array of dirty field names)
+      # @return [Boolean] true if this signature had not yet warned this window
+      #
+      def record_dirty_warning!(signature)
+        # Safety net for subclasses that override initialize without calling super.
+        @warned_dirty_signatures ||= Concurrent::Map.new
+        # Atomic: put_if_absent returns nil when the key was absent (and was
+        # just stored), or the existing value otherwise. nil => first time.
+        @warned_dirty_signatures.put_if_absent(signature, true).nil?
       end
     end
   end

--- a/lib/familia/horreum/management.rb
+++ b/lib/familia/horreum/management.rb
@@ -749,6 +749,7 @@ module Familia
       def instantiate_from_hash(obj_hash)
         instance = allocate
         instance.instance_variable_set(:@dirty_fields, Concurrent::Map.new)
+        instance.instance_variable_set(:@warned_dirty_signatures, Concurrent::Map.new)
         instance.send(:initialize_relatives)
         instance.send(:initialize_with_keyword_args_deserialize_value, **obj_hash)
         # Object was just loaded from Redis, so it matches DB state exactly.
@@ -800,6 +801,7 @@ module Familia
         # Use a temporary instance for deserialization (needs serialize_value/deserialize_value)
         temp = allocate
         temp.instance_variable_set(:@dirty_fields, Concurrent::Map.new)
+        temp.instance_variable_set(:@warned_dirty_signatures, Concurrent::Map.new)
         temp.send(:initialize_relatives)
 
         raw_hash.each_with_object({}) do |(field, raw_val), result|

--- a/lib/familia/settings.rb
+++ b/lib/familia/settings.rb
@@ -204,10 +204,10 @@ module Familia
     # has unsaved scalar field changes. Acts as the fallback when a Horreum
     # subclass does not set its own +dirty_write_warnings+ class setting.
     #
-    # This governs only the WARNING path: which dirty writes emit a warning and
-    # how often. It is orthogonal to the raise paths -- #strict_write_order and
-    # #raise_on_unsaved_parent_write decide independently whether a write raises
-    # (see Familia::DataType#warn_if_dirty!).
+    # The resolved mode drives both warning and raise behavior: :warn/:once
+    # control warning frequency, :strict forces a raise, and :off suppresses
+    # everything (warnings and raises) for the class. See the precedence note
+    # below and Familia::DataType#warn_if_dirty!.
     #
     # @param val [Symbol, nil] The mode, or nil to read the current value
     # @return [Symbol] Current mode (defaults to :once when unconfigured)
@@ -219,8 +219,10 @@ module Familia
     # - :strict: Raise Familia::Problem on every violation.
     # - :off: Suppress warnings entirely.
     #
-    # Note: +Familia.strict_write_order = true+ always raises and takes
-    # precedence over this setting and any class-level override.
+    # Note: +Familia.strict_write_order = true+ raises for any class whose mode
+    # is not explicitly +:off+. A class-level +:off+ is authoritative -- it
+    # suppresses both warnings and raises, overriding +strict_write_order+ and
+    # +raise_on_unsaved_parent_write+. "Off means off."
     #
     # @example Temporarily silence all classes during a bulk import
     #   Familia.dirty_write_warnings = :off

--- a/lib/familia/settings.rb
+++ b/lib/familia/settings.rb
@@ -16,6 +16,7 @@ module Familia
   @pipelined_mode = :warn
   @strict_write_order = false
   @raise_on_unsaved_parent_write = true
+  @dirty_write_warnings = nil # nil resolves to the built-in default (:once)
 
   # Schema validation configuration
   @schema_path = nil      # Directory containing schema files (String or Pathname)
@@ -197,6 +198,48 @@ module Familia
       return true if @raise_on_unsaved_parent_write.nil?
 
       @raise_on_unsaved_parent_write
+    end
+
+    # Global default for how collection writes react when the parent Horreum
+    # has unsaved scalar field changes. Acts as the fallback when a Horreum
+    # subclass does not set its own +dirty_write_warnings+ class setting.
+    #
+    # This governs only the WARNING path: which dirty writes emit a warning and
+    # how often. It is orthogonal to the raise paths -- #strict_write_order and
+    # #raise_on_unsaved_parent_write decide independently whether a write raises
+    # (see Familia::DataType#warn_if_dirty!).
+    #
+    # @param val [Symbol, nil] The mode, or nil to read the current value
+    # @return [Symbol] Current mode (defaults to :once when unconfigured)
+    #
+    # Available modes:
+    # - :once (default): Warn once per distinct dirty-field signature within a
+    #   dirty window (deduped). A change to the dirty set warns again.
+    # - :warn: Warn on every collection write (legacy behavior).
+    # - :strict: Raise Familia::Problem on every violation.
+    # - :off: Suppress warnings entirely.
+    #
+    # Note: +Familia.strict_write_order = true+ always raises and takes
+    # precedence over this setting and any class-level override.
+    #
+    # @example Temporarily silence all classes during a bulk import
+    #   Familia.dirty_write_warnings = :off
+    #   import_records(data)
+    #   Familia.dirty_write_warnings = :once  # restore
+    #
+    def dirty_write_warnings(val = nil)
+      unless val.nil?
+        valid = %i[strict warn once off]
+        unless valid.include?(val)
+          raise ArgumentError, "dirty_write_warnings must be one of #{valid.inspect}, got #{val.inspect}"
+        end
+        @dirty_write_warnings = val
+      end
+      @dirty_write_warnings || :once
+    end
+
+    def dirty_write_warnings=(val)
+      dirty_write_warnings(val)
     end
 
     # Directory containing schema files for JSON Schema validation.

--- a/try/features/dirty_write_warnings_try.rb
+++ b/try/features/dirty_write_warnings_try.rb
@@ -1,0 +1,456 @@
+# try/features/dirty_write_warnings_try.rb
+#
+# frozen_string_literal: true
+#
+# Coverage for issue #277: dedupe warn_if_dirty! emissions per dirty window,
+# surface a remediation hint in the message, and add the dirty_write_warnings
+# class-level mode control (:strict, :warn, :once, :off).
+#
+# These tests operate on *saved* (dirty-after-save) parents so the warning/dedup
+# paths are exercised in isolation. As of #278, mutating a collection on a NEW,
+# unsaved dirty parent raises by default (Familia.raise_on_unsaved_parent_write);
+# the composition of that raise with this mode control is covered in its own
+# section near the bottom.
+
+require_relative '../support/helpers/test_helpers'
+
+Familia.debug = false
+
+# Captures everything written via Familia.warn during the block by swapping the
+# logger (reassigning $stderr does not work -- the logger memoizes its stream).
+def capture_familia_warnings
+  captured = StringIO.new
+  original_logger = Familia.logger
+  Familia.logger = Familia::FamiliaLogger.new(captured)
+  begin
+    yield
+  ensure
+    Familia.logger = original_logger
+  end
+  captured.string
+end
+
+# Counts how many distinct dirty-write warnings landed in the captured output.
+# The phrase appears exactly once per warn call and never in DB-command logs.
+def count_dirty_warnings(output)
+  output.scan('unsaved scalar fields').length
+end
+
+# Uses the global default (:once) -- no explicit class setting.
+class DWWDefaultPlan < Familia::Horreum
+  identifier_field :planid
+  field :planid
+  field :name
+  field :region
+  set :features
+end
+
+class DWWOncePlan < Familia::Horreum
+  dirty_write_warnings :once
+  identifier_field :planid
+  field :planid
+  field :name
+  field :region
+  set :features
+  hashkey :limits
+end
+
+class DWWWarnPlan < Familia::Horreum
+  dirty_write_warnings :warn
+  identifier_field :planid
+  field :planid
+  field :name
+  set :features
+end
+
+class DWWOffPlan < Familia::Horreum
+  dirty_write_warnings :off
+  identifier_field :planid
+  field :planid
+  field :name
+  set :features
+end
+
+class DWWStrictPlan < Familia::Horreum
+  dirty_write_warnings :strict
+  identifier_field :planid
+  field :planid
+  field :name
+  set :features
+end
+
+# Inheritance fixtures
+class DWWBasePlan < Familia::Horreum
+  dirty_write_warnings :off
+  identifier_field :planid
+  field :planid
+  field :name
+  set :features
+end
+
+class DWWSubPlan < DWWBasePlan; end
+
+class DWWSubOverridePlan < DWWBasePlan
+  dirty_write_warnings :warn
+end
+
+# Known clean baseline for the global-state tests
+Familia.strict_write_order = false
+Familia.dirty_write_warnings = :once
+Familia.raise_on_unsaved_parent_write = true
+
+# ---------------------------------------------------------------------------
+# Class-level setting resolution
+# ---------------------------------------------------------------------------
+
+## A class without an explicit setting resolves to the global default (:once)
+DWWDefaultPlan.dirty_write_warnings
+#=> :once
+
+## An explicit class setting is reported back
+DWWOncePlan.dirty_write_warnings
+#=> :once
+
+## :warn class reports :warn
+DWWWarnPlan.dirty_write_warnings
+#=> :warn
+
+## A subclass inherits the parent class setting through the chain
+DWWSubPlan.dirty_write_warnings
+#=> :off
+
+## A subclass can override the inherited setting
+DWWSubOverridePlan.dirty_write_warnings
+#=> :warn
+
+## Class-level setter rejects invalid modes
+begin
+  DWWDefaultPlan.dirty_write_warnings :nonsense
+  :no_raise
+rescue ArgumentError => e
+  e.message.include?('must be one of')
+end
+#=> true
+
+## Global setter rejects invalid modes
+begin
+  Familia.dirty_write_warnings = :nonsense
+  :no_raise
+rescue ArgumentError => e
+  e.message.include?('must be one of')
+end
+#=> true
+
+# ---------------------------------------------------------------------------
+# :once (default) -- dedup per dirty window (saved/dirty-after-save parents)
+# ---------------------------------------------------------------------------
+
+## :once mode warns once across repeated writes with the same dirty signature
+@p1 = DWWOncePlan.new(planid: 'once1', name: 'A')
+@p1.save
+@p1.name = 'B' # dirty: {name}
+@out1 = capture_familia_warnings do
+  @p1.features.add('x')
+  @p1.features.add('y')
+  @p1.features.add('z')
+end
+count_dirty_warnings(@out1)
+#=> 1
+
+## The single emitted warning carries the remediation hint
+@out1.include?('(call #save first or wrap in atomic_write)')
+#=> true
+
+## The warning names the unsaved field(s)
+@out1.include?('name')
+#=> true
+
+## :once mode re-warns when the dirty signature grows (genuinely new info)
+@p2 = DWWOncePlan.new(planid: 'once2', name: 'A', region: 'X')
+@p2.save
+@out2 = capture_familia_warnings do
+  @p2.name = 'B'          # dirty {name}
+  @p2.features.add('a')   # warn (sig [name])
+  @p2.features.add('a2')  # deduped
+  @p2.region = 'Y'        # dirty {name, region}
+  @p2.features.add('b')   # warn (sig [name, region])
+  @p2.features.add('b2')  # deduped
+end
+count_dirty_warnings(@out2)
+#=> 2
+
+## Writes across different DataTypes on one parent share the dedup table
+@p3 = DWWOncePlan.new(planid: 'once3', name: 'A')
+@p3.save
+@p3.name = 'B' # dirty {name}
+@out3 = capture_familia_warnings do
+  @p3.features.add('x')   # warn (sig [name])
+  @p3.limits['cap'] = '5' # same signature -> deduped despite different DataType
+end
+count_dirty_warnings(@out3)
+#=> 1
+
+## Blanket clear_dirty! resets the dedup window so the same signature warns again
+@p4 = DWWOncePlan.new(planid: 'once4', name: 'A')
+@p4.save
+@out4 = capture_familia_warnings do
+  @p4.name = 'B'
+  @p4.features.add('a')   # warn (sig [name])
+  @p4.features.add('a2')  # deduped
+  @p4.clear_dirty!        # clears dirty AND resets dedup window
+  @p4.name = 'C'          # dirty {name} again
+  @p4.features.add('b')   # warns again -- window was reset
+end
+count_dirty_warnings(@out4)
+#=> 2
+
+## Partial clear_dirty! also resets the dedup window
+@p5 = DWWOncePlan.new(planid: 'once5', name: 'A', region: 'X')
+@p5.save
+@out5 = capture_familia_warnings do
+  @p5.name = 'B'
+  @p5.region = 'Y'         # dirty {name, region}
+  @p5.features.add('a')    # warn (sig [name, region])
+  @p5.features.add('a2')   # deduped
+  @p5.clear_dirty!(:region) # partial clear -> dirty {name}, window reset
+  @p5.features.add('b')    # warns (sig [name])
+end
+count_dirty_warnings(@out5)
+#=> 2
+
+## record_dirty_warning! returns true the first time a signature is seen
+@rp = DWWOncePlan.new(planid: 'rec1', name: 'A')
+@rp.name = 'B'
+@sig = @rp.dirty_fields.sort.freeze
+@rp.record_dirty_warning!(@sig)
+#=> true
+
+## record_dirty_warning! returns false for an already-seen signature
+@rp.record_dirty_warning!(@sig)
+#=> false
+
+# ---------------------------------------------------------------------------
+# :warn -- legacy every-write behavior
+# ---------------------------------------------------------------------------
+
+## :warn mode emits a warning on every collection write
+@w1 = DWWWarnPlan.new(planid: 'warn1', name: 'A')
+@w1.save
+@w1.name = 'B'
+@out_w = capture_familia_warnings do
+  @w1.features.add('x')
+  @w1.features.add('y')
+  @w1.features.add('z')
+end
+count_dirty_warnings(@out_w)
+#=> 3
+
+## :warn mode still includes the remediation hint
+@out_w.include?('(call #save first or wrap in atomic_write)')
+#=> true
+
+# ---------------------------------------------------------------------------
+# :off -- suppressed for the class
+# ---------------------------------------------------------------------------
+
+## :off mode suppresses warnings entirely for the class
+@o1 = DWWOffPlan.new(planid: 'off1', name: 'A')
+@o1.save
+@o1.name = 'B'
+@out_o = capture_familia_warnings do
+  @o1.features.add('x')
+  @o1.features.add('y')
+end
+count_dirty_warnings(@out_o)
+#=> 0
+
+# ---------------------------------------------------------------------------
+# :strict -- raises for the class even when global strict is off
+# ---------------------------------------------------------------------------
+
+## :strict class raises Familia::Problem even when global strict_write_order is off
+Familia.strict_write_order = false
+@s1 = DWWStrictPlan.new(planid: 'strict1', name: 'A')
+@s1.save
+@s1.name = 'B'
+begin
+  @s1.features.add('x')
+  @s1.clear_dirty!
+  :no_raise
+rescue Familia::Problem => e
+  [:raised, e.message.include?('unsaved scalar fields'),
+   e.message.include?('(call #save first or wrap in atomic_write)')]
+end
+#=> [:raised, true, true]
+
+# ---------------------------------------------------------------------------
+# Global strict_write_order raises every class EXCEPT those explicitly :off
+# ---------------------------------------------------------------------------
+
+## :off overrides even global strict_write_order -- off means off, the class
+## mode is the most specific signal and wins over the global escalation
+Familia.strict_write_order = true
+@go = DWWOffPlan.new(planid: 'goff1', name: 'A')
+@go.save
+@go.name = 'B'
+@go_out = begin
+  capture_familia_warnings { @go.features.add('x') }
+ensure
+  Familia.strict_write_order = false
+  @go.clear_dirty!
+end
+count_dirty_warnings(@go_out)
+#=> 0
+
+## Global strict raises on EVERY write (exempt from :once dedup)
+Familia.strict_write_order = true
+@gd = DWWOncePlan.new(planid: 'gd1', name: 'A')
+@gd.save
+@gd.name = 'B'
+@gd_raises = 0
+2.times do
+  @gd.features.add('x')
+rescue Familia::Problem
+  @gd_raises += 1
+end
+Familia.strict_write_order = false
+@gd.clear_dirty!
+@gd_raises
+#=> 2
+
+# ---------------------------------------------------------------------------
+# Global default fallback
+# ---------------------------------------------------------------------------
+
+## Familia.dirty_write_warnings = :off silences a class with no own setting
+Familia.dirty_write_warnings = :off
+DWWDefaultPlan.dirty_write_warnings
+#=> :off
+
+## ...and that suppression is observable on a collection write
+@gf = DWWDefaultPlan.new(planid: 'gf1', name: 'A')
+@gf.save
+@gf.name = 'B'
+@out_gf = capture_familia_warnings do
+  @gf.features.add('x')
+end
+Familia.dirty_write_warnings = :once # restore before the assertion
+count_dirty_warnings(@out_gf)
+#=> 0
+
+## A class with its own explicit setting ignores the global override
+DWWOncePlan.dirty_write_warnings
+#=> :once
+
+## Restoring the global default flows back to fallback classes
+Familia.dirty_write_warnings = :once
+DWWDefaultPlan.dirty_write_warnings
+#=> :once
+
+# ---------------------------------------------------------------------------
+# atomic_write suppression takes priority over all modes (including :strict)
+# ---------------------------------------------------------------------------
+
+## atomic_write suppresses the warning/raise even for a :strict class
+Familia.strict_write_order = false
+@aw = DWWStrictPlan.new(planid: 'aw1', name: 'A')
+@aw.save
+@aw_result = @aw.atomic_write do
+  @aw.name = 'Dirty'      # makes parent dirty by design
+  @aw.features.add('x')   # would raise in :strict, but suppressed inside the block
+end
+@aw_result
+#=> true
+
+## ...and no warning text leaked while inside the atomic_write block
+@aw2 = DWWStrictPlan.new(planid: 'aw2', name: 'A')
+@aw2.save
+@out_aw = capture_familia_warnings do
+  @aw2.atomic_write do
+    @aw2.name = 'Dirty'
+    @aw2.features.add('y')
+  end
+end
+count_dirty_warnings(@out_aw)
+#=> 0
+
+# ---------------------------------------------------------------------------
+# Composition with #278: new, unsaved parent raise-by-default
+#
+# For a NON-off class the raise paths (strict_write_order, class :strict, and
+# #278's new-object safety raise) fire independently of the warn mode -- so a
+# :once/:warn class still raises on a new, unsaved parent by default. But an
+# explicit :off is authoritative for the class ("off means off") and overrides
+# every raise switch; Familia.raise_on_unsaved_parent_write only matters for
+# classes that have NOT opted out.
+# ---------------------------------------------------------------------------
+
+## raise_on_unsaved_parent_write defaults to true
+Familia.raise_on_unsaved_parent_write
+#=> true
+
+## A new, unsaved :once parent RAISES by default (safety raise wins over warn mode)
+@ni = DWWOncePlan.new(planid: 'newonce', name: 'A')
+@ni.name = 'B' # dirty, never saved
+@ni_outcome = begin
+  @ni.features.add('x')
+  :no_raise
+rescue Familia::Problem => e
+  [:raised, e.message.include?('new, unsaved object'),
+   e.message.include?('(call #save first or wrap in atomic_write)')]
+ensure
+  @ni.clear_dirty!
+end
+@ni_outcome
+#=> [:raised, true, true]
+
+## A new, unsaved :off parent is suppressed entirely -- off means off (no warn, no raise)
+@nf = DWWOffPlan.new(planid: 'newoff', name: 'A')
+@nf.name = 'B'
+@nf_out = begin
+  capture_familia_warnings { @nf.features.add('x') }
+ensure
+  @nf.clear_dirty!
+end
+count_dirty_warnings(@nf_out)
+#=> 0
+
+## raise_on_unsaved_parent_write=false: a new unsaved :once parent warns, deduped, new-object message
+Familia.raise_on_unsaved_parent_write = false
+@nw = DWWOncePlan.new(planid: 'newwarn', name: 'A')
+@nw.name = 'B'
+@nw_out = begin
+  capture_familia_warnings do
+    @nw.features.add('x')
+    @nw.features.add('y') # deduped (same dirty signature)
+  end
+ensure
+  Familia.raise_on_unsaved_parent_write = true
+  @nw.clear_dirty!
+end
+[count_dirty_warnings(@nw_out), @nw_out.include?('new, unsaved object')]
+#=> [1, true]
+
+# @nf (above) already proved :off suppresses a new unsaved parent with
+# raise_on_unsaved_parent_write at its default (true). Together with this case
+# (raise_on_unsaved_parent_write = false), :off is shown to suppress regardless
+# of the safety switch -- the class mode is authoritative either way.
+
+## :off suppresses a new unsaved parent independent of raise_on_unsaved_parent_write
+Familia.raise_on_unsaved_parent_write = false
+@no = DWWOffPlan.new(planid: 'newoff2', name: 'A')
+@no.name = 'B'
+@no_out = begin
+  capture_familia_warnings { @no.features.add('x') }
+ensure
+  Familia.raise_on_unsaved_parent_write = true
+  @no.clear_dirty!
+end
+count_dirty_warnings(@no_out)
+#=> 0
+
+## Teardown
+Familia.strict_write_order = false
+Familia.dirty_write_warnings = :once
+Familia.raise_on_unsaved_parent_write = true
+Familia.dbclient.flushdb

--- a/try/features/safe_dump/safe_dump_advanced_try.rb
+++ b/try/features/safe_dump/safe_dump_advanced_try.rb
@@ -37,7 +37,7 @@ Customer.safe_dump_fields
 end.sort
 
 (@all_non_safe_fields - Customer.safe_dump_fields).sort
-#=> [:custom_domains, :dirty_fields, :email, :password_reset, :sessions, :stripe_customer, :timeline]
+#=> [:custom_domains, :dirty_fields, :email, :password_reset, :sessions, :stripe_customer, :timeline, :warned_dirty_signatures]
 
 ## Implementing models like Customer can rest assured knowing
 ## any other field not in the safe list will not be dumped.


### PR DESCRIPTION
## Summary

Implements issue #277: adds a per-class `dirty_write_warnings` mode control that complements the global `strict_write_order` setting, with intelligent deduplication of warnings per dirty-field signature within a dirty window. Warnings now include a remediation hint, and the feature composes cleanly with the #278 safety raise for new, unsaved parents.

## Key Changes

- **New class-level setting**: `dirty_write_warnings` on every `Familia::Horreum` subclass with four modes:
  - `:strict` – raise `Familia::Problem` (overrides global `strict_write_order=false`)
  - `:warn` – warn on every collection write (legacy behavior)
  - `:once` – warn once per distinct dirty-field signature per window (new default)
  - `:off` – suppress entirely for the class (overrides all raise switches)

- **New global setting**: `Familia.dirty_write_warnings` provides the default mode for classes without their own setting, defaulting to `:once`

- **Deduplication primitive**: `record_dirty_warning!(signature)` on `Horreum` instances uses `Concurrent::Map#put_if_absent` to track which dirty-field signatures have warned in the current window, mirroring the `mark_dirty!` pattern

- **Window reset**: `clear_dirty!` (full or partial) now resets the dedup window via `@warned_dirty_signatures.clear`, so the same signature warns again after a save or field change

- **Remediation hint**: All dirty-write messages now append `(call #save first or wrap in atomic_write)` so the fix is self-evident

- **Raise/warn composition**: Raise paths (global `strict_write_order`, class `:strict`, or new/unsaved parent safety) fire independently of the warning mode and are exempt from dedup. An explicit `:off` is authoritative and suppresses both warnings and raises, consistent with how explicit "ignore" beats global escalation in other tools

- **atomic_write priority**: Active `atomic_write` blocks suppress all warnings and raises, taking priority over every mode

## Implementation Details

- **Mode resolution** (`DataType#resolve_dirty_warning_mode`): Walks the parent class's `dirty_write_warnings` setting (which itself walks the subclass chain) and falls back to `Familia.dirty_write_warnings` global
- **Raise decision** (`DataType#raise_on_dirty_write?`): Checks global strict, class `:strict`, or new/unsaved parent safety independently of the warning mode
- **Message building** (`DataType#dirty_write_message`): Constructs distinct messages for new vs. saved parents, both ending with the remediation hint
- **Warning emission** (`DataType#emit_dirty_warning`): `:warn` warns unconditionally; `:once` dedupes via `record_dirty_warning!`
- **Subclass inheritance**: Class setting walks the superclass chain and falls back to global, allowing seed scripts and bulk importers to opt down without touching the global

## Decision logic

How a collection write on a dirty parent resolves to suppress / raise / warn. The class-level `dirty_write_warnings` mode is the most specific signal: an explicit `:off` short-circuits **above** the raise gate, so it suppresses both warnings and raises ("off means off"), overriding the global switches.

```mermaid
flowchart TD
    A(["collection write — e.g. plan.features.add(x)"]) --> B{"inside atomic_write block?"}
    B -->|yes| S1(["SUPPRESS — highest priority"]):::suppress
    B -->|no| C{"parent dirty?"}
    C -->|no| S2(["do nothing"]):::suppress
    C -->|yes| M["resolve mode = :strict / :warn / :once / :off"]
    M --> OFF{"mode == :off ?"}
    OFF -->|"yes — off means off"| S3(["SUPPRESS<br/>overrides BOTH global raise switches"]):::suppress
    OFF -->|no| G{{"RAISE GATE — raise if ANY:<br/>• Familia.strict_write_order<br/>• mode == :strict<br/>• new_record AND raise_on_unsaved_parent_write"}}
    G -->|any true| R(["RAISE Familia::Problem"]):::raise
    G -->|none true| W{"mode == :warn ?"}
    W -->|yes| WE(["WARN — every write"]):::warn
    W -->|"no (:once)"| WO(["WARN — once per dirty-field signature (deduped)"]):::warn

    classDef suppress fill:#e5e7eb,stroke:#6b7280,color:#111827
    classDef raise fill:#fee2e2,stroke:#dc2626,color:#7f1d1d
    classDef warn fill:#fef3c7,stroke:#d97706,color:#78350f
```

### Outcome matrix

**New, unsaved + dirty parent** (`strict_write_order = false`):

| mode | `raise_on_unsaved_parent_write = true` (default) | `= false` |
|---|---|---|
| `:once` | **RAISE** | warn (deduped) |
| `:warn` | **RAISE** | warn (every write) |
| `:off` | suppress | suppress |
| `:strict` | **RAISE** | **RAISE** |

With `strict_write_order = true`, every cell becomes **RAISE** — except the `:off` row, which stays `suppress`.

**Saved + dirty parent** (`new_record = false`): the new-object gate never fires, so the mode is fully in charge — `:once` → warn (deduped), `:warn` → warn (every write), `:off` → suppress, `:strict` → RAISE.

## Test Coverage

Comprehensive tryouts in `try/features/dirty_write_warnings_try.rb` covering:
- Class-level setting resolution and inheritance
- `:once` dedup behavior across repeated writes and signature changes
- Full and partial `clear_dirty!` window resets
- `:warn`, `:off`, `:strict` modes
- Global default fallback and override
- `atomic_write` priority over `:strict`
- Composition with #278 new/unsaved parent safety raise

https://claude.ai/code/session_01DaPijWb8wNoa5A6U6c8KTh