### PR TITLE
Add Horreum.build factory block for atomic create-and-populate

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -268,7 +268,7 @@ Constraints:
 - Cannot nest inside another `transaction` or `atomic_write` (raises `Familia::OperationModeError`).
 - Collection method return values inside the block are `Redis::Future` objects (inherent to MULTI) -- do not inspect them before EXEC.
 
-**Factory pattern -- `build`/`construct` for create-and-populate:**
+**Factory pattern -- `build` for create-and-populate:**
 ```ruby
 user = User.build(email: "alice@example.com") do |u|
   u.name = "Alice"          # deferred scalar
@@ -278,7 +278,7 @@ end
 # new(...) runs first; the block's scalars + collections commit in one
 # MULTI/EXEC at block exit. Returns the persisted instance.
 ```
-`build` (alias `construct`) is class-level sugar over `new` + `atomic_write`: it inherits the same single-database constraint (`CrossDatabaseError`) and `save` (overwrite) semantics. Unlike `create!` it does no duplicate check but does fold collection writes into the atomic commit. Without a block it degenerates to `new(...).save`.
+`build` is class-level sugar over `new` + `atomic_write` with create-only semantics: it raises `RecordExistsError` if the identifier already exists, inherits the same single-database constraint (`CrossDatabaseError`), and folds collection writes into the atomic commit. Without a block it degenerates to `new(...).save`. For overwrite/upsert behaviour, use `save` or `save_with_collections` directly.
 
 **Instances timeline**: The class-level `instances` sorted set is a timeline of last-modified times, not a registry. `persist_to_storage` (called by `save`) and `commit_fields`/`batch_update` all call `touch_instances!` to update the timestamp. Use `in_instances?(identifier)` for fast O(log N) checks without loading the object.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -268,6 +268,18 @@ Constraints:
 - Cannot nest inside another `transaction` or `atomic_write` (raises `Familia::OperationModeError`).
 - Collection method return values inside the block are `Redis::Future` objects (inherent to MULTI) -- do not inspect them before EXEC.
 
+**Factory pattern -- `build`/`construct` for create-and-populate:**
+```ruby
+user = User.build(email: "alice@example.com") do |u|
+  u.name = "Alice"          # deferred scalar
+  u.tags.add("admin")       # collection op folded into the same MULTI
+  u.sessions.push("abc123")
+end
+# new(...) runs first; the block's scalars + collections commit in one
+# MULTI/EXEC at block exit. Returns the persisted instance.
+```
+`build` (alias `construct`) is class-level sugar over `new` + `atomic_write`: it inherits the same single-database constraint (`CrossDatabaseError`) and `save` (overwrite) semantics. Unlike `create!` it does no duplicate check but does fold collection writes into the atomic commit. Without a block it degenerates to `new(...).save`.
+
 **Instances timeline**: The class-level `instances` sorted set is a timeline of last-modified times, not a registry. `persist_to_storage` (called by `save`) and `commit_fields`/`batch_update` all call `touch_instances!` to update the timestamp. Use `in_instances?(identifier)` for fast O(log N) checks without loading the object.
 
 ### Instances Timeline Lifecycle

--- a/changelog.d/20260603_000000_claude_279_build_block.rst
+++ b/changelog.d/20260603_000000_claude_279_build_block.rst
@@ -1,13 +1,12 @@
 Added
 -----
 
-- ``Horreum.build`` (alias ``Horreum.construct``): a factory block that creates
-  an instance, yields it for scalar and collection setup, then commits
-  everything in a single ``MULTI/EXEC`` when the block exits. Collection
-  mutations made inside the block (e.g. ``u.tags.add(...)``) are folded into the
-  same transaction as the implicit ``HMSET``, so factory/fixture code no longer
-  has to sequence ``save`` before collection writes or reach for
-  ``atomic_write`` directly. #279
+- ``Horreum.build``: a factory block that creates an instance, yields it for
+  scalar and collection setup, then commits everything in a single
+  ``MULTI/EXEC`` when the block exits. Collection mutations made inside the
+  block (e.g. ``u.tags.add(...)``) are folded into the same transaction as the
+  implicit ``HMSET``, so factory/fixture code no longer has to sequence ``save``
+  before collection writes or reach for ``atomic_write`` directly. #279
 
   .. code-block:: ruby
 
@@ -17,10 +16,10 @@ Added
      end
      # HMSET + SADD + RPUSH all fire in one MULTI/EXEC at block exit
 
-  ``build`` has ``save`` (overwrite) semantics like ``atomic_write`` -- it does
-  not perform the duplicate check that ``create!`` does; use ``create!`` for
-  create-only behaviour. Because it builds on ``atomic_write``, the same
-  single-database constraint applies: a related field on a different
+  ``build`` has create-only semantics: it raises ``Familia::RecordExistsError``
+  if the identifier already exists, following the principle of least
+  astonishment for a factory method. Because it builds on ``atomic_write``, the
+  same single-database constraint applies: a related field on a different
   ``logical_database`` raises ``Familia::CrossDatabaseError`` (fall back to
   ``save_with_collections`` in that case). Called without a block, ``build`` is
   equivalent to ``new(...).save``.
@@ -28,11 +27,11 @@ Added
 AI Assistance
 -------------
 
-- AI implemented the ``build``/``construct`` factory block from #279, composing
-  it on the existing ``atomic_write`` infrastructure rather than duplicating the
+- AI implemented the ``build`` factory block from #279, composing it on the
+  existing ``atomic_write`` infrastructure rather than duplicating the
   ``MULTI/EXEC`` plumbing, so it inherits the cross-database guard, same-instance
   re-entrancy protection, and dirty-state warning suppression. Added a tryouts
   suite covering the atomic commit of scalars and collections, exception
   rollback (no partial writes, verified down to the raw collection key),
-  overwrite semantics, the ``construct`` alias, positional-identifier usage, and
+  create-only semantics (duplicate rejection), positional-identifier usage, and
   the cross-database error path.

--- a/changelog.d/20260603_000000_claude_279_build_block.rst
+++ b/changelog.d/20260603_000000_claude_279_build_block.rst
@@ -1,0 +1,38 @@
+Added
+-----
+
+- ``Horreum.build`` (alias ``Horreum.construct``): a factory block that creates
+  an instance, yields it for scalar and collection setup, then commits
+  everything in a single ``MULTI/EXEC`` when the block exits. Collection
+  mutations made inside the block (e.g. ``u.tags.add(...)``) are folded into the
+  same transaction as the implicit ``HMSET``, so factory/fixture code no longer
+  has to sequence ``save`` before collection writes or reach for
+  ``atomic_write`` directly. #279
+
+  .. code-block:: ruby
+
+     user = User.build(email: 'alice@example.com') do |u|
+       u.tags.add('admin')
+       u.sessions.push('abc123')
+     end
+     # HMSET + SADD + RPUSH all fire in one MULTI/EXEC at block exit
+
+  ``build`` has ``save`` (overwrite) semantics like ``atomic_write`` -- it does
+  not perform the duplicate check that ``create!`` does; use ``create!`` for
+  create-only behaviour. Because it builds on ``atomic_write``, the same
+  single-database constraint applies: a related field on a different
+  ``logical_database`` raises ``Familia::CrossDatabaseError`` (fall back to
+  ``save_with_collections`` in that case). Called without a block, ``build`` is
+  equivalent to ``new(...).save``.
+
+AI Assistance
+-------------
+
+- AI implemented the ``build``/``construct`` factory block from #279, composing
+  it on the existing ``atomic_write`` infrastructure rather than duplicating the
+  ``MULTI/EXEC`` plumbing, so it inherits the cross-database guard, same-instance
+  re-entrancy protection, and dirty-state warning suppression. Added a tryouts
+  suite covering the atomic commit of scalars and collections, exception
+  rollback (no partial writes, verified down to the raw collection key),
+  overwrite semantics, the ``construct`` alias, positional-identifier usage, and
+  the cross-database error path.

--- a/lib/familia/horreum/management.rb
+++ b/lib/familia/horreum/management.rb
@@ -48,6 +48,12 @@ module Familia
       # identifier already exists. If it does, a Familia::RecordExistsError exception is
       # raised to prevent overwriting existing data.
       #
+      # Concurrency: the duplicate check is best-effort, not fully atomic.
+      # It routes through {#save_if_not_exists!}, which uses WATCH + MULTI/EXEC
+      # to abort if the key appears between the check and the write -- more
+      # cautious than a bare read-then-write, but a true guarantee needs a
+      # server-side check (e.g. Lua). See {#save_if_not_exists!}.
+      #
       # Finally, the method saves the new instance returns it.
       #
       # @example Creating an object with keyword arguments
@@ -64,6 +70,7 @@ module Familia
       # @see #save
       def create!(...)
         hobj = new(...)
+        # Best-effort duplicate guard: WATCH + MULTI/EXEC, not fully atomic.
         hobj.save_if_not_exists!
 
         # If a block is given, yield the created object
@@ -99,6 +106,15 @@ module Familia
       # a factory helper should not silently overwrite existing records.
       # Use {Persistence#save} or {Persistence#save_with_collections} when
       # you explicitly want overwrite/upsert behaviour.
+      #
+      # Concurrency: the duplicate check is best-effort, not atomic. The
+      # +exists?+ read and the subsequent write are separate operations with no
+      # WATCH between them, so two concurrent +build+ calls for the same
+      # identifier can both pass the check and the later write wins. This guard
+      # is weaker than {.create!} (which uses WATCH + MULTI/EXEC via
+      # {#save_if_not_exists!}); it is intended for single-threaded
+      # factory/fixture use. Use {.create!} when concurrent creators are
+      # possible.
       #
       # ## Without a block
       #
@@ -140,6 +156,9 @@ module Familia
         # a post-build callback, so it must not leak into new/initialize.
         instance = new(*, **)
 
+        # Best-effort duplicate guard (TOCTOU): no WATCH between this read and
+        # the write below, so concurrent builds can race. See .create! for a
+        # WATCH-guarded alternative.
         raise Familia::RecordExistsError, instance.dbkey if instance.exists?
 
         if block_given?

--- a/lib/familia/horreum/management.rb
+++ b/lib/familia/horreum/management.rb
@@ -105,8 +105,10 @@ module Familia
       # When called without a block there are no collection operations to fold
       # in, so +build+ degenerates to +new(...).save+ and returns the instance.
       #
-      # @param args [Array] Positional arguments forwarded to {.new}.
-      # @param kwargs [Hash] Keyword arguments (field values) forwarded to {.new}.
+      # Positional and keyword arguments are forwarded to {.new}. The block is
+      # NOT forwarded to the constructor -- it is invoked here, after building,
+      # with the new instance.
+      #
       # @yield [instance] The newly built instance, for scalar/collection setup.
       # @yieldparam instance [Horreum] The not-yet-persisted instance.
       # @return [Horreum] The built and persisted instance.
@@ -133,8 +135,10 @@ module Familia
       # @see Persistence#save_with_collections Sequential alternative for
       #   cross-database configurations
       #
-      def build(...)
-        instance = new(...)
+      def build(*, **)
+        # Forward only positional/keyword args to the constructor; the block is
+        # a post-build callback, so it must not leak into new/initialize.
+        instance = new(*, **)
 
         raise Familia::RecordExistsError, instance.dbkey if instance.exists?
 

--- a/lib/familia/horreum/management.rb
+++ b/lib/familia/horreum/management.rb
@@ -107,19 +107,18 @@ module Familia
       # Use {Persistence#save} or {Persistence#save_with_collections} when
       # you explicitly want overwrite/upsert behaviour.
       #
-      # Concurrency: the duplicate check is best-effort, not atomic. The
-      # +exists?+ read and the subsequent write are separate operations with no
-      # WATCH between them, so two concurrent +build+ calls for the same
-      # identifier can both pass the check and the later write wins. This guard
-      # is weaker than {.create!} (which uses WATCH + MULTI/EXEC via
-      # {#save_if_not_exists!}); it is intended for single-threaded
-      # factory/fixture use. Use {.create!} when concurrent creators are
-      # possible.
+      # Concurrency: when called without a block, +build+ delegates to
+      # {#save_if_not_exists!} which uses WATCH + MULTI/EXEC for race-safe
+      # duplicate detection. With a block, the duplicate check is best-effort
+      # (TOCTOU): the +exists?+ read and the subsequent +atomic_write+ are
+      # separate operations with no WATCH between them, so concurrent +build+
+      # calls for the same identifier can both pass the check. See issue #288
+      # for composing WATCH into the block path.
       #
       # ## Without a block
       #
       # When called without a block there are no collection operations to fold
-      # in, so +build+ degenerates to +new(...).save+ and returns the instance.
+      # in, so +build+ uses +save_if_not_exists!+ and returns the instance.
       #
       # Positional and keyword arguments are forwarded to {.new}. The block is
       # NOT forwarded to the constructor -- it is invoked here, after building,
@@ -156,15 +155,17 @@ module Familia
         # a post-build callback, so it must not leak into new/initialize.
         instance = new(*, **)
 
-        # Best-effort duplicate guard (TOCTOU): no WATCH between this read and
-        # the write below, so concurrent builds can race. See .create! for a
-        # WATCH-guarded alternative.
-        raise Familia::RecordExistsError, instance.dbkey if instance.exists?
-
         if block_given?
+          # Best-effort duplicate guard (TOCTOU): no WATCH between this read
+          # and the atomic_write below, so concurrent builds can race. See
+          # issue #288 for composing WATCH into atomic_write.
+          raise Familia::RecordExistsError, instance.dbkey if instance.exists?
+
           instance.atomic_write { yield instance }
         else
-          instance.save
+          # No block means no collection ops to fold in, so we can use the
+          # WATCH-guarded save_if_not_exists! directly — race-safe.
+          instance.save_if_not_exists!
         end
 
         instance

--- a/lib/familia/horreum/management.rb
+++ b/lib/familia/horreum/management.rb
@@ -93,12 +93,12 @@ module Familia
       #
       # ## Persistence semantics
       #
-      # +build+ uses {Horreum#atomic_write}, which has +save+ semantics: it
-      # writes unconditionally and overwrites any existing record with the same
-      # identifier. It does NOT perform the existence check that {.create!}
-      # does. Use {.create!} when you need create-only (raise-on-duplicate)
-      # behaviour; note +create!+ cannot fold collection writes into the same
-      # atomic commit.
+      # +build+ has create-only semantics: it raises
+      # {Familia::RecordExistsError} if an object with the same identifier
+      # already exists. This follows the principle of least astonishment --
+      # a factory helper should not silently overwrite existing records.
+      # Use {Persistence#save} or {Persistence#save_with_collections} when
+      # you explicitly want overwrite/upsert behaviour.
       #
       # ## Without a block
       #
@@ -111,6 +111,8 @@ module Familia
       # @yieldparam instance [Horreum] The not-yet-persisted instance.
       # @return [Horreum] The built and persisted instance.
       #
+      # @raise [Familia::RecordExistsError] If an object with the same identifier
+      #   already exists in the database.
       # @raise [Familia::CrossDatabaseError] If the class has related fields on a
       #   different +logical_database+ than the parent (MULTI/EXEC cannot span
       #   databases). Fall back to building the object and using
@@ -127,13 +129,14 @@ module Familia
       # @example Without a block (plain save)
       #   user = User.build(email: 'bob@example.com')
       #
-      # @see #create! Create-only factory (raises on duplicate; no atomic collections)
       # @see Horreum#atomic_write The underlying single-MULTI/EXEC write
       # @see Persistence#save_with_collections Sequential alternative for
       #   cross-database configurations
       #
       def build(...)
         instance = new(...)
+
+        raise Familia::RecordExistsError, instance.dbkey if instance.exists?
 
         if block_given?
           instance.atomic_write { yield instance }
@@ -143,7 +146,6 @@ module Familia
 
         instance
       end
-      alias construct build
 
       def multiget(...)
         rawmultiget(...).filter_map { |json| Familia::JsonSerializer.parse(json) }

--- a/lib/familia/horreum/management.rb
+++ b/lib/familia/horreum/management.rb
@@ -73,6 +73,78 @@ module Familia
         hobj
       end
 
+      # Builds, populates, and atomically persists a new instance in one step.
+      #
+      # This is a factory wrapper around {Horreum#atomic_write} for the common
+      # case of "create an object, set up its collections, and save -- all at
+      # once". The block receives the freshly-built (but not-yet-persisted)
+      # instance. Scalar assignments and collection mutations made inside the
+      # block are all committed in a single MULTI/EXEC when the block exits:
+      #
+      #   - Scalar setters (+u.name = ...+) stay in memory until the implicit
+      #     save queues the HMSET inside the transaction.
+      #   - Collection mutations (+u.tags.add(...)+) auto-route into the open
+      #     transaction because +DataType#dbclient+ honours
+      #     +Fiber[:familia_transaction]+.
+      #
+      # Nothing reaches the database until the block exits, so a factory no
+      # longer has to choose between sequencing +save+ before collection writes
+      # or reaching for +atomic_write+ directly.
+      #
+      # ## Persistence semantics
+      #
+      # +build+ uses {Horreum#atomic_write}, which has +save+ semantics: it
+      # writes unconditionally and overwrites any existing record with the same
+      # identifier. It does NOT perform the existence check that {.create!}
+      # does. Use {.create!} when you need create-only (raise-on-duplicate)
+      # behaviour; note +create!+ cannot fold collection writes into the same
+      # atomic commit.
+      #
+      # ## Without a block
+      #
+      # When called without a block there are no collection operations to fold
+      # in, so +build+ degenerates to +new(...).save+ and returns the instance.
+      #
+      # @param args [Array] Positional arguments forwarded to {.new}.
+      # @param kwargs [Hash] Keyword arguments (field values) forwarded to {.new}.
+      # @yield [instance] The newly built instance, for scalar/collection setup.
+      # @yieldparam instance [Horreum] The not-yet-persisted instance.
+      # @return [Horreum] The built and persisted instance.
+      #
+      # @raise [Familia::CrossDatabaseError] If the class has related fields on a
+      #   different +logical_database+ than the parent (MULTI/EXEC cannot span
+      #   databases). Fall back to building the object and using
+      #   {Persistence#save_with_collections} in that case.
+      # @raise [Familia::NoIdentifier] If the instance has no usable identifier.
+      #
+      # @example Factory/fixture creation with collections (issue #279)
+      #   user = User.build(email: 'alice@example.com') do |u|
+      #     u.tags.add('admin')
+      #     u.sessions.push('abc123')
+      #   end
+      #   # HMSET + SADD + RPUSH all fire in one MULTI/EXEC at block exit
+      #
+      # @example Without a block (plain save)
+      #   user = User.build(email: 'bob@example.com')
+      #
+      # @see #create! Create-only factory (raises on duplicate; no atomic collections)
+      # @see Horreum#atomic_write The underlying single-MULTI/EXEC write
+      # @see Persistence#save_with_collections Sequential alternative for
+      #   cross-database configurations
+      #
+      def build(...)
+        instance = new(...)
+
+        if block_given?
+          instance.atomic_write { yield instance }
+        else
+          instance.save
+        end
+
+        instance
+      end
+      alias construct build
+
       def multiget(...)
         rawmultiget(...).filter_map { |json| Familia::JsonSerializer.parse(json) }
       end

--- a/try/features/build_block_try.rb
+++ b/try/features/build_block_try.rb
@@ -1,0 +1,169 @@
+# try/features/build_block_try.rb
+#
+# Tests for the class-level `build` (alias `construct`) factory block.
+# See issue #279. `build` wraps `new` + `atomic_write` so that scalar fields
+# and collection mutations made inside the block all commit in a single
+# MULTI/EXEC at block exit.
+
+require_relative '../support/helpers/test_helpers'
+
+Familia.debug = false
+
+# Primary test class with one of each collection type
+class BuildTestUser < Familia::Horreum
+  identifier_field :email
+  field :email
+  field :name
+  field :role
+  set :tags
+  list :sessions
+  sorted_set :scores
+  hashkey :settings
+end
+
+# Class with a cross-database collection for the CrossDatabaseError path
+class BuildCrossDbUser < Familia::Horreum
+  logical_database 0
+  identifier_field :email
+  field :email
+  field :name
+  list :sessions, logical_database: 5
+end
+
+# Clean slate
+BuildTestUser.instances.clear
+BuildTestUser.all.each(&:destroy!)
+BuildCrossDbUser.instances.clear rescue nil
+
+## build with a block persists scalars and collections atomically
+@user_a = BuildTestUser.build(email: 'alice@example.com', name: 'Alice') do |u|
+  u.role = 'admin'
+  u.tags.add('staff')
+  u.tags.add('beta')
+  u.sessions.push('sess_a1')
+  u.scores.add('reputation', 100.0)
+  u.settings['theme'] = 'dark'
+end
+@reloaded_a = BuildTestUser.find_by_id('alice@example.com')
+[
+  @reloaded_a.name,
+  @reloaded_a.role,
+  @reloaded_a.tags.members.sort,
+  @reloaded_a.sessions.members,
+  @reloaded_a.scores.members,
+  @reloaded_a.settings['theme'],
+]
+#=> ['Alice', 'admin', ['beta', 'staff'], ['sess_a1'], ['reputation'], 'dark']
+
+## build returns the built instance
+@user_b = BuildTestUser.build(email: 'bob@example.com', name: 'Bob') do |u|
+  u.tags.add('member')
+end
+[@user_b.is_a?(BuildTestUser), @user_b.email, @user_b.name]
+#=> [true, 'bob@example.com', 'Bob']
+
+## build without a block degenerates to new + save
+@user_c = BuildTestUser.build(email: 'carol@example.com', name: 'Carol')
+@reloaded_c = BuildTestUser.find_by_id('carol@example.com')
+[@user_c.is_a?(BuildTestUser), @reloaded_c.name]
+#=> [true, 'Carol']
+
+## construct is an alias for build
+@user_d = BuildTestUser.construct(email: 'dave@example.com', name: 'Dave') do |u|
+  u.tags.add('aliased')
+end
+@reloaded_d = BuildTestUser.find_by_id('dave@example.com')
+[@reloaded_d.name, @reloaded_d.tags.members]
+#=> ['Dave', ['aliased']]
+
+## build accepts a positional identifier argument plus a block
+@user_e = BuildTestUser.build('erin@example.com') do |u|
+  u.name = 'Erin'
+  u.tags.add('positional')
+end
+@reloaded_e = BuildTestUser.find_by_id('erin@example.com')
+[@reloaded_e.email, @reloaded_e.name, @reloaded_e.tags.members]
+#=> ['erin@example.com', 'Erin', ['positional']]
+
+## the built object is registered in the instances timeline
+BuildTestUser.in_instances?('alice@example.com')
+#=> true
+
+## a scalar-only block still commits the scalar fields
+@user_f = BuildTestUser.build(email: 'frank@example.com') do |u|
+  u.name = 'Frank'
+  u.role = 'viewer'
+end
+@reloaded_f = BuildTestUser.find_by_id('frank@example.com')
+[@reloaded_f.name, @reloaded_f.role]
+#=> ['Frank', 'viewer']
+
+## an exception inside the block aborts the whole commit (nothing persists)
+@build_raised = false
+begin
+  BuildTestUser.build(email: 'ghost@example.com', name: 'Ghost') do |u|
+    u.tags.add('doomed')
+    raise 'boom'
+  end
+rescue RuntimeError
+  @build_raised = true
+end
+# Fresh object: neither the hash key nor the collection should exist
+[@build_raised, BuildTestUser.find_by_id('ghost@example.com'), BuildTestUser.in_instances?('ghost@example.com')]
+#=> [true, nil, false]
+
+## the aborted build leaves no collection key behind (true atomicity)
+## If collection writes were immediate (non-atomic), the tags SADD would have
+## landed before the exception. Because build folds them into the same MULTI,
+## the discarded transaction leaves the collection key absent.
+@ghost_tags_key = BuildTestUser.new(email: 'ghost@example.com').tags.dbkey
+Familia.dbclient.exists?(@ghost_tags_key)
+#=> false
+
+## the built instance is not dirty after a successful build
+@user_h = BuildTestUser.build(email: 'heidi@example.com', name: 'Heidi') do |u|
+  u.role = 'editor'
+  u.tags.add('clean')
+end
+@user_h.dirty?
+#=> false
+
+## build has save (overwrite) semantics, not create-only
+@user_i1 = BuildTestUser.build(email: 'ivan@example.com', name: 'Ivan First') do |u|
+  u.tags.add('first')
+end
+@user_i2 = BuildTestUser.build(email: 'ivan@example.com', name: 'Ivan Second') do |u|
+  u.tags.add('second')
+end
+@reloaded_i = BuildTestUser.find_by_id('ivan@example.com')
+# Scalar is overwritten; the set accumulates both adds (no implicit clear)
+[@reloaded_i.name, @reloaded_i.tags.members.sort]
+#=> ['Ivan Second', ['first', 'second']]
+
+## a clear-then-add inside the block is part of the same atomic commit
+@user_j = BuildTestUser.build(email: 'judy@example.com', name: 'Judy') do |u|
+  u.tags.add('temp')
+  u.tags.clear
+  u.tags.add('final')
+end
+@reloaded_j = BuildTestUser.find_by_id('judy@example.com')
+@reloaded_j.tags.members
+#=> ['final']
+
+## build raises CrossDatabaseError when a related field spans databases
+@cross_raised = nil
+begin
+  BuildCrossDbUser.build(email: 'cross@example.com', name: 'Cross') do |u|
+    u.sessions.push('nope')
+  end
+rescue Familia::CrossDatabaseError => e
+  @cross_raised = [e.field_name, e.field_database, e.horreum_database]
+end
+@cross_raised
+#=> [:sessions, 5, 0]
+
+# Cleanup
+BuildTestUser.instances.clear
+BuildTestUser.all.each(&:destroy!)
+BuildCrossDbUser.instances.clear rescue nil
+BuildCrossDbUser.all.each(&:destroy!) rescue nil

--- a/try/features/build_block_try.rb
+++ b/try/features/build_block_try.rb
@@ -30,10 +30,28 @@ class BuildCrossDbUser < Familia::Horreum
   list :sessions, logical_database: 5
 end
 
+# Probe class: records whether initialize received a block, to prove that
+# build forwards only positional/keyword args to new -- not the build callback.
+class BuildBlockLeakProbe < Familia::Horreum
+  identifier_field :email
+  field :email
+  set :tags
+
+  class << self
+    attr_accessor :init_saw_block
+  end
+
+  def initialize(*args, **kwargs)
+    self.class.init_saw_block = block_given?
+    super
+  end
+end
+
 # Clean slate
 BuildTestUser.instances.clear
 BuildTestUser.all.each(&:destroy!)
 BuildCrossDbUser.instances.clear rescue nil
+BuildBlockLeakProbe.instances.clear rescue nil
 
 ## build with a block persists scalars and collections atomically
 @user_a = BuildTestUser.build(email: 'alice@example.com', name: 'Alice') do |u|
@@ -147,6 +165,11 @@ end
 @reloaded_j.tags.members
 #=> ['final']
 
+## build forwards only args/kwargs to new -- the callback block does not leak into initialize
+BuildBlockLeakProbe.build(email: 'probe@example.com') { |u| u.tags.add('x') }
+BuildBlockLeakProbe.init_saw_block
+#=> false
+
 ## build raises CrossDatabaseError when a related field spans databases
 @cross_raised = nil
 begin
@@ -164,3 +187,5 @@ BuildTestUser.instances.clear
 BuildTestUser.all.each(&:destroy!)
 BuildCrossDbUser.instances.clear rescue nil
 BuildCrossDbUser.all.each(&:destroy!) rescue nil
+BuildBlockLeakProbe.instances.clear rescue nil
+BuildBlockLeakProbe.all.each(&:destroy!) rescue nil

--- a/try/features/build_block_try.rb
+++ b/try/features/build_block_try.rb
@@ -1,9 +1,9 @@
 # try/features/build_block_try.rb
 #
-# Tests for the class-level `build` (alias `construct`) factory block.
+# Tests for the class-level `build` factory block.
 # See issue #279. `build` wraps `new` + `atomic_write` so that scalar fields
 # and collection mutations made inside the block all commit in a single
-# MULTI/EXEC at block exit.
+# MULTI/EXEC at block exit. Uses create-only semantics (raises on duplicate).
 
 require_relative '../support/helpers/test_helpers'
 
@@ -68,14 +68,6 @@ end
 [@user_c.is_a?(BuildTestUser), @reloaded_c.name]
 #=> [true, 'Carol']
 
-## construct is an alias for build
-@user_d = BuildTestUser.construct(email: 'dave@example.com', name: 'Dave') do |u|
-  u.tags.add('aliased')
-end
-@reloaded_d = BuildTestUser.find_by_id('dave@example.com')
-[@reloaded_d.name, @reloaded_d.tags.members]
-#=> ['Dave', ['aliased']]
-
 ## build accepts a positional identifier argument plus a block
 @user_e = BuildTestUser.build('erin@example.com') do |u|
   u.name = 'Erin'
@@ -128,17 +120,22 @@ end
 @user_h.dirty?
 #=> false
 
-## build has save (overwrite) semantics, not create-only
+## build raises RecordExistsError on duplicate (create-only semantics)
 @user_i1 = BuildTestUser.build(email: 'ivan@example.com', name: 'Ivan First') do |u|
   u.tags.add('first')
 end
-@user_i2 = BuildTestUser.build(email: 'ivan@example.com', name: 'Ivan Second') do |u|
-  u.tags.add('second')
+@duplicate_raised = false
+begin
+  BuildTestUser.build(email: 'ivan@example.com', name: 'Ivan Second') do |u|
+    u.tags.add('second')
+  end
+rescue Familia::RecordExistsError
+  @duplicate_raised = true
 end
 @reloaded_i = BuildTestUser.find_by_id('ivan@example.com')
-# Scalar is overwritten; the set accumulates both adds (no implicit clear)
-[@reloaded_i.name, @reloaded_i.tags.members.sort]
-#=> ['Ivan Second', ['first', 'second']]
+# Original is untouched; duplicate was rejected
+[@duplicate_raised, @reloaded_i.name, @reloaded_i.tags.members]
+#=> [true, 'Ivan First', ['first']]
 
 ## a clear-then-add inside the block is part of the same atomic commit
 @user_j = BuildTestUser.build(email: 'judy@example.com', name: 'Judy') do |u|


### PR DESCRIPTION
## Summary

Adds `Horreum.build`, a class-level factory method that creates an instance, yields it for scalar and collection setup, then commits everything in a single `MULTI/EXEC` when the block exits. This eliminates the need to sequence `save` before collection writes or reach for `atomic_write` directly in factory/fixture code.

## Key Changes

- **New `build` class method** (`lib/familia/horreum/management.rb`):
  - Wraps `new` + `atomic_write` to fold scalar assignments and collection mutations into one atomic transaction
  - Has create-only semantics: raises `RecordExistsError` if the identifier already exists
  - Without a block, degenerates to `new(...).save_if_not_exists!` for race-safe duplicate detection
  - Inherits the same single-database constraint as `atomic_write`: raises `CrossDatabaseError` if related fields span databases
  - Forwards only positional/keyword args to the constructor; the block is a post-build callback and does not leak into `initialize`

- **Comprehensive tryouts test suite** (`try/features/build_block_try.rb`):
  - Verifies atomic commit of scalars and collections in a single `MULTI/EXEC`
  - Tests exception rollback (no partial writes, verified down to raw collection keys)
  - Validates create-only semantics (duplicate rejection)
  - Covers positional identifier usage and block-less invocation
  - Tests the cross-database error path
  - Confirms the built instance is not dirty after successful build
  - Verifies the block callback does not leak into `initialize`

- **Documentation**:
  - Added detailed docstring with concurrency notes, persistence semantics, and examples
  - Updated `CLAUDE.md` with factory pattern guidance
  - Added changelog fragment explaining the feature and use cases

## Implementation Details

The `build` method leverages the existing `atomic_write` infrastructure rather than duplicating transaction plumbing, so it automatically inherits:
- Cross-database guard (`CrossDatabaseError`)
- Same-instance re-entrancy protection
- Dirty-state warning suppression

When called with a block, the duplicate check is best-effort (TOCTOU): the `exists?` read and subsequent `atomic_write` are separate operations with no `WATCH` between them. This is noted in the docstring with a reference to issue #288 for future composing of `WATCH` into the block path. Without a block, `save_if_not_exists!` provides race-safe duplicate detection via `WATCH + MULTI/EXEC`.

Resolves #279.

https://claude.ai/code/session_018hXRGw7t7cBqJivABAmc5N