### PR TITLE
Clarify clear_dirty! dedup-window reset comment (no behavior change)

### DIFF
--- a/lib/familia/horreum/dirty_tracking.rb
+++ b/lib/familia/horreum/dirty_tracking.rb
@@ -109,8 +109,11 @@ module Familia
         else
           field_names.each { |f| @dirty_fields.delete(f.to_sym) }
         end
-        # The dirty set just changed (full or partial clear); reset the dedup
-        # window so future signatures warn at least once. See record_dirty_warning!.
+        # Reset the dedup window on every clear_dirty! call. After a real clear
+        # the dirty set has changed, so previously-warned signatures are stale.
+        # On a no-op clear (a field name that was never dirty) the window still
+        # resets, which at worst re-warns one already-seen signature -- harmless,
+        # and not worth a branch to avoid. See record_dirty_warning!.
         @warned_dirty_signatures&.clear
       end
 


### PR DESCRIPTION
## Summary

Follow-up to review feedback on #287. **Comment-only change — no behavior change.**

The `clear_dirty!` comment claimed:

> The dirty set just changed (full or partial clear); reset the dedup window...

That invariant only holds when a deletion actually occurred. `clear_dirty!` resets the dedup window (`@warned_dirty_signatures`) **unconditionally**, so calling it with a field name that was never dirty also resets the window — the comment over-claimed, which is what the reviewer flagged. This reword states the behavior honestly and documents why the unconditional reset is intentional: on a no-op clear it re-warns at most one already-seen signature, which is harmless and not worth an extra branch to avoid.

```ruby
# Reset the dedup window on every clear_dirty! call. After a real clear
# the dirty set has changed, so previously-warned signatures are stale.
# On a no-op clear (a field name that was never dirty) the window still
# resets, which at worst re-warns one already-seen signature -- harmless,
# and not worth a branch to avoid. See record_dirty_warning!.
@warned_dirty_signatures&.clear
```

## Why not change the behavior instead?

The behavioral "fix" (reset only when a field was actually removed) was considered and deliberately **not** done:

- **No real impact:** no internal Familia call site passes a non-dirty field to `clear_dirty!`, and the worst case is one extra warning — never a missed one, never data.
- **It adds complexity and a footgun:** the obvious guard (counting `Concurrent::Map#delete` return values) is subtly wrong — `@dirty_fields` stores *old values* that can be `false`, so deleting a genuinely-dirty field can return a falsy value and be undercounted. A correct version needs a `key?` presence check — i.e. more code to avoid a non-problem.
- **Spec alignment:** the unconditional reset matches issue #277's acceptance criterion, "`clear_dirty!` (full or partial) resets the dedup window."

So the only genuine debt was the misleading comment; this PR fixes exactly that. No changelog fragment (internal comment, not a user-facing or API change).

## Test plan

- Comment-only; `ruby -c` clean.
- `bundle exec try try/features/dirty_tracking_try.rb try/features/dirty_write_warnings_try.rb` → 122 passing.

https://claude.ai/code/session_01DaPijWb8wNoa5A6U6c8KTh

---
_Generated by [Claude Code](https://claude.ai/code/session_01DaPijWb8wNoa5A6U6c8KTh)_