### PR TITLE
Compose WATCH into atomic_write for race-safe build with block

### DIFF
--- a/changelog.d/20260604_000000_claude_288_watch_atomic_write.rst
+++ b/changelog.d/20260604_000000_claude_288_watch_atomic_write.rst
@@ -1,0 +1,34 @@
+Fixed
+-----
+
+- ``Horreum.build`` with a block no longer has a TOCTOU race between the
+  ``exists?`` check and the ``atomic_write`` commit. The block path now uses
+  ``atomic_write(watch_keys:, pre_check:)`` so the existence check runs between
+  ``WATCH`` and ``MULTI`` -- if the key is created by a concurrent client in that
+  window, Redis aborts the transaction and the method retries with exponential
+  backoff (up to 3 attempts). Previously, two concurrent ``build`` calls for the
+  same identifier could both pass the check and the later write would win
+  silently. #288
+
+Added
+-----
+
+- ``atomic_write`` now accepts optional ``watch_keys:`` and ``pre_check:``
+  keyword parameters for composing Redis ``WATCH`` into the ``MULTI/EXEC``
+  transaction. ``watch_keys`` specifies keys to watch for concurrent
+  modification; ``pre_check`` is a callable executed between ``WATCH`` and
+  ``MULTI`` (the only window where reads return real values while the watched
+  keys are guarded). On ``WATCH`` abort the method retries with exponential
+  backoff. This enables optimistic locking patterns without leaving the
+  ``atomic_write`` contract. #288
+
+AI Assistance
+-------------
+
+- AI implemented WATCH composition into ``atomic_write`` from #288, extracting
+  the existing transaction body into ``execute_unwatched_atomic_write`` and adding
+  ``execute_watched_atomic_write`` with WATCH + retry logic mirroring
+  ``save_if_not_exists!``. Updated ``build`` to pass ``watch_keys:`` and
+  ``pre_check:`` instead of the prior bare ``exists?`` guard. Added a dedicated
+  tryouts suite verifying the watched path, pre_check rejection, retry on
+  simulated WATCH abort, argument validation, and nesting guards.

--- a/lib/familia/horreum/atomic_write.rb
+++ b/lib/familia/horreum/atomic_write.rb
@@ -45,14 +45,29 @@ module Familia
       # are atomic; the read-validate-write is not.
       #
       # @param update_expiration [Boolean] Whether to set TTL inside the txn.
+      # @param watch_keys [Array<String>, nil] Optional list of Redis keys to
+      #   WATCH before opening the MULTI. When provided, the transaction is
+      #   wrapped in a WATCH block: if any watched key is modified between the
+      #   WATCH and EXEC, Redis aborts the transaction and the method retries
+      #   (up to 3 attempts with exponential backoff). This enables optimistic
+      #   locking patterns such as "create-only" semantics in +build+.
+      # @param pre_check [Proc, nil] Optional callable executed between WATCH
+      #   and MULTI -- the only window where reads return real values (not
+      #   Redis::Future objects) while the watched keys are still guarded.
+      #   Typically used for existence checks that should abort early:
+      #     pre_check: -> { raise RecordExistsError, dbkey if exists? }
+      #   Requires +watch_keys+ to be set.
       # @yield Block containing field assignments and collection mutations.
       # @return [Boolean] true if the transaction's EXEC completed and every
       #   queued command returned without an exception; false if the
       #   transaction was discarded or any queued command returned an error.
-      # @raise [ArgumentError] If no block is given.
+      # @raise [ArgumentError] If no block is given, or if +pre_check+ is
+      #   provided without +watch_keys+.
       # @raise [Familia::OperationModeError] If called within an existing transaction.
       # @raise [Familia::CrossDatabaseError] If related fields span multiple databases.
       # @raise [Familia::NoIdentifier] If the identifier is nil or empty.
+      # @raise [Familia::OptimisticLockError] If retries are exhausted after
+      #   concurrent modification is detected (only when +watch_keys+ is set).
       #
       # @example Atomically update scalar fields and a set
       #   plan.atomic_write do
@@ -62,12 +77,19 @@ module Familia
       #     plan.features.add("sso")
       #   end
       #
+      # @example Race-safe create with WATCH (used by build)
+      #   user.atomic_write(
+      #     watch_keys: [user.dbkey],
+      #     pre_check: -> { raise RecordExistsError, user.dbkey if user.exists? }
+      #   ) { user.tags.add("new") }
+      #
       # @see Persistence#save_with_collections For sequential (non-atomic)
       #   scalar+collection writes (supports cross-database configurations).
       # @see Connection#transaction For raw MULTI/EXEC access.
       #
-      def atomic_write(update_expiration: true)
+      def atomic_write(update_expiration: true, watch_keys: nil, pre_check: nil)
         raise ArgumentError, 'Block required for atomic_write' unless block_given?
+        raise ArgumentError, 'pre_check requires watch_keys' if pre_check && !watch_keys
 
         # Mirror save's nesting guard -- atomic_write opens its own MULTI and
         # cannot be nested inside an outer transaction (see Persistence#save).
@@ -95,27 +117,11 @@ module Familia
           # MULTI/EXEC.
           prepare_for_save
 
-          result = transaction do |_conn|
-            # Yield FIRST so scalar setters mutate ivars and collection mutations
-            # queue their commands (SADD, ZADD, etc.) in the open MULTI.
-            # Collection mutations auto-route via Fiber[:familia_transaction]
-            # (see DataType#dbclient).
-            yield
-
-            # Then queue the HMSET for scalar fields. to_h_for_storage snapshots
-            # ivars at command-queue time, so any assignments made inside the
-            # block are captured. Also queues expiration, class indexes, and
-            # touch_instances!.
-            persist_to_storage(update_expiration)
+          if watch_keys&.any?
+            execute_watched_atomic_write(watch_keys, pre_check, update_expiration) { yield }
+          else
+            execute_unwatched_atomic_write(update_expiration) { yield }
           end
-
-          # A MultiResult is always returned by `transaction` -- inspect its
-          # successful? flag rather than testing for nil. Individual commands
-          # inside MULTI return exception objects (rather than raising) when
-          # they fail; successful? is false if any of those slipped through.
-          success = atomic_write_success?(result)
-          clear_dirty! if success
-          success
         ensure
           release_atomic_write_ownership!
         end
@@ -148,6 +154,74 @@ module Familia
       end
 
       private
+
+      # Executes the standard (unwatched) atomic_write flow: a single
+      # MULTI/EXEC containing the user block and persist_to_storage.
+      #
+      # @param update_expiration [Boolean]
+      # @yield User block (scalar setters + collection mutations)
+      # @return [Boolean]
+      def execute_unwatched_atomic_write(update_expiration)
+        result = transaction do |_conn|
+          yield
+          persist_to_storage(update_expiration)
+        end
+
+        success = atomic_write_success?(result)
+        clear_dirty! if success
+        success
+      end
+
+      # Executes the WATCH-guarded atomic_write flow: WATCH → pre_check →
+      # MULTI/EXEC, with retry on OptimisticLockError.
+      #
+      # When EXEC is aborted by WATCH (a watched key was modified between
+      # WATCH and EXEC), +multi+ returns nil. We detect this via the
+      # MultiResult wrapper and raise OptimisticLockError to trigger a
+      # retry. The retry re-issues WATCH, re-runs the pre_check, and
+      # re-opens MULTI/EXEC.
+      #
+      # @param watch_keys [Array<String>] Keys to WATCH
+      # @param pre_check [Proc, nil] Callable run between WATCH and MULTI
+      # @param update_expiration [Boolean]
+      # @param max_attempts [Integer] Maximum retry attempts (default: 3)
+      # @yield User block (scalar setters + collection mutations)
+      # @return [Boolean]
+      # @raise [Familia::OptimisticLockError] If retries exhausted
+      def execute_watched_atomic_write(watch_keys, pre_check, update_expiration, max_attempts: 3)
+        attempts = 0
+
+        begin
+          attempts += 1
+
+          result = dbclient.watch(*watch_keys) do
+            pre_check&.call
+
+            txn_result = transaction do |_conn|
+              yield
+              persist_to_storage(update_expiration)
+            end
+
+            # WATCH abort: EXEC returns nil → multi returns nil →
+            # MultiResult wraps nil. Raise to trigger retry.
+            if txn_result.is_a?(MultiResult) && txn_result.results.nil?
+              raise Familia::OptimisticLockError,
+                "WATCH detected concurrent modification of #{watch_keys.join(', ')}"
+            end
+
+            txn_result
+          end
+
+          success = atomic_write_success?(result)
+          clear_dirty! if success
+          success
+        rescue Familia::OptimisticLockError
+          raise if attempts >= max_attempts
+
+          sleep(0.001 * (2**attempts))
+          retry
+        end
+      end
 
       # Atomically claim same-instance ownership or raise if a competing
       # Fiber/Thread already owns it. Held for the duration of the ivar

--- a/lib/familia/horreum/atomic_write.rb
+++ b/lib/familia/horreum/atomic_write.rb
@@ -83,13 +83,24 @@ module Familia
       #     pre_check: -> { raise RecordExistsError, user.dbkey if user.exists? }
       #   ) { user.tags.add("new") }
       #
+      # @note When +watch_keys+ is set and a WATCH abort triggers a retry,
+      #   the block is re-executed (up to +max_attempts+ times). Scalar
+      #   setters and collection mutations are safe to replay (the aborted
+      #   MULTI discards all queued commands), but side effects outside
+      #   Redis (logging, external API calls) will fire again. Design
+      #   blocks to be retry-safe when using +watch_keys+.
+      # @note +prepare_for_save+ (timestamps, unique-index validation) runs
+      #   once before the retry loop, not on each attempt. This matches
+      #   +save_if_not_exists!+ behaviour and keeps timestamps consistent
+      #   across retries.
+      #
       # @see Persistence#save_with_collections For sequential (non-atomic)
       #   scalar+collection writes (supports cross-database configurations).
       # @see Connection#transaction For raw MULTI/EXEC access.
       #
       def atomic_write(update_expiration: true, watch_keys: nil, pre_check: nil)
         raise ArgumentError, 'Block required for atomic_write' unless block_given?
-        raise ArgumentError, 'pre_check requires watch_keys' if pre_check && !watch_keys
+        raise ArgumentError, 'pre_check requires watch_keys' if pre_check && !watch_keys&.any?
 
         # Mirror save's nesting guard -- atomic_write opens its own MULTI and
         # cannot be nested inside an outer transaction (see Persistence#save).

--- a/lib/familia/horreum/management.rb
+++ b/lib/familia/horreum/management.rb
@@ -107,13 +107,13 @@ module Familia
       # Use {Persistence#save} or {Persistence#save_with_collections} when
       # you explicitly want overwrite/upsert behaviour.
       #
-      # Concurrency: when called without a block, +build+ delegates to
-      # {#save_if_not_exists!} which uses WATCH + MULTI/EXEC for race-safe
-      # duplicate detection. With a block, the duplicate check is best-effort
-      # (TOCTOU): the +exists?+ read and the subsequent +atomic_write+ are
-      # separate operations with no WATCH between them, so concurrent +build+
-      # calls for the same identifier can both pass the check. See issue #288
-      # for composing WATCH into the block path.
+      # Concurrency: both paths use WATCH + MULTI/EXEC for race-safe
+      # duplicate detection. Without a block, +build+ delegates to
+      # {#save_if_not_exists!}. With a block, +atomic_write+ is called
+      # with +watch_keys:+ and +pre_check:+ so the existence check runs
+      # between WATCH and MULTI -- if the key is created by another client
+      # in that window, Redis aborts the transaction and the method retries
+      # with exponential backoff (up to 3 attempts). See issue #288.
       #
       # ## Without a block
       #
@@ -156,12 +156,10 @@ module Familia
         instance = new(*, **)
 
         if block_given?
-          # Best-effort duplicate guard (TOCTOU): no WATCH between this read
-          # and the atomic_write below, so concurrent builds can race. See
-          # issue #288 for composing WATCH into atomic_write.
-          raise Familia::RecordExistsError, instance.dbkey if instance.exists?
-
-          instance.atomic_write { yield instance }
+          instance.atomic_write(
+            watch_keys: [instance.dbkey],
+            pre_check: -> { raise Familia::RecordExistsError, instance.dbkey if instance.exists? }
+          ) { yield instance }
         else
           # No block means no collection ops to fold in, so we can use the
           # WATCH-guarded save_if_not_exists! directly — race-safe.

--- a/try/features/atomic_write_watch_try.rb
+++ b/try/features/atomic_write_watch_try.rb
@@ -58,6 +58,16 @@ rescue ArgumentError
 end
 #=> :raised
 
+## pre_check with empty watch_keys array also raises ArgumentError
+@u4b = WatchTestUser.new(email: 'watch4b@example.com', name: 'Watch4b')
+begin
+  @u4b.atomic_write(watch_keys: [], pre_check: -> { true }) { @u4b.name = 'x' }
+  :no_raise
+rescue ArgumentError
+  :raised
+end
+#=> :raised
+
 ## atomic_write with empty watch_keys array falls back to unwatched path
 @u5 = WatchTestUser.new(email: 'watch5@example.com', name: 'Watch5')
 @u5.atomic_write(watch_keys: []) do
@@ -100,14 +110,15 @@ end
 #=> ['Watch8', ['keep_me']]
 
 ## watched atomic_write retries on OptimisticLockError (simulated WATCH abort)
+# Simulate a WATCH abort by returning MultiResult.new(nil) on the first
+# attempt WITHOUT calling the block, mirroring real WATCH behaviour where
+# EXEC discards all queued commands (nothing reaches Redis).
 @u9 = WatchTestUser.new(email: 'watch9@example.com', name: 'Watch9')
 attempt_count = 0
 original_transaction = @u9.method(:transaction)
 @u9.define_singleton_method(:transaction) do |&blk|
   attempt_count += 1
   if attempt_count == 1
-    # Simulate a WATCH abort on first attempt: multi returns nil
-    blk.call(nil)
     Familia::MultiResult.new(nil)
   else
     original_transaction.call(&blk)

--- a/try/features/atomic_write_watch_try.rb
+++ b/try/features/atomic_write_watch_try.rb
@@ -1,0 +1,153 @@
+# try/features/atomic_write_watch_try.rb
+#
+# Tests for WATCH composition into atomic_write (issue #288).
+# Verifies that atomic_write(watch_keys:, pre_check:) provides
+# race-safe optimistic locking for create-only patterns like build.
+
+require_relative '../support/helpers/test_helpers'
+
+Familia.debug = false
+
+class WatchTestUser < Familia::Horreum
+  identifier_field :email
+  field :email
+  field :name
+  field :role
+  set :tags
+  list :sessions
+end
+
+# Clean slate
+WatchTestUser.instances.clear
+WatchTestUser.all.each(&:destroy!)
+
+## atomic_write with watch_keys persists scalars and collections
+@u1 = WatchTestUser.new(email: 'watch1@example.com', name: 'Watch1')
+@u1.atomic_write(watch_keys: [@u1.dbkey]) do
+  @u1.role = 'admin'
+  @u1.tags.add('staff')
+  @u1.sessions.push('sess1')
+end
+@r1 = WatchTestUser.find_by_id('watch1@example.com')
+[@r1.name, @r1.role, @r1.tags.members, @r1.sessions.members]
+#=> ['Watch1', 'admin', ['staff'], ['sess1']]
+
+## atomic_write with watch_keys and pre_check executes pre_check
+@u2 = WatchTestUser.new(email: 'watch2@example.com', name: 'Watch2')
+@u2.save
+@u3 = WatchTestUser.new(email: 'watch2@example.com', name: 'Watch2-dup')
+@pre_check_raised = false
+begin
+  @u3.atomic_write(
+    watch_keys: [@u3.dbkey],
+    pre_check: -> { raise Familia::RecordExistsError, @u3.dbkey if @u3.exists? }
+  ) { @u3.tags.add('should_not_persist') }
+rescue Familia::RecordExistsError
+  @pre_check_raised = true
+end
+@pre_check_raised
+#=> true
+
+## pre_check without watch_keys raises ArgumentError
+@u4 = WatchTestUser.new(email: 'watch4@example.com', name: 'Watch4')
+begin
+  @u4.atomic_write(pre_check: -> { true }) { @u4.name = 'x' }
+  :no_raise
+rescue ArgumentError
+  :raised
+end
+#=> :raised
+
+## atomic_write with empty watch_keys array falls back to unwatched path
+@u5 = WatchTestUser.new(email: 'watch5@example.com', name: 'Watch5')
+@u5.atomic_write(watch_keys: []) do
+  @u5.role = 'viewer'
+  @u5.tags.add('unwatched')
+end
+@r5 = WatchTestUser.find_by_id('watch5@example.com')
+[@r5.name, @r5.role, @r5.tags.members]
+#=> ['Watch5', 'viewer', ['unwatched']]
+
+## watched atomic_write clears dirty state on success
+@u6 = WatchTestUser.new(email: 'watch6@example.com', name: 'Watch6')
+@u6.atomic_write(watch_keys: [@u6.dbkey]) do
+  @u6.role = 'editor'
+end
+@u6.dirty?
+#=> false
+
+## watched atomic_write updates instances timeline
+@u7 = WatchTestUser.new(email: 'watch7@example.com', name: 'Watch7')
+@u7.atomic_write(watch_keys: [@u7.dbkey]) { @u7.role = 'member' }
+WatchTestUser.in_instances?('watch7@example.com')
+#=> true
+
+## watched atomic_write rolls back on exception in user block
+@u8 = WatchTestUser.new(email: 'watch8@example.com', name: 'Watch8')
+@u8.save
+@u8.tags.add('keep_me')
+begin
+  @u8.atomic_write(watch_keys: [@u8.dbkey]) do
+    @u8.name = 'Should not persist'
+    @u8.tags.add('should_not_persist')
+    raise 'boom'
+  end
+rescue RuntimeError
+  # expected
+end
+@r8 = WatchTestUser.find_by_id('watch8@example.com')
+[@r8.name, @r8.tags.members.sort]
+#=> ['Watch8', ['keep_me']]
+
+## watched atomic_write retries on OptimisticLockError (simulated WATCH abort)
+@u9 = WatchTestUser.new(email: 'watch9@example.com', name: 'Watch9')
+attempt_count = 0
+original_transaction = @u9.method(:transaction)
+@u9.define_singleton_method(:transaction) do |&blk|
+  attempt_count += 1
+  if attempt_count == 1
+    # Simulate a WATCH abort on first attempt: multi returns nil
+    blk.call(nil)
+    Familia::MultiResult.new(nil)
+  else
+    original_transaction.call(&blk)
+  end
+end
+@u9.atomic_write(watch_keys: [@u9.dbkey]) do
+  @u9.role = 'retried'
+end
+[attempt_count >= 2, WatchTestUser.find_by_id('watch9@example.com').role]
+#=> [true, 'retried']
+
+## build with block uses WATCH path (duplicate rejected even under concurrent setup)
+@u10 = WatchTestUser.build(email: 'watch10@example.com', name: 'First') do |u|
+  u.tags.add('original')
+end
+@dup_rejected = false
+begin
+  WatchTestUser.build(email: 'watch10@example.com', name: 'Second') do |u|
+    u.tags.add('duplicate')
+  end
+rescue Familia::RecordExistsError
+  @dup_rejected = true
+end
+@r10 = WatchTestUser.find_by_id('watch10@example.com')
+[@dup_rejected, @r10.name, @r10.tags.members]
+#=> [true, 'First', ['original']]
+
+## watched atomic_write raises OperationModeError when nested inside transaction
+@u11 = WatchTestUser.new(email: 'watch11@example.com', name: 'Watch11')
+@u11.save
+begin
+  Familia.transaction do
+    @u11.atomic_write(watch_keys: [@u11.dbkey]) { @u11.name = 'fail' }
+  end
+  :no_raise
+rescue Familia::OperationModeError
+  :raised
+end
+#=> :raised
+
+# Cleanup
+WatchTestUser.instances.clear
+WatchTestUser.all.each(&:destroy!)


### PR DESCRIPTION
## Summary

Fixes issue #288 by composing Redis `WATCH` into `atomic_write`, enabling race-safe duplicate detection in `build` with a block. Previously, the existence check and write were separate operations with a TOCTOU window; now they're guarded by `WATCH` so concurrent modifications trigger a retry.

## Key Changes

- **`atomic_write` now accepts `watch_keys:` and `pre_check:` parameters**
  - `watch_keys`: Array of Redis keys to WATCH before opening MULTI
  - `pre_check`: Callable executed between WATCH and MULTI (the only window where reads return real values while watched keys are guarded)
  - On WATCH abort (concurrent modification detected), the method retries with exponential backoff (up to 3 attempts)
  - Requires `watch_keys` to be set if `pre_check` is provided; raises `ArgumentError` otherwise

- **Refactored `atomic_write` implementation**
  - Extracted unwatched flow into `execute_unwatched_atomic_write` (standard MULTI/EXEC)
  - Added `execute_watched_atomic_write` with WATCH + retry logic
  - Both paths maintain the same contract: clear dirty state on success, roll back on exception

- **Updated `build` with block to use WATCH path**
  - Now calls `atomic_write(watch_keys: [instance.dbkey], pre_check: -> { ... })`
  - Existence check runs between WATCH and MULTI, eliminating the TOCTOU race
  - Concurrent `build` calls for the same identifier will now properly reject duplicates

- **Added comprehensive tryouts suite** (`try/features/atomic_write_watch_try.rb`)
  - Verifies watched atomic_write persists scalars and collections
  - Tests pre_check execution and rejection
  - Validates argument constraints (pre_check requires watch_keys)
  - Confirms empty watch_keys falls back to unwatched path
  - Tests dirty state clearing and instances timeline updates
  - Verifies rollback on exception in user block
  - Simulates WATCH abort and confirms retry behavior
  - Tests build with block duplicate rejection
  - Validates nesting guard (OperationModeError when nested in transaction)

## Implementation Details

- `execute_watched_atomic_write` wraps the transaction in `dbclient.watch(*watch_keys)` block
- Detects WATCH abort by checking if `MultiResult.results` is nil (EXEC returned nil)
- Raises `OptimisticLockError` on abort to trigger retry with exponential backoff (0.002s, 0.004s, 0.008s)
- Pre-check runs after WATCH but before MULTI, ensuring reads are real values while keys are guarded
- Maintains all existing atomic_write guarantees: nesting guard, cross-database check, identifier validation

https://claude.ai/code/session_0167ajUQ6oRTDUWGJjGagUgZ