### PR TITLE
Add cross-model atomic_write and fix WATCH optimistic lock

### DIFF
--- a/changelog.d/20260605_215849_claude_epic_brahmagupta_05mM6.rst
+++ b/changelog.d/20260605_215849_claude_epic_brahmagupta_05mM6.rst
@@ -1,0 +1,21 @@
+Fixed
+-----
+
+- The ``WATCH``-based optimistic lock used by ``atomic_write(watch_keys:)``,
+  ``save_if_not_exists!``, and therefore ``build``/``create!`` was **inert** in
+  the default connection configuration: ``WATCH`` was sent on one connection
+  while the ``MULTI/EXEC`` opened on another, so a concurrent modification of a
+  watched key never aborted the write and could be silently overwritten. The
+  ``WATCH`` and the ``MULTI`` are now driven through a single resolved
+  connection, so the optimistic lock aborts on concurrent modification as
+  documented. #296
+
+AI Assistance
+-------------
+
+- Root-caused and fixed with Claude Code: identified the split-connection
+  defect, designed the shared single-connection ``execute_watched_transaction``
+  primitive (deliberately avoiding a fiber-pinning approach that would have
+  silently degraded ``MULTI/EXEC`` to non-atomic individual commands), and
+  replaced the previous *simulated* abort test with real concurrent-modification
+  tests proven to fail on the old code and pass after the fix. #296

--- a/changelog.d/20260605_215850_claude_epic_brahmagupta_05mM6.rst
+++ b/changelog.d/20260605_215850_claude_epic_brahmagupta_05mM6.rst
@@ -1,0 +1,18 @@
+Added
+-----
+
+- ``Familia.atomic_write(*instances)`` persists multiple Horreum instances in a
+  single ``MULTI/EXEC``, with an optional ``watch_keys:``/``pre_check:``
+  create-only variant for race-safe "create A and B together" semantics. All
+  participating instances (and their related fields) must resolve to one logical
+  database, raising ``Familia::CrossDatabaseError`` otherwise; on Redis Cluster
+  the keys must additionally share a hash slot (co-locate with hash tags). #296
+
+AI Assistance
+-------------
+
+- Designed and implemented with Claude Code on top of the single-connection
+  ``WATCH`` primitive: the all-roots same-database guard, the
+  prepare-outside / persist-inside orchestration, and the test suite covering
+  atomic two-model commit (invisible mid-transaction), rollback on error,
+  cross-database rejection, the nesting guard, and a real create-only race. #296

--- a/docs/migrating/v2.10.0.md
+++ b/docs/migrating/v2.10.0.md
@@ -131,6 +131,75 @@ end
 
 The `pre_check` callable runs between `WATCH` and `MULTI`. On `WATCH` abort, the method retries with exponential backoff.
 
+### Cross-model `atomic_write`
+
+The module-level `Familia.atomic_write(*instances, ...)` persists several
+(possibly different-class) Horreum instances in a **single** `MULTI/EXEC`. Once
+the `MULTI` opens, every instance's `dbclient` resolves to the same transaction
+connection, so each model's `HMSET`/`EXPIRE`/index `HSET`/instances `ZADD` queue
+together and commit atomically:
+
+```ruby
+Familia.atomic_write(customer, org) do
+  org.owner_id = customer.identifier
+  customer.orgs.add(org.identifier)
+end
+# customer's HMSET + org's HMSET + both collections' writes
+# all land in ONE MULTI/EXEC
+```
+
+The optional block runs **inside** the transaction, before each instance is
+persisted — the place to wire cross-references between instances and mutate
+collections. Read-validate (`prepare_for_save`: timestamps + unique-index reads)
+runs **outside** the `MULTI`; only the writes are atomic. The method returns
+`true` on a clean commit and clears each instance's dirty state; on rollback it
+returns `false` (or propagates the raised exception) and leaves dirty state
+intact on every instance.
+
+**Constraint: all instances must share one logical database.** `MULTI/EXEC` is
+valid only within a single logical database, so the transaction is anchored on
+`instances.first.dbclient` and a pre-flight guard rejects any set of roots (or
+their related fields) that span databases:
+
+```ruby
+class Account < Familia::Horreum; logical_database 0; end
+class AuditEntry < Familia::Horreum; logical_database 5; end
+
+Familia.atomic_write(account, audit_entry) { ... }
+# raises Familia::CrossDatabaseError before any write —
+# MULTI/EXEC cannot cross logical databases
+```
+
+For configurations that genuinely span databases, persist each model
+separately (e.g. with `save_with_collections`).
+
+#### Race-safe create-only across models
+
+Combine `watch_keys:` with a `pre_check:` that rejects existing keys to get
+create-only semantics spanning multiple models:
+
+```ruby
+Familia.atomic_write(customer, org,
+  watch_keys: [customer.dbkey, org.dbkey],
+  pre_check: -> {
+    [customer, org].each { |r| raise Familia::RecordExistsError, r.dbkey if r.exists? }
+  }
+) do
+  customer.name = 'Acme Owner'
+  org.owner_id = customer.identifier
+end
+```
+
+A concurrent creation of **either** key during the `WATCH` window aborts the
+whole `MULTI` and retries; on retry the existence check raises
+`RecordExistsError` — no silent overwrite. If the watched keys keep changing and
+retries are exhausted, `Familia::OptimisticLockError` is raised instead.
+
+> **Redis Cluster note:** a cross-model `MULTI` additionally requires the watched
+> and written keys to share a hash slot, otherwise the server returns a
+> `CROSSSLOT` error. Co-locate related models with hash tags so they route to one
+> slot, e.g. `customer:{acct42}:object` and `org:{acct42}:object`.
+
 ### Per-class dirty-write warning controls
 
 ```ruby

--- a/lib/familia/connection/operations.rb
+++ b/lib/familia/connection/operations.rb
@@ -232,9 +232,16 @@ module Familia
                 Familia::Connection::TransactionCore.execute_normal_transaction(-> { conn }) { persist_all.call }
               end
             else
-              Familia::Connection::TransactionCore.execute_normal_transaction(
-                -> { instances.first.dbclient }
-              ) { persist_all.call }
+              # Route the non-watched path through the instance #transaction so it
+              # inherits execute_transaction's handler-compatibility gate: a
+              # connection whose handler disallows transactions falls back per
+              # Familia.transaction_mode (raise/warn/individual) instead of
+              # issuing a raw MULTI on an unsupported connection. (The watched
+              # branch above must call execute_normal_transaction directly to
+              # reuse the WATCH-resolved connection; this branch has no such
+              # constraint.) Anchored on instances.first -- the guard ensures all
+              # roots share one logical database, so it routes every instance.
+              instances.first.transaction { persist_all.call }
             end
 
           success = result.is_a?(Familia::MultiResult) ? result.successful? : !result.nil?

--- a/lib/familia/connection/operations.rb
+++ b/lib/familia/connection/operations.rb
@@ -183,6 +183,13 @@ module Familia
       #   written keys to share a hash slot (CROSSSLOT error otherwise).
       #   Co-locate related models with hash tags, e.g. +customer:{acct42}:object+.
       #
+      # @note When +watch_keys+ is set and a WATCH abort triggers a retry, the
+      #   user block AND each +persist_to_storage+ are re-executed on every
+      #   attempt. The aborted MULTI discards all queued Redis commands, so Redis
+      #   state is clean on retry, but side effects outside Redis (logging,
+      #   counters, external API calls) in the user block fire again -- design
+      #   retry-safe blocks when using +watch_keys+.
+      #
       # @see Familia::Horreum::AtomicWrite#atomic_write Single-instance variant.
       #
       def atomic_write(*instances, update_expiration: true, watch_keys: nil, pre_check: nil, &user_block)
@@ -195,30 +202,47 @@ module Familia
 
         guard_cross_model_database!(instances)        # all roots + their related fields share ONE logical db
 
-        instances.each { |i| i.send(:prepare_for_save) }   # READS — outside the txn
-
-        persist_all = lambda do
-          user_block&.call
-          instances.each { |i| i.send(:persist_to_storage, update_expiration) }
-        end
-
-        result =
-          if watch_keys&.any?
-            Familia::Connection::TransactionCore.execute_watched_transaction(
-              -> { instances.first.dbclient }, watch_keys: watch_keys
-            ) do |conn|
-              pre_check&.call
-              Familia::Connection::TransactionCore.execute_normal_transaction(-> { conn }) { persist_all.call }
-            end
-          else
-            Familia::Connection::TransactionCore.execute_normal_transaction(
-              -> { instances.first.dbclient }
-            ) { persist_all.call }
+        # Activate atomic_write mode on every instance BEFORE prepare_for_save so
+        # that collection mutations in the user block do not trip dirty-write
+        # warnings -- or, under :strict / raise_on_unsaved_parent_write, raises --
+        # against the just-dirtied scalars. Those scalars are persisted by this
+        # same MULTI, so the writes are legitimate. Mirrors the instance-level
+        # atomic_write (which acquires ownership before prepare_for_save). Only the
+        # instances actually acquired are released, in the ensure below.
+        acquired = []
+        begin
+          instances.each do |i|
+            i.send(:acquire_atomic_write_ownership!)
+            acquired << i
           end
 
-        success = result.is_a?(Familia::MultiResult) ? result.successful? : !result.nil?
-        instances.each { |i| i.send(:clear_dirty!) } if success
-        success
+          instances.each { |i| i.send(:prepare_for_save) }   # READS — outside the txn
+
+          persist_all = lambda do
+            user_block&.call
+            instances.each { |i| i.send(:persist_to_storage, update_expiration) }
+          end
+
+          result =
+            if watch_keys&.any?
+              Familia::Connection::TransactionCore.execute_watched_transaction(
+                -> { instances.first.dbclient }, watch_keys: watch_keys
+              ) do |conn|
+                pre_check&.call
+                Familia::Connection::TransactionCore.execute_normal_transaction(-> { conn }) { persist_all.call }
+              end
+            else
+              Familia::Connection::TransactionCore.execute_normal_transaction(
+                -> { instances.first.dbclient }
+              ) { persist_all.call }
+            end
+
+          success = result.is_a?(Familia::MultiResult) ? result.successful? : !result.nil?
+          instances.each { |i| i.send(:clear_dirty!) } if success
+          success
+        ensure
+          acquired.each { |i| i.send(:release_atomic_write_ownership!) }
+        end
       end
 
       # Executes Database commands in a pipeline for improved performance.

--- a/lib/familia/connection/operations.rb
+++ b/lib/familia/connection/operations.rb
@@ -101,6 +101,126 @@ module Familia
       end
       alias multi transaction
 
+      # Persists multiple Horreum instances in a SINGLE MULTI/EXEC transaction.
+      #
+      # This is the cross-model / multi-instance counterpart to
+      # {Familia::Horreum::AtomicWrite#atomic_write}. Where the instance method
+      # composes one object's scalar HMSET and collection mutations into one
+      # transaction, this module-level method folds the persistence of several
+      # (possibly different-class) instances into one atomic MULTI/EXEC.
+      #
+      # ## Why this works
+      #
+      # Once a MULTI opens, every instance's +dbclient+ resolves to the same
+      # +Fiber[:familia_transaction]+ connection. So the HMSET, EXPIRE, index
+      # HSET, and instances ZADD for each instance all queue on one socket and
+      # commit together. The transaction is anchored on
+      # +instances.first.dbclient+; because {#guard_cross_model_database!}
+      # enforces that all roots share ONE logical database, every instance
+      # routes to that same connection -- there is no special routing to
+      # engineer, the same-logical-DB requirement IS the constraint.
+      #
+      # ## Read/write split
+      #
+      # The read-validate-write split is the key constraint. +prepare_for_save+
+      # (timestamps + unique-index reads) runs OUTSIDE the transaction because
+      # the reads it performs would return uninspectable +Redis::Future+ objects
+      # inside MULTI/EXEC. Only +persist_to_storage+ (HMSET/EXPIRE/index
+      # HSET/instances ZADD -- write-only) runs INSIDE.
+      #
+      # ## Optimistic locking / create-only
+      #
+      # Pass +watch_keys:+ to wrap the MULTI in a WATCH block, and +pre_check:+
+      # to run a guard between WATCH and MULTI (the only window where reads
+      # return real values while the watched keys are guarded). A concurrent
+      # modification of any watched key aborts EXEC and retries (the committed
+      # primitive owns abort detection + retry). This enables a race-safe
+      # create-only pattern -- see the example below.
+      #
+      # @param instances [Array<Familia::Horreum>] One or more instances to persist.
+      # @param update_expiration [Boolean] Whether to set each instance's TTL
+      #   inside the transaction (default: true).
+      # @param watch_keys [Array<String>, nil] Optional keys to WATCH before
+      #   opening the MULTI. When present, the transaction retries on WATCH abort.
+      # @param pre_check [Proc, nil] Optional callable executed between WATCH and
+      #   MULTI. Requires +watch_keys+. Typically raises to abort early (e.g.
+      #   existence checks for create-only semantics).
+      # @yield Optional user block run inside the transaction BEFORE each
+      #   instance is persisted -- the place to assign cross-references between
+      #   instances (e.g. +org.owner_id = customer.identifier+) and mutate
+      #   collections.
+      # @return [Boolean] true if the MULTI/EXEC committed cleanly; false if the
+      #   transaction was discarded or any queued command returned an error.
+      #
+      # @raise [ArgumentError] If no instances are given, or +pre_check+ is
+      #   provided without +watch_keys+.
+      # @raise [Familia::OperationModeError] If called within an existing transaction.
+      # @raise [Familia::CrossDatabaseError] If the roots (or their related
+      #   fields) span multiple logical databases.
+      # @raise [Familia::OptimisticLockError] If +watch_keys+ retries are exhausted.
+      #
+      # @example Persist two models atomically
+      #   Familia.atomic_write(customer, org) do
+      #     org.owner_id = customer.identifier
+      #     customer.orgs.add(org.identifier)
+      #   end
+      #
+      # @example Race-safe create-only (reject if EITHER key already exists)
+      #   Familia.atomic_write(customer, org,
+      #     watch_keys: [customer.dbkey, org.dbkey],
+      #     pre_check: -> {
+      #       [customer, org].each { |r| raise Familia::RecordExistsError, r.dbkey if r.exists? }
+      #     }
+      #   ) do
+      #     customer.name = 'Acme Owner'
+      #     org.owner_id = customer.identifier
+      #   end
+      #   # A concurrent creation of EITHER key during the WATCH window aborts the
+      #   # whole MULTI and retries; on retry the existence check raises
+      #   # RecordExistsError -- no silent overwrite.
+      #
+      # @note On Redis Cluster, a cross-model MULTI also requires the watched and
+      #   written keys to share a hash slot (CROSSSLOT error otherwise).
+      #   Co-locate related models with hash tags, e.g. +customer:{acct42}:object+.
+      #
+      # @see Familia::Horreum::AtomicWrite#atomic_write Single-instance variant.
+      #
+      def atomic_write(*instances, update_expiration: true, watch_keys: nil, pre_check: nil, &user_block)
+        raise ArgumentError, 'atomic_write requires at least one instance' if instances.empty?
+        raise ArgumentError, 'pre_check requires watch_keys' if pre_check && !watch_keys&.any?
+        if Fiber[:familia_transaction]
+          raise Familia::OperationModeError,
+                'Cannot call Familia.atomic_write within a transaction. It opens its own MULTI/EXEC and cannot be nested.'
+        end
+
+        guard_cross_model_database!(instances)        # all roots + their related fields share ONE logical db
+
+        instances.each { |i| i.send(:prepare_for_save) }   # READS — outside the txn
+
+        persist_all = lambda do
+          user_block&.call
+          instances.each { |i| i.send(:persist_to_storage, update_expiration) }
+        end
+
+        result =
+          if watch_keys&.any?
+            Familia::Connection::TransactionCore.execute_watched_transaction(
+              -> { instances.first.dbclient }, watch_keys: watch_keys
+            ) do |conn|
+              pre_check&.call
+              Familia::Connection::TransactionCore.execute_normal_transaction(-> { conn }) { persist_all.call }
+            end
+          else
+            Familia::Connection::TransactionCore.execute_normal_transaction(
+              -> { instances.first.dbclient }
+            ) { persist_all.call }
+          end
+
+        success = result.is_a?(Familia::MultiResult) ? result.successful? : !result.nil?
+        instances.each { |i| i.send(:clear_dirty!) } if success
+        success
+      end
+
       # Executes Database commands in a pipeline for improved performance.
       #
       # Pipelines send multiple commands without waiting for individual responses,
@@ -274,6 +394,49 @@ module Familia
         ensure
           client&.close
         end
+      end
+
+      private
+
+      # Pre-flight guard for {#atomic_write}: every root instance -- and, by
+      # transitivity, every related field on every root -- must resolve to the
+      # SAME logical database. MULTI/EXEC cannot span databases, so anchoring the
+      # transaction on +instances.first.dbclient+ is only correct when all roots
+      # share that database.
+      #
+      # Two layers of checking:
+      #
+      # 1. Compare each root's resolved logical database (+klass.logical_database+
+      #    falling back to +Familia.logical_database || 0+). If they differ, the
+      #    roots span databases and a synthetic "(root)" {Familia::CrossDatabaseError}
+      #    is raised before any write.
+      #
+      # 2. Reuse each instance's existing per-instance field guard
+      #    (+guard_atomic_write_database!+), which checks that instance's
+      #    +related_fields+ and +class_related_fields+ against its own database.
+      #    Because step 1 proved all instance databases are equal, this
+      #    transitively proves every field across every root shares the one
+      #    database.
+      #
+      # @param instances [Array<Familia::Horreum>]
+      # @raise [Familia::CrossDatabaseError] if roots span databases, or any
+      #   instance has a related field on a different database.
+      # @return [void]
+      #
+      def guard_cross_model_database!(instances)
+        dbs = instances.map { |i| i.class.logical_database || Familia.logical_database || 0 }
+        unless dbs.uniq.size == 1
+          # roots span databases — MULTI/EXEC cannot cross databases
+          offender_idx = dbs.index { |d| d != dbs.first }
+          offender = instances[offender_idx]
+          raise Familia::CrossDatabaseError.new(
+            "#{offender.class} (root)", dbs[offender_idx], dbs.first
+          )
+        end
+        # Reuse each instance's existing per-instance field guard (related_fields +
+        # class_related_fields vs that instance's own db). Since all instance dbs are
+        # equal, this transitively proves every field shares the one db.
+        instances.each { |i| i.send(:guard_atomic_write_database!) }
       end
     end
   end

--- a/lib/familia/connection/transaction_core.rb
+++ b/lib/familia/connection/transaction_core.rb
@@ -169,6 +169,38 @@ module Familia
         # Return same MultiResult format as other methods
         MultiResult.new(command_return_values)
       end
+
+      # Runs a WATCH-guarded transaction on a SINGLE resolved connection so the
+      # WATCH and the MULTI/EXEC share one socket (the optimistic lock is only
+      # effective this way). The caller's block receives the resolved connection
+      # and is expected to run any pre-check reads and then open the MULTI via
+      # execute_normal_transaction(-> { conn }) { ... }. Retries on WATCH abort.
+      #
+      # @param dbclient_proc [Proc] resolves the concrete Redis client (called once per attempt)
+      # @param watch_keys [Array<String>] keys to WATCH
+      # @param max_attempts [Integer]
+      # @yield [conn] the resolved connection
+      # @return [MultiResult, Object] the block's result
+      # @raise [Familia::OptimisticLockError] if retries are exhausted
+      def self.execute_watched_transaction(dbclient_proc, watch_keys:, max_attempts: 3)
+        attempts = 0
+        begin
+          attempts += 1
+          conn = dbclient_proc.call
+          txn_result = conn.watch(*watch_keys) do
+            yield(conn)
+          end
+          if txn_result.is_a?(MultiResult) && txn_result.results.nil?
+            raise Familia::OptimisticLockError,
+                  "WATCH detected concurrent modification of #{watch_keys.join(', ')}"
+          end
+          txn_result
+        rescue Familia::OptimisticLockError
+          raise if attempts >= max_attempts
+          sleep(0.001 * (2**attempts))
+          retry
+        end
+      end
     end
   end
 end

--- a/lib/familia/connection/transaction_core.rb
+++ b/lib/familia/connection/transaction_core.rb
@@ -199,13 +199,23 @@ module Familia
           txn_result = conn.watch(*watch_keys) do
             yield(conn)
           end
-          if txn_result.is_a?(MultiResult) && txn_result.results.nil?
+          # Detect a WATCH abort regardless of how the block opened the MULTI: a
+          # block that goes through execute_normal_transaction gets a
+          # MultiResult(nil) on abort, while one that drives conn.multi directly
+          # would see a bare nil (aborted EXEC). Treat both as an abort so the
+          # retry fires either way.
+          if txn_result.nil? || (txn_result.is_a?(MultiResult) && txn_result.results.nil?)
             raise WatchAbortError,
                   "WATCH detected concurrent modification of #{watch_keys.join(', ')}"
           end
           txn_result
         rescue WatchAbortError
           raise if attempts >= max_attempts
+
+          # Exponential backoff between WATCH retries (sub-10ms). This sleep
+          # blocks the current thread; under a Fiber::Scheduler (Ruby 3+) it
+          # yields cooperatively, but with no scheduler installed it parks the
+          # thread for the backoff window.
           sleep(0.001 * (2**attempts))
           retry
         end

--- a/lib/familia/connection/transaction_core.rb
+++ b/lib/familia/connection/transaction_core.rb
@@ -170,6 +170,15 @@ module Familia
         MultiResult.new(command_return_values)
       end
 
+      # Internal sentinel raised ONLY by execute_watched_transaction to mark a
+      # genuine WATCH abort (EXEC discarded). It lets the retry loop distinguish
+      # a real abort -- which should retry -- from an OptimisticLockError raised
+      # by the caller's pre_check or user block, which must propagate untouched
+      # (otherwise the loop would silently re-run the whole transaction and mask
+      # the real failure). Subclasses OptimisticLockError so a public
+      # `rescue Familia::OptimisticLockError` still catches an exhausted retry.
+      class WatchAbortError < Familia::OptimisticLockError; end
+
       # Runs a WATCH-guarded transaction on a SINGLE resolved connection so the
       # WATCH and the MULTI/EXEC share one socket (the optimistic lock is only
       # effective this way). The caller's block receives the resolved connection
@@ -191,11 +200,11 @@ module Familia
             yield(conn)
           end
           if txn_result.is_a?(MultiResult) && txn_result.results.nil?
-            raise Familia::OptimisticLockError,
+            raise WatchAbortError,
                   "WATCH detected concurrent modification of #{watch_keys.join(', ')}"
           end
           txn_result
-        rescue Familia::OptimisticLockError
+        rescue WatchAbortError
           raise if attempts >= max_attempts
           sleep(0.001 * (2**attempts))
           retry

--- a/lib/familia/horreum/atomic_write.rb
+++ b/lib/familia/horreum/atomic_write.rb
@@ -186,11 +186,20 @@ module Familia
       # Executes the WATCH-guarded atomic_write flow: WATCH → pre_check →
       # MULTI/EXEC, with retry on OptimisticLockError.
       #
+      # Delegates to +TransactionCore.execute_watched_transaction+, which
+      # resolves the connection ONCE and drives both WATCH and the MULTI/EXEC
+      # through that SAME connection. This is what makes the optimistic lock
+      # effective: WATCH and EXEC must share a socket, otherwise the lock is
+      # inert. The MULTI is opened on the resolved connection via
+      # +execute_normal_transaction(-> { conn })+, so nested collection writes
+      # join it through +Fiber[:familia_transaction]+.
+      #
       # When EXEC is aborted by WATCH (a watched key was modified between
-      # WATCH and EXEC), +multi+ returns nil. We detect this via the
-      # MultiResult wrapper and raise OptimisticLockError to trigger a
-      # retry. The retry re-issues WATCH, re-runs the pre_check, and
-      # re-opens MULTI/EXEC.
+      # WATCH and EXEC), +multi+ returns nil; the primitive detects this via
+      # the MultiResult wrapper, raises OptimisticLockError, and retries
+      # (re-issuing WATCH, re-running the pre_check, and re-opening
+      # MULTI/EXEC). A pre_check that raises a non-OptimisticLockError (e.g.
+      # RecordExistsError) propagates out un-retried.
       #
       # @param watch_keys [Array<String>] Keys to WATCH
       # @param pre_check [Proc, nil] Callable run between WATCH and MULTI
@@ -200,38 +209,19 @@ module Familia
       # @return [Boolean]
       # @raise [Familia::OptimisticLockError] If retries exhausted
       def execute_watched_atomic_write(watch_keys, pre_check, update_expiration, max_attempts: 3)
-        attempts = 0
-
-        begin
-          attempts += 1
-
-          result = dbclient.watch(*watch_keys) do
-            pre_check&.call
-
-            txn_result = transaction do |_conn|
-              yield
-              persist_to_storage(update_expiration)
-            end
-
-            # WATCH abort: EXEC returns nil → multi returns nil →
-            # MultiResult wraps nil. Raise to trigger retry.
-            if txn_result.is_a?(MultiResult) && txn_result.results.nil?
-              raise Familia::OptimisticLockError,
-                "WATCH detected concurrent modification of #{watch_keys.join(', ')}"
-            end
-
-            txn_result
+        result = Familia::Connection::TransactionCore.execute_watched_transaction(
+          -> { dbclient }, watch_keys: watch_keys, max_attempts: max_attempts
+        ) do |conn|
+          pre_check&.call
+          Familia::Connection::TransactionCore.execute_normal_transaction(-> { conn }) do |_m|
+            yield
+            persist_to_storage(update_expiration)
           end
-
-          success = atomic_write_success?(result)
-          clear_dirty! if success
-          success
-        rescue Familia::OptimisticLockError
-          raise if attempts >= max_attempts
-
-          sleep(0.001 * (2**attempts))
-          retry
         end
+
+        success = atomic_write_success?(result)
+        clear_dirty! if success
+        success
       end
 
       # Atomically claim same-instance ownership or raise if a competing

--- a/lib/familia/horreum/management.rb
+++ b/lib/familia/horreum/management.rb
@@ -48,11 +48,11 @@ module Familia
       # identifier already exists. If it does, a Familia::RecordExistsError exception is
       # raised to prevent overwriting existing data.
       #
-      # Concurrency: the duplicate check is best-effort, not fully atomic.
+      # Concurrency: the duplicate check is race-safe via optimistic locking.
       # It routes through {#save_if_not_exists!}, which uses WATCH + MULTI/EXEC
-      # to abort if the key appears between the check and the write -- more
-      # cautious than a bare read-then-write, but a true guarantee needs a
-      # server-side check (e.g. Lua). See {#save_if_not_exists!}.
+      # on a single connection to abort if the key appears between the check and
+      # the write. This is an effective optimistic lock, though not a server-side
+      # atomic check (e.g. Lua). See {#save_if_not_exists!}.
       #
       # Finally, the method saves the new instance returns it.
       #
@@ -84,7 +84,8 @@ module Familia
       # @see #save
       def create!(...)
         hobj = new(...)
-        # Best-effort duplicate guard: WATCH + MULTI/EXEC, not fully atomic.
+        # Race-safe duplicate guard: WATCH + MULTI/EXEC optimistic lock on one
+        # connection (not a server-side atomic check).
         hobj.save_if_not_exists!
 
         # If a block is given, yield the created object
@@ -121,8 +122,9 @@ module Familia
       # Use {Persistence#save} or {Persistence#save_with_collections} when
       # you explicitly want overwrite/upsert behaviour.
       #
-      # Concurrency: both paths use WATCH + MULTI/EXEC for race-safe
-      # duplicate detection. Without a block, +build+ delegates to
+      # Concurrency: both paths use a WATCH + MULTI/EXEC optimistic lock on a
+      # single connection for race-safe duplicate detection (not a server-side
+      # atomic check). Without a block, +build+ delegates to
       # {#save_if_not_exists!}. With a block, +atomic_write+ is called
       # with +watch_keys:+ and +pre_check:+ so the existence check runs
       # between WATCH and MULTI -- if the key is created by another client

--- a/lib/familia/horreum/persistence.rb
+++ b/lib/familia/horreum/persistence.rb
@@ -197,22 +197,29 @@ module Familia
 
       # Conditionally persists object only if it doesn't already exist in storage.
       #
-      # Uses optimistic locking (WATCH) to atomically check existence and save.
-      # If the object doesn't exist, performs identical operations as save.
-      # If it exists, raises an error with retry logic for optimistic lock failures.
+      # Uses optimistic locking (WATCH + MULTI/EXEC on a single connection) to
+      # guard the existence check against the save. If the object doesn't exist,
+      # performs identical operations as save. If it exists, raises an error;
+      # concurrent modification of the watched key aborts EXEC and retries.
       #
       # `save_if_not_exists` doesn't call save because of the gap between checking
       # existence and persisting the data. We can't check for existence inside the
       # transaction because commands are queued and not executed until EXEC
       # is called (if you try you get a Redis::Future object). So here we use a
       # WATCH + MULTI/EXEC pattern to fail the transaction if the key is created
-      # (or modified in any way) to avoid silent data corruption♀︎.
+      # (or modified in any way) between the check and EXEC, avoiding silent data
+      # corruption♀︎. The WATCH and the MULTI/EXEC run on the SAME resolved
+      # connection (see TransactionCore.execute_watched_transaction) -- this is
+      # what makes the optimistic lock effective; split across connections it
+      # would be inert.
 
       # ♀︎ Additional note about WATCH + MULTI/EXEC in Valkey/Redis or any two
-      # step existence check in any database: although it is more cautious,
-      # it is not atomic. The only way to do that is if the database process
-      # can determine itself whether the record already exists or not. For
-      # Valkey/Redis, that means writing the lua to do that.
+      # step existence check in any database: although it is more cautious and,
+      # on a single connection, a genuine optimistic lock (a concurrent write to
+      # the watched key aborts EXEC), it is still not a server-side atomic check.
+      # The only way to do that is if the database process can determine itself
+      # whether the record already exists or not. For Valkey/Redis, that means
+      # writing the lua to do that.
       #
       # @param update_expiration [Boolean] Whether to refresh key expiration (default: true)
       # @return [Boolean] true on successful save
@@ -241,36 +248,27 @@ module Familia
         # Prepare object for persistence (timestamps, validation)
         prepare_for_save
 
-        attempts = 0
-        begin
-          attempts += 1
+        # Drive WATCH + MULTI/EXEC through a SINGLE resolved connection so the
+        # optimistic lock is effective (the primitive owns abort detection and
+        # retry). The existence check runs in the WATCH window: if the key is
+        # created between WATCH and EXEC, Redis aborts and the primitive retries.
+        result = Familia::Connection::TransactionCore.execute_watched_transaction(
+          -> { dbclient }, watch_keys: [dbkey]
+        ) do |conn|
+          raise Familia::RecordExistsError, dbkey if exists?
 
-          result = watch do
-            raise Familia::RecordExistsError, dbkey if exists?
-
-            txn_result = transaction do |_multi|
-              persist_to_storage(update_expiration)
-            end
-
-            Familia.debug "[save_if_not_exists]: txn_result=#{txn_result.inspect}"
-
-            txn_result
+          Familia::Connection::TransactionCore.execute_normal_transaction(-> { conn }) do |_m|
+            persist_to_storage(update_expiration)
           end
-
-          Familia.debug "[save_if_not_exists]: result=#{result.inspect}"
-
-          # Clear dirty tracking after successful save
-          clear_dirty! unless result.nil?
-
-          # Return boolean indicating success (consistent with save method)
-          !result.nil?
-        rescue OptimisticLockError => e
-          Familia.debug "[save_if_not_exists]: OptimisticLockError (#{attempts}): #{e.message}"
-          raise if attempts >= 3
-
-          sleep(0.001 * (2**attempts))
-          retry
         end
+
+        Familia.debug "[save_if_not_exists]: result=#{result.inspect}"
+
+        # Clear dirty tracking after successful save
+        clear_dirty! unless result.nil?
+
+        # Return boolean indicating success (consistent with save method)
+        !result.nil?
       end
 
       # Non-raising variant of save_if_not_exists!

--- a/lib/familia/horreum/persistence.rb
+++ b/lib/familia/horreum/persistence.rb
@@ -144,10 +144,10 @@ module Familia
         end
 
         # Clear dirty tracking after successful save
-        clear_dirty! unless result.nil?
+        clear_dirty! if persisted_successfully?(result)
 
         # Return boolean indicating success
-        !result.nil?
+        persisted_successfully?(result)
       end
 
       # Saves scalar fields first, then executes collection operations in the block.
@@ -265,10 +265,10 @@ module Familia
         Familia.debug "[save_if_not_exists]: result=#{result.inspect}"
 
         # Clear dirty tracking after successful save
-        clear_dirty! unless result.nil?
+        clear_dirty! if persisted_successfully?(result)
 
         # Return boolean indicating success (consistent with save method)
-        !result.nil?
+        persisted_successfully?(result)
       end
 
       # Non-raising variant of save_if_not_exists!
@@ -333,10 +333,28 @@ module Familia
         end
 
         # Clear dirty tracking after successful commit
-        clear_dirty! unless result.nil?
+        clear_dirty! if persisted_successfully?(result)
 
         result
       end
+
+      # Whether a persistence MULTI/EXEC committed cleanly. A MultiResult is
+      # successful when no queued command returned an Exception; a nil result
+      # (e.g. a discarded/aborted transaction) is a failure. Shared by save,
+      # save_if_not_exists!, commit_fields, and multi_field_update so they all
+      # interpret the transaction result the same way -- a partial-command
+      # failure must not clear dirty state or report success. Mirrors
+      # AtomicWrite#atomic_write_success?.
+      #
+      # @param result [MultiResult, nil]
+      # @return [Boolean]
+      def persisted_successfully?(result)
+        return false if result.nil?
+        return result.successful? if result.is_a?(Familia::MultiResult)
+
+        true
+      end
+      private :persisted_successfully?
 
       # Updates multiple fields atomically in a Database transaction.
       #
@@ -482,7 +500,7 @@ module Familia
           touch_instances!
         end
 
-        clear_dirty!(*field_names) unless result.nil?
+        clear_dirty!(*field_names) if persisted_successfully?(result)
 
         self
       end

--- a/try/features/atomic_write_watch_try.rb
+++ b/try/features/atomic_write_watch_try.rb
@@ -17,9 +17,22 @@ class WatchTestUser < Familia::Horreum
   list :sessions
 end
 
-# Clean slate
+# Clean slate. Use a raw DEL sweep rather than WatchTestUser.all.each(&:destroy!)
+# because the real-race tests below intentionally create PARTIAL keys from a
+# second connection (a key with no identifier/email field). destroy! would
+# raise Familia::NoIdentifier on such a key, so flush keys directly instead.
+def flush_watch_test_keys!
+  raw = Redis.new(url: Familia.uri.to_s)
+  %w[watch_test_user:* watch_exhaust:*].each do |pattern|
+    keys = raw.keys(pattern)
+    raw.del(*keys) unless keys.empty?
+  end
+ensure
+  raw&.close
+end
+
 WatchTestUser.instances.clear
-WatchTestUser.all.each(&:destroy!)
+flush_watch_test_keys!
 
 ## atomic_write with watch_keys persists scalars and collections
 @u1 = WatchTestUser.new(email: 'watch1@example.com', name: 'Watch1')
@@ -109,26 +122,99 @@ end
 [@r8.name, @r8.tags.members.sort]
 #=> ['Watch8', ['keep_me']]
 
-## watched atomic_write retries on OptimisticLockError (simulated WATCH abort)
-# Simulate a WATCH abort by returning MultiResult.new(nil) on the first
-# attempt WITHOUT calling the block, mirroring real WATCH behaviour where
-# EXEC discards all queued commands (nothing reaches Redis).
+## watched atomic_write retries on REAL WATCH abort, then succeeds
+# A pre_check that, from a SECOND independent connection, mutates the
+# watched key on the FIRST attempt only. That out-of-band write happens
+# inside the WATCH window, so attempt 1's EXEC is aborted by Redis; the
+# primitive retries, attempt 2 sees no interfering write and commits. The
+# atomic_write's own value must be the one that persists.
+@racer9 = Redis.new(url: Familia.uri.to_s)
 @u9 = WatchTestUser.new(email: 'watch9@example.com', name: 'Watch9')
-attempt_count = 0
-original_transaction = @u9.method(:transaction)
-@u9.define_singleton_method(:transaction) do |&blk|
-  attempt_count += 1
-  if attempt_count == 1
-    Familia::MultiResult.new(nil)
-  else
-    original_transaction.call(&blk)
-  end
-end
-@u9.atomic_write(watch_keys: [@u9.dbkey]) do
+@attempt_count9 = 0
+@u9.atomic_write(
+  watch_keys: [@u9.dbkey],
+  pre_check: -> {
+    @attempt_count9 += 1
+    @racer9.hset(@u9.dbkey, 'name', 'RacerTouch') if @attempt_count9 == 1
+  }
+) do
   @u9.role = 'retried'
 end
-[attempt_count >= 2, WatchTestUser.find_by_id('watch9@example.com').role]
-#=> [true, 'retried']
+@r9 = WatchTestUser.find_by_id('watch9@example.com')
+[@attempt_count9, @r9.role, @r9.name]
+#=> [2, 'retried', 'Watch9']
+
+## watched atomic_write raises OptimisticLockError after exhausting retries
+# A pre_check that mutates the watched key from a SECOND connection on
+# EVERY attempt, so every EXEC aborts and retries are exhausted. The racer's
+# value must survive (no silent overwrite by atomic_write). RED on the old
+# split-connection code (WATCH was inert -> EXEC always committed), GREEN
+# now that WATCH + MULTI/EXEC share one connection.
+@racer10 = Redis.new(url: Familia.uri.to_s)
+@racer10.hset('watch_exhaust:key', 'name', 'RacerOwned')
+@u_ex = WatchTestUser.new(email: 'watch_exhaust@example.com', name: 'ExhaustVictim')
+# WATCH a key the racer keeps changing; persist would target the user's key.
+@watched_key = 'watch_exhaust:key'
+@counter10 = 0
+begin
+  @u_ex.atomic_write(
+    watch_keys: [@watched_key],
+    pre_check: -> {
+      @counter10 += 1
+      @racer10.hset(@watched_key, 'name', "RacerOwned#{@counter10}")
+    }
+  ) do
+    @u_ex.role = 'should_not_persist'
+  end
+  :no_raise
+rescue Familia::OptimisticLockError
+  :raised
+end
+#=> :raised
+
+## ... and the exhausted-retry race left the racer's value intact (no overwrite)
+[@counter10 >= 3, @racer10.hget('watch_exhaust:key', 'name').start_with?('RacerOwned')]
+#=> [true, true]
+
+## save_if_not_exists! real race: key created in WATCH window then retry raises RecordExistsError
+# Stub the instance exists? to report false (so the in-WATCH existence check
+# passes) but, as a side effect, create the key from a SECOND connection.
+# attempt 1: exists?->false, side-effect creates key, EXEC aborts (watched
+# key changed). retry attempt 2: exists? side-effect runs again but the key
+# already exists from attempt 1, and the now-real key makes the WATCH window
+# check raise RecordExistsError -- i.e. no silent overwrite of the racer's row.
+@u_sine = WatchTestUser.new(email: 'watch_sine@example.com', name: 'SineRace')
+# Closure-captured locals: a singleton method defined with a block evaluates
+# @ivars against the SINGLETON object (the instance), not this top-level
+# binding, so use lexical locals here. @sine_box aliases the same mutable
+# array so the next test case can read the attempt count.
+sine_box = [0]
+sine_racer = Redis.new(url: Familia.uri.to_s)
+@sine_box = sine_box
+real_exists = WatchTestUser.instance_method(:exists?)
+@u_sine.define_singleton_method(:exists?) do
+  sine_box[0] += 1
+  if sine_box[0] == 1
+    # Report absent, but as a side effect create the key out-of-band from a
+    # second connection -- inside the WATCH window -- so attempt 1's EXEC is
+    # aborted by the changed watched key.
+    sine_racer.hset(dbkey, 'name', 'RacerCreated')
+    false
+  else
+    real_exists.bind(self).call # now reflects reality: the key exists
+  end
+end
+begin
+  @u_sine.save_if_not_exists!
+  :no_raise
+rescue Familia::RecordExistsError
+  :raised
+end
+#=> :raised
+
+## save_if_not_exists! real race took >=2 attempts and left racer's value intact
+[@sine_box[0] >= 2, Redis.new(url: Familia.uri.to_s).hget(@u_sine.dbkey, 'name')]
+#=> [true, 'RacerCreated']
 
 ## build with block uses WATCH path (duplicate rejected even under concurrent setup)
 @u10 = WatchTestUser.build(email: 'watch10@example.com', name: 'First') do |u|
@@ -161,4 +247,4 @@ end
 
 # Cleanup
 WatchTestUser.instances.clear
-WatchTestUser.all.each(&:destroy!)
+flush_watch_test_keys!

--- a/try/features/atomic_write_watch_try.rb
+++ b/try/features/atomic_write_watch_try.rb
@@ -191,6 +191,7 @@ end
 sine_box = [0]
 sine_racer = Redis.new(url: Familia.uri.to_s)
 @sine_box = sine_box
+@sine_racer = sine_racer # ivar alias so the later block can read + the cleanup can close it
 real_exists = WatchTestUser.instance_method(:exists?)
 @u_sine.define_singleton_method(:exists?) do
   sine_box[0] += 1
@@ -213,7 +214,7 @@ end
 #=> :raised
 
 ## save_if_not_exists! real race took >=2 attempts and left racer's value intact
-[@sine_box[0] >= 2, Redis.new(url: Familia.uri.to_s).hget(@u_sine.dbkey, 'name')]
+[@sine_box[0] >= 2, @sine_racer.hget(@u_sine.dbkey, 'name')]
 #=> [true, 'RacerCreated']
 
 ## build with block uses WATCH path (duplicate rejected even under concurrent setup)
@@ -246,5 +247,8 @@ end
 #=> :raised
 
 # Cleanup
+@racer9&.close
+@racer10&.close
+@sine_racer&.close
 WatchTestUser.instances.clear
 flush_watch_test_keys!

--- a/try/features/cross_model_atomic_write_try.rb
+++ b/try/features/cross_model_atomic_write_try.rb
@@ -358,6 +358,36 @@ end
 [@strict7, @r_scust7.orgs.members]
 #=> [true, ['cm_strict_org_7']]
 
+## 8. Non-watched path honors execute_transaction's handler-compatibility gate
+## (regression for the #300 review). When the resolved connection's handler
+## disallows transactions (fiber-pinned FiberConnectionHandler, allows_transaction
+## == false) and transaction_mode is :strict, Familia.atomic_write must surface a
+## descriptive OperationModeError via the gate -- not issue a raw MULTI on an
+## unsupported connection. Routing the non-watched branch through instance
+## #transaction (instead of execute_normal_transaction directly) inherits it.
+## Globals are restored in the ensure to avoid cross-test pollution.
+@prev_txn_mode8 = Familia.transaction_mode
+@conn8 = CMCustomer.create_dbclient
+@cust8 = CMCustomer.new(custid: 'cm_cust_8', name: 'GateCheck')
+@gate8 = begin
+  Familia.configure { |c| c.transaction_mode = :strict }
+  Fiber[:familia_connection] = [@conn8, Familia.middleware_version]
+  Fiber[:familia_connection_handler_class] = Familia::Connection::FiberConnectionHandler
+  begin
+    Familia.atomic_write(@cust8) { @cust8.name = 'ShouldNotRawMulti' }
+    :no_raise
+  rescue Familia::OperationModeError
+    :raised
+  end
+ensure
+  Fiber[:familia_connection] = nil
+  Fiber[:familia_connection_handler_class] = nil
+  Familia.configure { |c| c.transaction_mode = @prev_txn_mode8 }
+  @conn8&.close
+end
+@gate8
+#=> :raised
+
 # Cleanup
 @probe1&.close
 @probe2&.close

--- a/try/features/cross_model_atomic_write_try.rb
+++ b/try/features/cross_model_atomic_write_try.rb
@@ -175,6 +175,13 @@ end
 ## does NOT raise for per-command errors). Stub execute_normal_transaction to
 ## return a failed MultiResult after running the block, so scalars are touched
 ## but neither instance is cleared.
+##
+## NOTE: the stub does not set Fiber[:familia_transaction], so persist_to_storage
+## resolves a live connection and actually writes the dirty values to Redis (the
+## teardown flush clears them before any read-back). This is an intentional
+## simplification to exercise the dirty-state-preservation path -- it is NOT a
+## faithful failed-MULTI (a real aborted EXEC writes nothing); Familia.atomic_write
+## does not itself roll back partial Redis writes.
 @cust4b = CMCustomer.new(custid: 'cm_cust_4b', name: 'DirtyBefore')
 @org4b = CMOrg.new(orgid: 'cm_org_4b', name: 'DirtyBeforeOrg')
 @cust4b.save

--- a/try/features/cross_model_atomic_write_try.rb
+++ b/try/features/cross_model_atomic_write_try.rb
@@ -54,7 +54,7 @@ end
 # so flush keys directly via a second raw connection.
 def flush_cross_model_keys!
   raw = Redis.new(url: Familia.uri.to_s)
-  %w[cm_customer:* cm_org:* cm_db_zero:*].each do |pattern|
+  %w[cm_customer:* cm_org:* cm_db_zero:* cm_strict_customer:* cm_strict_org:*].each do |pattern|
     keys = raw.keys(pattern)
     raw.del(*keys) unless keys.empty?
   end
@@ -310,9 +310,46 @@ end
 ## and the victim's own key was never written under its identifier.
 [
   @racer6.hget(@org6b.dbkey, 'name'),
-  Redis.new(url: Familia.uri.to_s).exists(@cust6b.dbkey),
+  @racer6.exists(@cust6b.dbkey),
 ]
 #=> ['RacerOwnedOrg', 0]
+
+## 7. Dirty-write suppression: Familia.atomic_write activates atomic_write_mode?
+## on every instance (like the instance-level variant), so collection mutations
+## in the user block against just-dirtied scalars do not fire dirty-write
+## warnings -- or, under dirty_write_warnings :strict, a Familia::Problem raise.
+## Without that activation this happy path would raise. (Regression test for the
+## #300 review finding.)
+class CMStrictCustomer < Familia::Horreum
+  dirty_write_warnings :strict
+  identifier_field :custid
+  field :custid
+  field :name
+  set :orgs
+end
+class CMStrictOrg < Familia::Horreum
+  dirty_write_warnings :strict
+  identifier_field :orgid
+  field :orgid
+  field :name
+  set :members
+end
+CMStrictCustomer.instances.clear
+CMStrictOrg.instances.clear
+@scust7 = CMStrictCustomer.new(custid: 'cm_strict_cust_7', name: 'S')
+@sorg7 = CMStrictOrg.new(orgid: 'cm_strict_org_7', name: 'SO')
+@strict7 = begin
+  Familia.atomic_write(@scust7, @sorg7) do
+    @scust7.name = 'StrictChanged'        # dirties a scalar
+    @scust7.orgs.add(@sorg7.identifier)   # collection mutation on a dirtied :strict parent
+    @sorg7.members.add(@scust7.identifier)
+  end
+rescue Familia::Problem => e
+  [:raised, e.message.to_s[0, 40]]
+end
+@r_scust7 = CMStrictCustomer.find_by_id('cm_strict_cust_7')
+[@strict7, @r_scust7.orgs.members]
+#=> [true, ['cm_strict_org_7']]
 
 # Cleanup
 @probe1&.close
@@ -322,5 +359,7 @@ end
 @racer6&.close
 CMCustomer.instances.clear
 CMOrg.instances.clear
+CMStrictCustomer.instances.clear
+CMStrictOrg.instances.clear
 flush_cross_model_keys!
 flush_cross_model_db5!

--- a/try/features/cross_model_atomic_write_try.rb
+++ b/try/features/cross_model_atomic_write_try.rb
@@ -1,0 +1,326 @@
+# try/features/cross_model_atomic_write_try.rb
+#
+# Tests for the module-level Familia.atomic_write(*instances, ...) which
+# persists multiple (possibly cross-class) Horreum instances in ONE
+# MULTI/EXEC. See lib/familia/connection/operations.rb#atomic_write.
+#
+# The read/write split is the key constraint: prepare_for_save (timestamps +
+# unique-index reads) runs OUTSIDE the txn; persist_to_storage (HMSET/EXPIRE/
+# index HSET/instances ZADD) runs INSIDE. Anchoring the MULTI on
+# instances.first.dbclient is only correct because the guard enforces all
+# roots share ONE logical database, so every instance routes to that same
+# connection inside the MULTI.
+
+require_relative '../support/helpers/test_helpers'
+
+Familia.debug = false
+
+# Two models that mirror the issue's POCustomer/POOrg. Both live on the
+# default logical database (0) so they share one connection inside the MULTI.
+class CMCustomer < Familia::Horreum
+  identifier_field :custid
+  field :custid
+  field :name
+  field :org_id
+  set :orgs
+end
+
+class CMOrg < Familia::Horreum
+  identifier_field :orgid
+  field :orgid
+  field :name
+  field :owner_id
+  set :members
+end
+
+# Two models that span DIFFERENT logical databases, for the CrossDatabaseError
+# guard. CMDbZero resolves to 0, CMDbFive to 5 -- MULTI/EXEC cannot cross them.
+class CMDbZero < Familia::Horreum
+  logical_database 0
+  identifier_field :id
+  field :id
+  field :name
+end
+
+class CMDbFive < Familia::Horreum
+  logical_database 5
+  identifier_field :id
+  field :id
+  field :name
+end
+
+# Raw DEL sweep for teardown. destroy! raises NoIdentifier on partial keys
+# (the create-only race intentionally creates a key with no identifier field),
+# so flush keys directly via a second raw connection.
+def flush_cross_model_keys!
+  raw = Redis.new(url: Familia.uri.to_s)
+  %w[cm_customer:* cm_org:* cm_db_zero:*].each do |pattern|
+    keys = raw.keys(pattern)
+    raw.del(*keys) unless keys.empty?
+  end
+ensure
+  raw&.close
+end
+
+# CMDbFive lives on database 5; sweep it on its own connection.
+def flush_cross_model_db5!
+  raw = Redis.new(url: "#{Familia.uri}/5")
+  keys = raw.keys('cm_db_five:*')
+  raw.del(*keys) unless keys.empty?
+ensure
+  raw&.close
+end
+
+CMCustomer.instances.clear
+CMOrg.instances.clear
+flush_cross_model_keys!
+flush_cross_model_db5!
+
+## 1a. Two models persisted atomically: a separate Redis probe sees NEITHER
+## key mid-transaction. The probe runs INSIDE the user block (which executes
+## inside the open MULTI), so its reads observe pre-commit state.
+@probe1 = Redis.new(url: Familia.uri.to_s)
+@cust1 = CMCustomer.new(custid: 'cm_cust_1', name: 'Pending')
+@org1 = CMOrg.new(orgid: 'cm_org_1', name: 'PendingOrg')
+@mid_txn_seen = nil
+Familia.atomic_write(@cust1, @org1) do
+  @cust1.name = 'Acme Owner'
+  @org1.name = 'Acme Inc'
+  @org1.owner_id = @cust1.identifier
+  @cust1.orgs.add(@org1.identifier)
+  @org1.members.add(@cust1.identifier)
+  # Mid-transaction probe on a SECOND connection: neither key is visible yet
+  # because the MULTI has not EXEC'd.
+  @mid_txn_seen = [@probe1.exists(@cust1.dbkey), @probe1.exists(@org1.dbkey)]
+end
+@mid_txn_seen
+#=> [0, 0]
+
+## 1b. After the MULTI commits, BOTH keys exist (probed on the second connection)
+[@probe1.exists(@cust1.dbkey), @probe1.exists(@org1.dbkey)]
+#=> [1, 1]
+
+## 1c. Scalars committed on both models
+@r_cust1 = CMCustomer.find_by_id('cm_cust_1')
+@r_org1 = CMOrg.find_by_id('cm_org_1')
+[@r_cust1.name, @r_org1.name, @r_org1.owner_id]
+#=> ['Acme Owner', 'Acme Inc', 'cm_cust_1']
+
+## 1d. Collection mutations committed on both models
+[@r_cust1.orgs.members.sort, @r_org1.members.members.sort]
+#=> [['cm_org_1'], ['cm_cust_1']]
+
+## 1e. Both roots registered in their instances timelines
+[CMCustomer.in_instances?('cm_cust_1'), CMOrg.in_instances?('cm_org_1')]
+#=> [true, true]
+
+## 2. An exception raised inside the user block rolls back BOTH: neither key
+## exists afterward, and dirty state is preserved on both instances.
+@cust2 = CMCustomer.new(custid: 'cm_cust_2', name: 'RollbackCust')
+@org2 = CMOrg.new(orgid: 'cm_org_2', name: 'RollbackOrg')
+@raised2 = false
+begin
+  Familia.atomic_write(@cust2, @org2) do
+    @cust2.name = 'ShouldNotPersist'
+    @org2.name = 'ShouldNotPersist'
+    @cust2.orgs.add('ghost')
+    raise 'boom'
+  end
+rescue RuntimeError
+  @raised2 = true
+end
+@probe2 = Redis.new(url: Familia.uri.to_s)
+[
+  @raised2,
+  @probe2.exists(@cust2.dbkey),
+  @probe2.exists(@org2.dbkey),
+  @cust2.dirty?,
+  @org2.dirty?,
+]
+#=> [true, 0, 0, true, true]
+
+## 3a. CrossDatabaseError raised when roots span databases (0 vs 5), BEFORE
+## any write. The synthetic "(root)" field_name identifies the offending root.
+@a3 = CMDbZero.new(id: 'cm_a3', name: 'Zero')
+@b3 = CMDbFive.new(id: 'cm_b3', name: 'Five')
+begin
+  Familia.atomic_write(@a3, @b3) do
+    @a3.name = 'WroteZero'
+    @b3.name = 'WroteFive'
+  end
+  :no_raise
+rescue Familia::CrossDatabaseError => e
+  [:raised, e.field_database, e.horreum_database, e.field_name.include?('(root)')]
+end
+#=> [:raised, 5, 0, true]
+
+## 3b. No writes landed for either root on the cross-db attempt
+@probe3a = Redis.new(url: Familia.uri.to_s)
+@probe3b = Redis.new(url: "#{Familia.uri}/5")
+[@probe3a.exists(@a3.dbkey), @probe3b.exists(@b3.dbkey)]
+#=> [0, 0]
+
+## 4a. Dirty state cleared for ALL roots on success
+@cust4 = CMCustomer.new(custid: 'cm_cust_4', name: 'DirtyClear')
+@org4 = CMOrg.new(orgid: 'cm_org_4', name: 'DirtyClearOrg')
+@ret4 = Familia.atomic_write(@cust4, @org4) do
+  @cust4.name = 'CustChanged'
+  @org4.name = 'OrgChanged'
+end
+[@ret4, @cust4.dirty?, @org4.dirty?]
+#=> [true, false, false]
+
+## 4b. Dirty state left intact for ALL roots when the MultiResult is
+## unsuccessful (a queued command returns an Exception object -- MULTI/EXEC
+## does NOT raise for per-command errors). Stub execute_normal_transaction to
+## return a failed MultiResult after running the block, so scalars are touched
+## but neither instance is cleared.
+@cust4b = CMCustomer.new(custid: 'cm_cust_4b', name: 'DirtyBefore')
+@org4b = CMOrg.new(orgid: 'cm_org_4b', name: 'DirtyBeforeOrg')
+@cust4b.save
+@org4b.save
+@cust4b.name = 'CustDirtyAfter'
+@org4b.name = 'OrgDirtyAfter'
+@failed_mr = Familia::MultiResult.new(['OK', RuntimeError.new('simulated command failure')])
+@orig_ent = Familia::Connection::TransactionCore.method(:execute_normal_transaction)
+Familia::Connection::TransactionCore.define_singleton_method(:execute_normal_transaction) do |_proc, &blk|
+  blk.call(nil)  # run persist_all so scalars/collections are touched
+  @failed_mr
+end
+begin
+  @ret4b = Familia.atomic_write(@cust4b, @org4b) do
+    @cust4b.name = 'CustDirtyAfter'
+    @org4b.name = 'OrgDirtyAfter'
+  end
+ensure
+  Familia::Connection::TransactionCore.define_singleton_method(:execute_normal_transaction, @orig_ent)
+end
+[@ret4b, @cust4b.dirty?, @org4b.dirty?]
+#=> [false, true, true]
+
+## 5. Nesting guard: calling Familia.atomic_write inside an open
+## Familia.transaction { } raises OperationModeError (it opens its own
+## MULTI/EXEC and cannot be nested).
+@cust5 = CMCustomer.new(custid: 'cm_cust_5', name: 'Nested')
+@org5 = CMOrg.new(orgid: 'cm_org_5', name: 'NestedOrg')
+begin
+  Familia.transaction do
+    Familia.atomic_write(@cust5, @org5) { @cust5.name = 'fail' }
+  end
+  :no_raise
+rescue Familia::OperationModeError
+  :raised
+end
+#=> :raised
+
+## 5b. atomic_write with no instances raises ArgumentError
+begin
+  Familia.atomic_write { nil }
+  :no_raise
+rescue ArgumentError
+  :raised
+end
+#=> :raised
+
+## 5c. pre_check without watch_keys raises ArgumentError
+@cust5c = CMCustomer.new(custid: 'cm_cust_5c', name: 'NoWatch')
+begin
+  Familia.atomic_write(@cust5c, pre_check: -> { true }) { @cust5c.name = 'x' }
+  :no_raise
+rescue ArgumentError
+  :raised
+end
+#=> :raised
+
+## 6a. Create-only happy path: neither key pre-exists, so both are created.
+@cust6 = CMCustomer.new(custid: 'cm_cust_6', name: 'CreateOnly')
+@org6 = CMOrg.new(orgid: 'cm_org_6', name: 'CreateOnlyOrg')
+@ret6 = Familia.atomic_write(@cust6, @org6,
+  watch_keys: [@cust6.dbkey, @org6.dbkey],
+  pre_check: -> { [@cust6, @org6].each { |r| raise Familia::RecordExistsError, r.dbkey if r.exists? } }
+) do
+  @cust6.name = 'CreatedCust'
+  @org6.owner_id = @cust6.identifier
+end
+@r_cust6 = CMCustomer.find_by_id('cm_cust_6')
+@r_org6 = CMOrg.find_by_id('cm_org_6')
+[@ret6, @r_cust6.name, @r_org6.owner_id]
+#=> [true, 'CreatedCust', 'cm_cust_6']
+
+## 6b. Create-only REAL concurrent creation. The org instance's exists? is
+## stubbed so that on attempt 1 it reports false (existence check passes) AND,
+## as a side effect, a racer creates the org key from a SECOND connection --
+## inside the WATCH window. So attempt 1 reaches EXEC, which Redis aborts
+## because the watched org key changed; the primitive retries. On attempt 2
+## the stub reflects reality (key exists) so the existence check raises
+## RecordExistsError -- no silent overwrite of the racer's row. A mutable box
+## counts attempts (singleton method blocks evaluate @ivars against the
+## singleton object, so use a lexical local) and drives determinism without
+## sleeps.
+@racer6 = Redis.new(url: Familia.uri.to_s)
+@cust6b = CMCustomer.new(custid: 'cm_cust_6b', name: 'Victim')
+@org6b = CMOrg.new(orgid: 'cm_org_6b', name: 'VictimOrg')
+# Lexical locals: a singleton method block evaluates @ivars against the
+# singleton object (the instance), not this top-level binding, so capture the
+# racer connection and attempt counter as locals.
+race_box = [0]
+race_conn = @racer6
+@race_box = race_box
+real_org_exists = CMOrg.instance_method(:exists?)
+@org6b.define_singleton_method(:exists?) do
+  race_box[0] += 1
+  if race_box[0] == 1
+    # Report absent, but as a side effect create the key out-of-band from a
+    # second connection -- inside the WATCH window -- so attempt 1's EXEC is
+    # aborted by the changed watched key, forcing a genuine retry.
+    race_conn.hset(dbkey, 'name', 'RacerOwnedOrg')
+    false
+  else
+    real_org_exists.bind(self).call # now reflects reality: the key exists
+  end
+end
+@raised6 = nil
+begin
+  Familia.atomic_write(@cust6b, @org6b,
+    watch_keys: [@cust6b.dbkey, @org6b.dbkey],
+    pre_check: -> {
+      [@cust6b, @org6b].each { |r| raise Familia::RecordExistsError, r.dbkey if r.exists? }
+    }
+  ) do
+    @cust6b.name = 'ShouldNotOverwrite'
+    @org6b.name = 'ShouldNotOverwrite'
+  end
+  @raised6 = :no_raise
+rescue Familia::RecordExistsError
+  @raised6 = :record_exists
+rescue Familia::OptimisticLockError
+  @raised6 = :optimistic_lock
+end
+# Either outcome is acceptable per spec (RecordExistsError once the racer's key
+# is seen, or OptimisticLockError if retries are exhausted); both prove it did
+# NOT silently overwrite. It must have taken at least 2 attempts (the WATCH
+# abort on attempt 1 forced a retry).
+[
+  [:record_exists, :optimistic_lock].include?(@raised6),
+  @race_box[0] >= 2,
+]
+#=> [true, true]
+
+## 6c. ... and the racer's value survived (atomic_write did not overwrite it),
+## and the victim's own key was never written under its identifier.
+[
+  @racer6.hget(@org6b.dbkey, 'name'),
+  Redis.new(url: Familia.uri.to_s).exists(@cust6b.dbkey),
+]
+#=> ['RacerOwnedOrg', 0]
+
+# Cleanup
+@probe1&.close
+@probe2&.close
+@probe3a&.close
+@probe3b&.close
+@racer6&.close
+CMCustomer.instances.clear
+CMOrg.instances.clear
+flush_cross_model_keys!
+flush_cross_model_db5!

--- a/try/investigation/cross_model_atomic_poc_try.rb
+++ b/try/investigation/cross_model_atomic_poc_try.rb
@@ -119,7 +119,7 @@ end
 
 ## PoC 2b: the racer's value survived (no silent overwrite) and the victim's
 ## own customer key was never written under its identifier.
-[@racer.hget(@org2.dbkey, 'name'), Redis.new(url: Familia.uri.to_s).exists(@cust2.dbkey)]
+[@racer.hget(@org2.dbkey, 'name'), @racer.exists(@cust2.dbkey)]
 #=> ['RacerOwned', 0]
 
 # Cleanup

--- a/try/investigation/cross_model_atomic_poc_try.rb
+++ b/try/investigation/cross_model_atomic_poc_try.rb
@@ -1,0 +1,130 @@
+# try/investigation/cross_model_atomic_poc_try.rb
+#
+# Proof-of-concept for module-level Familia.atomic_write(*instances, ...).
+#
+# Demonstrates two properties on the DEFAULT connection config:
+#
+#   1. Familia.atomic_write commits two (cross-class) models in ONE MULTI/EXEC:
+#      a separate raw connection sees NEITHER key mid-transaction and BOTH
+#      after EXEC.
+#   2. The create-only path (watch_keys: + a pre_check that rejects existing
+#      keys) is now RACE-SAFE: a concurrent creation of a watched key during
+#      the WATCH window aborts the whole MULTI and the retry surfaces the
+#      conflict instead of silently overwriting.
+#
+# Pre-fix contrast (for the record): before the committed
+# TransactionCore.execute_watched_transaction fix, WATCH and the MULTI/EXEC
+# could resolve to DIFFERENT pooled connections, so the WATCH was inert -- a
+# concurrent creation slipped through and atomic_write silently overwrote the
+# racer's row. Now WATCH + MULTI/EXEC share one resolved connection, so the
+# optimistic lock actually fires.
+
+require_relative '../support/helpers/test_helpers'
+
+Familia.debug = false
+
+class PocCustomer < Familia::Horreum
+  identifier_field :custid
+  field :custid
+  field :name
+  set :orgs
+end
+
+class PocOrg < Familia::Horreum
+  identifier_field :orgid
+  field :orgid
+  field :name
+  field :owner_id
+end
+
+# Raw DEL sweep (destroy! raises NoIdentifier on partial keys created by the
+# race probe, so flush directly via a second connection).
+def flush_poc_keys!
+  raw = Redis.new(url: Familia.uri.to_s)
+  %w[poc_customer:* poc_org:*].each do |pattern|
+    keys = raw.keys(pattern)
+    raw.del(*keys) unless keys.empty?
+  end
+ensure
+  raw&.close
+end
+
+PocCustomer.instances.clear
+PocOrg.instances.clear
+flush_poc_keys!
+
+## PoC 1: two models commit in ONE MULTI/EXEC. A separate raw connection
+## probes mid-transaction (inside the user block, which runs inside the open
+## MULTI) and sees NEITHER key; after EXEC it sees BOTH.
+@probe = Redis.new(url: Familia.uri.to_s)
+@cust = PocCustomer.new(custid: 'poc_cust', name: 'Pending')
+@org = PocOrg.new(orgid: 'poc_org', name: 'PendingOrg')
+@during = nil
+Familia.atomic_write(@cust, @org) do
+  @cust.name = 'Acme Owner'
+  @org.name = 'Acme Inc'
+  @org.owner_id = @cust.identifier
+  @cust.orgs.add(@org.identifier)
+  @during = [@probe.exists(@cust.dbkey), @probe.exists(@org.dbkey)]
+end
+@after = [@probe.exists(@cust.dbkey), @probe.exists(@org.dbkey)]
+# during: neither visible (MULTI not yet EXEC'd); after: both visible.
+[@during, @after]
+#=> [[0, 0], [1, 1]]
+
+## PoC 1b: the committed values are correct on both models
+@rc = PocCustomer.find_by_id('poc_cust')
+@ro = PocOrg.find_by_id('poc_org')
+[@rc.name, @rc.orgs.members, @ro.name, @ro.owner_id]
+#=> ['Acme Owner', ['poc_org'], 'Acme Inc', 'poc_cust']
+
+## PoC 2: create-only path is race-safe on the default connection. The org's
+## exists? is stubbed so attempt 1 reports false (existence check passes) but,
+## as a side effect, a racer creates the org key from a SECOND connection
+## inside the WATCH window. Attempt 1's EXEC is aborted (watched key changed);
+## the retry's existence check sees the racer's key and raises
+## RecordExistsError -- the racer's value is NOT overwritten.
+@racer = Redis.new(url: Familia.uri.to_s)
+@cust2 = PocCustomer.new(custid: 'poc_cust2', name: 'Victim')
+@org2 = PocOrg.new(orgid: 'poc_org2', name: 'VictimOrg')
+# Singleton-method blocks evaluate @ivars against the singleton object, so use
+# lexical locals for the racer connection and attempt counter.
+attempt_box = [0]
+racer_conn = @racer
+@attempt_box = attempt_box
+real_exists = PocOrg.instance_method(:exists?)
+@org2.define_singleton_method(:exists?) do
+  attempt_box[0] += 1
+  if attempt_box[0] == 1
+    racer_conn.hset(dbkey, 'name', 'RacerOwned')  # out-of-band, inside WATCH window
+    false
+  else
+    real_exists.bind(self).call
+  end
+end
+@outcome = begin
+  Familia.atomic_write(@cust2, @org2,
+    watch_keys: [@cust2.dbkey, @org2.dbkey],
+    pre_check: -> { [@cust2, @org2].each { |r| raise Familia::RecordExistsError, r.dbkey if r.exists? } }
+  ) { @org2.name = 'ShouldNotOverwrite' }
+  :no_raise
+rescue Familia::RecordExistsError
+  :record_exists
+rescue Familia::OptimisticLockError
+  :optimistic_lock
+end
+# Took >=2 attempts (attempt 1 aborted by WATCH), raised rather than overwrote.
+[[:record_exists, :optimistic_lock].include?(@outcome), @attempt_box[0] >= 2]
+#=> [true, true]
+
+## PoC 2b: the racer's value survived (no silent overwrite) and the victim's
+## own customer key was never written under its identifier.
+[@racer.hget(@org2.dbkey, 'name'), Redis.new(url: Familia.uri.to_s).exists(@cust2.dbkey)]
+#=> ['RacerOwned', 0]
+
+# Cleanup
+@probe&.close
+@racer&.close
+PocCustomer.instances.clear
+PocOrg.instances.clear
+flush_poc_keys!


### PR DESCRIPTION
## Summary

This PR adds module-level `Familia.atomic_write(*instances)` for persisting multiple Horreum instances in a single `MULTI/EXEC` transaction, and fixes a critical bug where the `WATCH`-based optimistic lock was inert due to split connections.

## Key Changes

### 1. Fixed WATCH Optimistic Lock (Critical Bug)
- **Problem**: `WATCH` was sent on one pooled connection while `MULTI/EXEC` opened on another, making the optimistic lock ineffective. Concurrent modifications of watched keys were never detected and could be silently overwritten.
- **Solution**: Introduced `TransactionCore.execute_watched_transaction` that resolves the connection once and drives both `WATCH` and `MULTI/EXEC` through the same socket.
- **Impact**: Fixes `atomic_write(watch_keys:)`, `save_if_not_exists!`, and therefore `build`/`create!` with duplicate detection.

### 2. Added Cross-Model `Familia.atomic_write(*instances, ...)`
- New module-level method in `lib/familia/connection/operations.rb` that persists multiple (possibly different-class) instances atomically.
- Once `MULTI` opens, every instance's `dbclient` resolves to the same transaction connection via `Fiber[:familia_transaction]`, so all `HMSET`/`EXPIRE`/index writes queue together.
- **Read/write split**: `prepare_for_save` (timestamps + unique-index reads) runs outside the transaction; only `persist_to_storage` (writes) runs inside.
- **Database constraint**: All instances must share one logical database; a pre-flight guard (`guard_cross_model_database!`) rejects cross-database attempts with `CrossDatabaseError`.
- **Optional block**: Runs inside the transaction before persistence, for wiring cross-references and mutating collections.
- **Return value**: `true` on clean commit (clears dirty state on all instances); `false` on rollback (preserves dirty state).

### 3. Added Optimistic Locking for Cross-Model Create-Only
- `watch_keys:` and `pre_check:` parameters enable race-safe "create A and B together" semantics.
- A concurrent creation of any watched key during the `WATCH` window aborts the whole `MULTI` and retries.
- On retry, the existence check raises `RecordExistsError` instead of silently overwriting.
- If retries exhaust, `OptimisticLockError` is raised.

### 4. Updated Single-Instance `atomic_write`
- Refactored `execute_watched_atomic_write` to delegate to the new `TransactionCore.execute_watched_transaction` primitive.
- Now benefits from the single-connection fix automatically.

### 5. Updated `save_if_not_exists!`
- Refactored to use `execute_watched_transaction` for proper optimistic locking.
- Updated documentation to clarify that the lock is now effective (on a single connection).

## Implementation Details

- **Connection resolution**: `execute_watched_transaction` resolves the connection once via the `dbclient_proc` and passes it to the caller's block, ensuring `WATCH` and `MULTI/EXEC` share one socket.
- **Nested transaction guard**: `atomic_write` raises `OperationModeError` if called within an existing transaction (it opens its own `MULTI/EXEC`).
- **Argument validation**: Requires at least one instance; `pre_check` requires `watch_keys`.
- **Comprehensive test coverage**: Added `try/features/cross_model_atomic_write_try.rb` with 6 test scenarios covering atomic commit, rollback, cross-database rejection, dirty state management, nesting guard, and real concurrent race conditions.

## Testing

- New feature tests in `try/features/cross_model_atomic_write_try.rb` (326 lines) covering two-model atomic commit, rollback, cross-database errors, dirty state, nesting guard, and race-safe create-only.
- Proof-of-concept in `try/investigation/cross_model_atomic_poc_try.rb` demonst

https://claude.ai/code/session_01PjVuo4aTcKA6NmS9j2a7Xc