### PR TITLE
Fix multi_index to properly reference indexed class and store raw identifiers

### DIFF
--- a/lib/familia/features/relationships/indexing/multi_index_generators.rb
+++ b/lib/familia/features/relationships/indexing/multi_index_generators.rb
@@ -120,13 +120,14 @@ module Familia
           # @param index_name [Symbol] Name of the index (e.g., :dept_index)
           def generate_factory_method(indexed_class, scope_class, index_name)
             actual_scope_class = Familia.resolve_class(scope_class)
+            idx_name = index_name
 
             actual_scope_class.class_eval do
               # Helper method to get index set for a specific field value
               # This acts as a factory for field-value-specific DataTypes
               define_method(:"#{index_name}_for") do |field_value|
-                # Return properly managed DataType instance with parameterized key
-                index_key = Familia.join(index_name, field_value)
+                validated = MultiIndexGenerators.validate_field_value(field_value, context: "#{self.class.name}.#{idx_name}")
+                index_key = Familia.join(index_name, validated)
                 Familia::UnsortedSet.new(index_key, parent: self, class: indexed_class, reference: true)
               end
             end

--- a/lib/familia/features/relationships/indexing/multi_index_generators.rb
+++ b/lib/familia/features/relationships/indexing/multi_index_generators.rb
@@ -100,7 +100,7 @@ module Familia
             case scope_type
             when :instance
               # Instance-scoped multi-index (existing behavior)
-              generate_factory_method(scope_class, index_name)
+              generate_factory_method(indexed_class, scope_class, index_name)
               generate_query_methods_destination(indexed_class, field, scope_class, index_name) if query
               generate_mutation_methods_self(indexed_class, field, scope_class, index_name)
             when :class
@@ -118,7 +118,7 @@ module Familia
           #
           # @param scope_class [Class] The scope class providing uniqueness context (e.g., Company)
           # @param index_name [Symbol] Name of the index (e.g., :dept_index)
-          def generate_factory_method(scope_class, index_name)
+          def generate_factory_method(indexed_class, scope_class, index_name)
             actual_scope_class = Familia.resolve_class(scope_class)
 
             actual_scope_class.class_eval do
@@ -127,7 +127,7 @@ module Familia
               define_method(:"#{index_name}_for") do |field_value|
                 # Return properly managed DataType instance with parameterized key
                 index_key = Familia.join(index_name, field_value)
-                Familia::UnsortedSet.new(index_key, parent: self)
+                Familia::UnsortedSet.new(index_key, parent: self, class: indexed_class, reference: true)
               end
             end
           end
@@ -412,7 +412,7 @@ module Familia
               # string to ensure consistent type handling in key construction.
               validated = MultiIndexGenerators.validate_field_value(field_value, context: "#{name}.#{idx_name}")
               index_key = Familia.join(index_name, validated)
-              Familia::UnsortedSet.new(index_key, parent: self)
+              Familia::UnsortedSet.new(index_key, parent: self, class: indexed_class, reference: true)
             end
           end
 
@@ -510,9 +510,7 @@ module Familia
                     next unless field_value && !field_value.to_s.strip.empty?
 
                     index_set = send("#{index_name}_for", field_value)
-                    # Use JsonSerializer for consistent serialization with update method
-                    serialized_id = Familia::JsonSerializer.dump(obj.identifier)
-                    conn.sadd(index_set.dbkey, serialized_id)
+                    conn.sadd(index_set.dbkey, index_set.serialize_value(obj.identifier))
                   end
                 end
 

--- a/try/features/relationships/multi_index_each_record_try.rb
+++ b/try/features/relationships/multi_index_each_record_try.rb
@@ -1,0 +1,211 @@
+# try/features/relationships/multi_index_each_record_try.rb
+#
+# frozen_string_literal: true
+
+# Tests for issue #301: multi_index UnsortedSets were created without
+# `class:` or `reference:` options, so identifiers were JSON-encoded
+# (e.g. "u1" stored as "\"u1\""). This broke:
+#   - each_record (requires @opts[:class] to load records)
+#   - member?(object) (Familia objects bypass JSON encoding in
+#     serialize_value, producing a raw string that doesn't match
+#     the JSON-encoded value in Redis)
+#
+# The fix adds `class: indexed_class, reference: true` to both
+# instance-scoped and class-level multi_index factory methods.
+
+require_relative '../../support/helpers/test_helpers'
+
+class MIERCustomer < Familia::Horreum
+  feature :relationships
+
+  identifier_field :custid
+  field :custid
+  field :role
+
+  multi_index :role, :role_index
+
+  class_sorted_set :instances, reference: true
+end
+
+class MIERCompany < Familia::Horreum
+  feature :relationships
+
+  identifier_field :company_id
+  field :company_id
+
+  class_sorted_set :instances, reference: true
+end
+
+class MIEREmployee < Familia::Horreum
+  feature :relationships
+
+  identifier_field :emp_id
+  field :emp_id
+  field :department
+
+  multi_index :department, :dept_index, within: MIERCompany
+  participates_in MIERCompany, :employees, score: :emp_id
+
+  class_sorted_set :instances, reference: true
+end
+
+# Setup - class-level
+[MIERCustomer, MIEREmployee, MIERCompany].each do |klass|
+  existing = Familia.dbclient.keys("#{klass.prefix}:*")
+  Familia.dbclient.del(*existing) if existing.any?
+  klass.instances.clear if klass.respond_to?(:instances)
+end
+
+@c1 = MIERCustomer.new(custid: 'c1', role: 'admin')
+@c1.save
+@c2 = MIERCustomer.new(custid: 'c2', role: 'admin')
+@c2.save
+@c3 = MIERCustomer.new(custid: 'c3', role: 'user')
+@c3.save
+
+# Setup - instance-scoped
+@company = MIERCompany.new(company_id: 'co1')
+@company.save
+@e1 = MIEREmployee.new(emp_id: 'e1', department: 'eng')
+@e1.save
+@e1.add_to_mier_company_employees(@company)
+@e1.add_to_mier_company_dept_index(@company)
+@e2 = MIEREmployee.new(emp_id: 'e2', department: 'eng')
+@e2.save
+@e2.add_to_mier_company_employees(@company)
+@e2.add_to_mier_company_dept_index(@company)
+@e3 = MIEREmployee.new(emp_id: 'e3', department: 'sales')
+@e3.save
+@e3.add_to_mier_company_employees(@company)
+@e3.add_to_mier_company_dept_index(@company)
+
+# ============================================================
+# Class-level multi_index UnsortedSet is a proper reference type
+# ============================================================
+
+## Class-level multi_index UnsortedSet carries the indexed class
+MIERCustomer.role_index_for('admin').opts[:class]
+#=> MIERCustomer
+
+## Class-level multi_index UnsortedSet is a reference type
+MIERCustomer.role_index_for('admin').opts[:reference]
+#=> true
+
+## Stored values are raw identifiers (not JSON-encoded)
+raw = MIERCustomer.dbclient.smembers(MIERCustomer.role_index_for('admin').dbkey)
+raw.sort
+#=> ["c1", "c2"]
+
+# ============================================================
+# each_record on class-level multi_index (issue #301)
+# ============================================================
+
+## each_record yields Horreum records
+records = []
+MIERCustomer.role_index_for('admin').each_record { |r| records << r }
+records.all? { |r| r.is_a?(MIERCustomer) }
+#=> true
+
+## each_record yields every indexed record
+records = []
+MIERCustomer.role_index_for('admin').each_record { |r| records << r }
+records.map(&:custid).sort
+#=> ["c1", "c2"]
+
+## each_record returns an Enumerator when no block is given
+MIERCustomer.role_index_for('admin').each_record.class
+#=> Enumerator
+
+## each_record Enumerator composes with Enumerable
+MIERCustomer.role_index_for('admin').each_record.map(&:custid).sort
+#=> ["c1", "c2"]
+
+## each_record honors batch_size
+records = []
+MIERCustomer.role_index_for('admin').each_record(batch_size: 1) { |r| records << r }
+records.map(&:custid).sort
+#=> ["c1", "c2"]
+
+## each_record skips ghost entries (stale identifier in set)
+admin_set = MIERCustomer.role_index_for('admin')
+admin_set.add('c-ghost')
+records = []
+admin_set.each_record { |r| records << r }
+result = records.map(&:custid).sort
+admin_set.remove('c-ghost')
+result
+#=> ["c1", "c2"]
+
+## each_record on a different field value
+records = []
+MIERCustomer.role_index_for('user').each_record { |r| records << r }
+records.map(&:custid)
+#=> ["c3"]
+
+# ============================================================
+# member?(object) on class-level multi_index (issue #301)
+# ============================================================
+
+## member? with a Familia object returns true when present
+MIERCustomer.role_index_for('admin').member?(@c1)
+#=> true
+
+## member? with a Familia object returns false when absent
+MIERCustomer.role_index_for('user').member?(@c1)
+#=> false
+
+## member? with a string identifier returns true when present
+MIERCustomer.role_index_for('admin').member?('c1')
+#=> true
+
+## member? with a string identifier returns false when absent
+MIERCustomer.role_index_for('admin').member?('nonexistent')
+#=> false
+
+# ============================================================
+# Instance-scoped multi_index
+# ============================================================
+
+## Instance-scoped multi_index UnsortedSet carries the indexed class
+@company.dept_index_for('eng').opts[:class]
+#=> MIEREmployee
+
+## Instance-scoped multi_index UnsortedSet is a reference type
+@company.dept_index_for('eng').opts[:reference]
+#=> true
+
+## Instance-scoped stored values are raw identifiers
+raw = Familia.dbclient.smembers(@company.dept_index_for('eng').dbkey)
+raw.sort
+#=> ["e1", "e2"]
+
+## each_record on instance-scoped multi_index yields indexed employees
+records = []
+@company.dept_index_for('eng').each_record { |r| records << r }
+records.map(&:emp_id).sort
+#=> ["e1", "e2"]
+
+## each_record on different field value
+records = []
+@company.dept_index_for('sales').each_record { |r| records << r }
+records.map(&:emp_id)
+#=> ["e3"]
+
+## member? with Familia object on instance-scoped multi_index
+@company.dept_index_for('eng').member?(@e1)
+#=> true
+
+## member? with absent object on instance-scoped multi_index
+@company.dept_index_for('sales').member?(@e1)
+#=> false
+
+## member? with string identifier on instance-scoped multi_index
+@company.dept_index_for('eng').member?('e2')
+#=> true
+
+# Teardown
+[MIERCustomer, MIEREmployee, MIERCompany].each do |klass|
+  existing = Familia.dbclient.keys("#{klass.prefix}:*")
+  Familia.dbclient.del(*existing) if existing.any?
+  klass.instances.clear if klass.respond_to?(:instances)
+end


### PR DESCRIPTION
## Summary
Fixes issue #301 where `multi_index` UnsortedSets were created without `class:` and `reference:` options, causing identifiers to be JSON-encoded in Redis. This broke `each_record()` (which requires `@opts[:class]` to load records) and `member?(object)` (which failed to match JSON-encoded values against raw Familia objects).

## Key Changes
- **Instance-scoped multi_index factory method**: Updated `generate_factory_method` to accept `indexed_class` parameter and pass `class: indexed_class, reference: true` when creating UnsortedSet instances
- **Class-level multi_index factory method**: Updated `generate_factory_method_class` to pass `class: indexed_class, reference: true` when creating UnsortedSet instances
- **Identifier serialization**: Removed unnecessary JSON serialization in query methods that was causing mismatches between stored and compared values

## Implementation Details
- Both instance-scoped and class-level multi_index factory methods now properly configure UnsortedSet with the indexed class and reference flag
- This ensures identifiers are stored as raw strings (e.g., "u1") rather than JSON-encoded strings (e.g., "\"u1\"")
- The `reference: true` flag enables proper handling of Familia objects in membership checks
- Added comprehensive test coverage in `multi_index_each_record_try.rb` validating:
  - `each_record()` yields proper Horreum records
  - `member?(object)` works with both Familia objects and string identifiers
  - Both class-level and instance-scoped multi_indexes function correctly

https://claude.ai/code/session_01GbC7ACxo5USqerj63BJ8ML