### PR TITLE
Fix four regressions in relationships indexing and sorted sets

### DIFF
--- a/changelog.d/20260614_000000_anthropic_loving-johnson.rst
+++ b/changelog.d/20260614_000000_anthropic_loving-johnson.rst
@@ -1,0 +1,33 @@
+Fixed
+-----
+
+- ``SortedSet#members(n)`` / ``#revmembers(n)`` returned one fewer element than
+  requested. Both ``members`` and ``membersraw`` decremented the count, so a
+  positive ``n`` resolved to ``n-1`` elements (``ListKey#members`` was already
+  correct). The count math now happens once.
+
+- Generated participation permission queries
+  (``<collection>_with_permission``) were dead code: they called
+  ``SortedSet#zrangebyscore`` (which does not exist) with a fallback that also
+  raised, and a score-range query cannot filter by permission anyway (permission
+  bits live in the fractional part of the score and are not a contiguous range).
+  The query now fetches members with scores and filters each via
+  ``ScoreEncoding.permission?``.
+
+- Class-level ``Model.destroy!(id)`` left unique-index entries orphaned (the
+  instance ``#destroy!`` already cleaned them). A stale ``find_by_<field>`` could
+  resolve a deleted record, and the freed value could not be reused because the
+  unique guard still saw the orphan. ``destroy!`` now loads the record before the
+  transaction and removes its class-level index entries atomically.
+
+- Changing a ``unique_index`` field value and saving left the old value's index
+  entry orphaned. Auto-indexing on save is now old-value-aware (via dirty
+  tracking) for unique indexes: the previous value's mapping is removed in the
+  same save transaction. ``multi_index`` keeps its existing add-only semantics.
+
+AI Assistance
+-------------
+
+- These four fixes, their failing-first tryouts, and this changelog were drafted
+  with AI assistance during a code review of the relationships and data-type
+  subsystems.

--- a/lib/familia/data_type/types/sorted_set.rb
+++ b/lib/familia/data_type/types/sorted_set.rb
@@ -205,7 +205,8 @@ module Familia
     end
 
     def members(count = -1, opts = {})
-      count -= 1 if count.positive?
+      # NOTE: count math (positive count -> end index) is handled once by
+      # membersraw. Do not decrement here too, or members(n) returns n-1.
       elements = membersraw count, opts
       deserialize_values(*elements)
     end
@@ -218,7 +219,8 @@ module Familia
     end
 
     def revmembers(count = -1, opts = {})
-      count -= 1 if count.positive?
+      # See #members: revmembersraw already converts a positive count to the
+      # correct end index; decrementing here as well would drop one element.
       elements = revmembersraw count, opts
       deserialize_values(*elements)
     end

--- a/lib/familia/features/relationships/participation/target_methods.rb
+++ b/lib/familia/features/relationships/participation/target_methods.rb
@@ -233,13 +233,16 @@ collection_name: collection_name)
             target_class.define_method(method_name) do |min_permission = :read|
               collection = send(collection_name)
 
-              # Assumes ScoreEncoding module is available
-              if defined?(ScoreEncoding)
-                permission_score = ScoreEncoding.permission_encode(0, min_permission)
-                collection.zrangebyscore(permission_score, '+inf', with_scores: true)
-              else
-                # Fallback to all members if ScoreEncoding not available
-                collection.members(with_scores: true)
+              # Permission bits are encoded in the FRACTIONAL part of each score
+              # (see ScoreEncoding) and do not form a contiguous range, so a
+              # score-range query (e.g. ZRANGEBYSCORE x +inf) cannot filter by
+              # permission -- it would match members regardless of their bits.
+              # Fetch every member with its score and test the bits per-member.
+              raw_pairs = collection.rangebyscoreraw('-inf', '+inf', with_scores: true)
+              raw_pairs.each_with_object([]) do |(raw_member, score), kept|
+                next unless ScoreEncoding.permission?(score, min_permission)
+
+                kept << collection.deserialize_value(raw_member)
               end
             end
           end

--- a/lib/familia/horreum/management.rb
+++ b/lib/familia/horreum/management.rb
@@ -576,6 +576,15 @@ module Familia
 
         objkey = dbkey identifier, suffix
 
+        # Load the object BEFORE the transaction so its field values are available
+        # for class-level index cleanup. Removing a unique-index entry needs the
+        # field value (e.g. email) to HDEL the right mapping, and reads cannot run
+        # inside MULTI/EXEC. If the hash is already gone (nil) we skip index
+        # cleanup -- without the field values the entries to remove are unknowable.
+        # This mirrors the instance #destroy! (which calls remove_from_class_indexes!)
+        # so both destroy paths leave indexes consistent (see issue #241).
+        loaded = find_by_dbkey(objkey, check_exists: false)
+
         # Execute all deletion operations within a transaction
         transaction do |conn|
           # Clean up related fields first to avoid orphaned keys
@@ -597,6 +606,10 @@ module Familia
           # Delete the main object key
           ret = conn.del(objkey)
           Familia.trace :DESTROY!, nil, "#{objkey} #{ret.inspect}" if Familia.debug?
+
+          # Clean up class-level index entries (same as instance #destroy!).
+          # Routes its HDELs into this open transaction via Fiber[:familia_transaction].
+          loaded&.send(:remove_from_class_indexes!)
 
           # Remove from instances collection to avoid ghost entries
           instances.remove(identifier) if respond_to?(:instances)

--- a/lib/familia/horreum/persistence.rb
+++ b/lib/familia/horreum/persistence.rb
@@ -823,16 +823,25 @@ module Familia
         nil # Explicit nil return as documented
       end
 
-      # Automatically update class-level indexes after save
+      # Automatically maintains class-level indexes after save.
       #
-      # Iterates through class-level indexing relationships and calls their
-      # corresponding add_to_class_* methods to populate indexes. Only processes
-      # class-level indexes (where within is nil), skipping instance-scoped
-      # indexes which require scope context.
+      # Iterates the class-level indexing relationships and applies the
+      # appropriate index mutation for each (see #apply_class_index_change).
+      # Only class-level indexes are processed here; instance-scoped indexes
+      # (declared with within: a class) require a scope instance and must be
+      # populated explicitly.
       #
-      # Uses idempotent Redis commands (HSET for unique_index) so repeated calls
-      # are safe and have negligible performance overhead. Note that multi_index
-      # always requires within: parameter, so only unique_index benefits from this.
+      # The previous value of each changed field is read from dirty tracking,
+      # which is still populated at this point (clear_dirty! runs AFTER the save
+      # transaction), so a changed indexed field can have its stale entry removed
+      # in the same transaction:
+      #
+      # - unique_index: routes through update_in_class_* (old-value-aware
+      #   HDEL + HSET) so changing an indexed field removes the prior mapping
+      #   atomically and the freed value can be reused.
+      # - multi_index: routes through add_to_class_* (add-only); prior buckets
+      #   are intentionally retained on a value change (see the
+      #   class_level_multi_index tests).
       #
       # @return [void]
       #
@@ -843,12 +852,13 @@ module Familia
       #   end
       #
       #   customer = Customer.new(email: 'test@example.com')
-      #   customer.save  # Automatically calls add_to_class_email_lookup
+      #   customer.save  # Automatically calls update_in_class_email_lookup
       #
-      # @note Only class-level unique_index declarations auto-populate.
-      #   Instance-scoped indexes (with within:) require manual population:
+      # @note Only class-level declarations auto-populate. Instance-scoped
+      #   indexes (with within:) require manual population:
       #   employee.add_to_company_badge_index(company)
       #
+      # @see #apply_class_index_change For the per-relationship routing.
       # @see Familia::Features::Relationships::Indexing For index declaration details
       #
       def auto_update_class_indexes

--- a/lib/familia/horreum/persistence.rb
+++ b/lib/familia/horreum/persistence.rb
@@ -854,6 +854,13 @@ module Familia
       def auto_update_class_indexes
         return unless self.class.respond_to?(:indexing_relationships)
 
+        # Dirty tracking is still populated here: clear_dirty! runs AFTER the save
+        # transaction, while this method runs INSIDE it (via persist_to_storage).
+        # Both `new` and the load path clear dirty after construction, so a
+        # captured old value is the previously-persisted value -- exactly what we
+        # must remove from the index when an indexed field changed.
+        changes = changed_fields # { field => [old_value, new_value] }
+
         self.class.indexing_relationships.each do |rel|
           unless rel.class_level?
             Familia.debug <<~LOG_MESSAGE
@@ -862,11 +869,36 @@ module Familia
             next
           end
 
-          # Call the existing add_to_class_* methods
-          add_method = :"add_to_class_#{rel.index_name}"
-          send(add_method) if respond_to?(add_method)
+          apply_class_index_change(rel, changes)
         end
       end
+
+      # Maintains a single class-level index entry for +rel+ during save.
+      #
+      # @param rel [IndexingRelationship] a class-level indexing relationship
+      # @param changes [Hash] dirty-tracking diff { field => [old_value, new_value] }
+      # @return [void]
+      def apply_class_index_change(rel, changes)
+        update_method = :"update_in_class_#{rel.index_name}"
+        add_method = :"add_to_class_#{rel.index_name}"
+
+        if rel.cardinality == :unique && respond_to?(update_method)
+          # unique_index: use the old-value-aware update so a changed indexed
+          # field removes its stale entry. Otherwise find_by_<field>(old_value)
+          # resolves a tombstone and the freed value cannot be reused (the unique
+          # guard sees the orphan). update_in_class_* always re-adds the current
+          # value, so new records are still indexed; its reentrant transaction
+          # joins this save's MULTI, so remove+add commit atomically.
+          change = changes[rel.field]
+          send(update_method, change && change.first)
+        elsif respond_to?(add_method)
+          # multi_index (and any add-only index): a value change does not retract
+          # prior buckets -- by design (see class_level_multi_index tests).
+          # HSET/SADD are idempotent so repeated saves stay safe.
+          send(add_method)
+        end
+      end
+      private :apply_class_index_change
 
       # Remove class-level index entries during destroy!
       #

--- a/try/bug_fixes/class_destroy_index_cleanup_try.rb
+++ b/try/bug_fixes/class_destroy_index_cleanup_try.rb
@@ -1,0 +1,50 @@
+# try/bug_fixes/class_destroy_index_cleanup_try.rb
+#
+# frozen_string_literal: true
+
+# Regression: the instance method `obj.destroy!` cleans class-level unique-index
+# entries (via remove_from_class_indexes!), but the class method
+# `Model.destroy!(id)` did NOT -- it only deleted the hash, related fields, and
+# the instances entry. That left the unique index pointing at a now-deleted
+# record, so `find_by_<field>(old_value)` resolved to a tombstone.
+
+require_relative '../support/helpers/test_helpers'
+
+class ::DestroyIdxUser < Familia::Horreum
+  feature :relationships
+  include Familia::Features::Relationships::Indexing
+
+  identifier_field :uid
+  field :uid
+  field :email
+
+  unique_index :email, :email_lookup
+end
+
+@u = DestroyIdxUser.new(uid: 'du1', email: 'del@example.com')
+@u.save
+
+## sanity: the unique index resolves the record before destroy
+DestroyIdxUser.find_by_email('del@example.com')&.uid
+#=> "du1"
+
+## class-level destroy! removes the object hash
+DestroyIdxUser.destroy!('du1')
+DestroyIdxUser.exists?('du1')
+#=> false
+
+## the index hashkey no longer maps the stale value to the dead id
+DestroyIdxUser.email_lookup.get('del@example.com')
+#=> nil
+
+## find_by_<field> on the old value returns nil (no tombstone)
+DestroyIdxUser.find_by_email('del@example.com')
+#=> nil
+
+## the freed email can be reused by a new record (orphan would block this)
+@u2 = DestroyIdxUser.new(uid: 'du2', email: 'del@example.com')
+@u2.save
+DestroyIdxUser.find_by_email('del@example.com')&.uid
+#=> "du2"
+
+DestroyIdxUser.destroy!('du2')

--- a/try/bug_fixes/permission_query_try.rb
+++ b/try/bug_fixes/permission_query_try.rb
@@ -1,0 +1,64 @@
+# try/bug_fixes/permission_query_try.rb
+#
+# frozen_string_literal: true
+
+# Regression: the generated `<collection>_with_permission` query method was dead
+# code. It called `collection.zrangebyscore` (SortedSet only defines
+# `rangebyscore`) and a fallback `members(with_scores: true)` (members takes a
+# positional count), so it raised NoMethodError/ArgumentError unconditionally.
+#
+# It was also semantically wrong: permission bits live in the fractional part of
+# the score and are NOT a contiguous range, so a `[score, +inf]` range query
+# matches members regardless of their actual permission bits. Filtering must be
+# done per-member via ScoreEncoding.permission?.
+
+require_relative '../support/helpers/test_helpers'
+
+SE = Familia::Features::Relationships::ScoreEncoding
+
+class ::PermTarget < Familia::Horreum
+  feature :relationships
+  identifier_field :tid
+  field :tid
+  field :name
+end
+
+class ::PermParticipant < Familia::Horreum
+  feature :relationships
+  identifier_field :pid
+  field :pid
+  participates_in PermTarget, :widgets, type: :sorted_set
+end
+
+@target = PermTarget.new(tid: "perm_target_1", name: "T")
+@target.save
+@target.widgets.delete!
+
+# Members stored with permission-encoded scores (timestamp.permission_bits)
+now = Familia.now
+@target.widgets.add("w_read",  SE.encode_score(now, [:read]))            # read
+@target.widgets.add("w_write", SE.encode_score(now, [:read, :write]))   # read + write
+@target.widgets.add("w_admin", SE.encode_score(now, [:read, :admin]))   # read + admin
+
+## the sorted_set participation generates a *_with_permission method
+@target.respond_to?(:widgets_with_permission)
+#=> true
+
+## widgets_with_permission(:read) returns every member that has the read bit
+@target.widgets_with_permission(:read).sort
+#=> ["w_admin", "w_read", "w_write"]
+
+## widgets_with_permission(:write) returns only members with the write bit
+@target.widgets_with_permission(:write).sort
+#=> ["w_write"]
+
+## widgets_with_permission(:admin) returns only members with the admin bit
+@target.widgets_with_permission(:admin)
+#=> ["w_admin"]
+
+## defaults to :read when no permission given
+@target.widgets_with_permission.sort
+#=> ["w_admin", "w_read", "w_write"]
+
+@target.widgets.delete!
+@target.destroy!

--- a/try/bug_fixes/sorted_set_members_count_try.rb
+++ b/try/bug_fixes/sorted_set_members_count_try.rb
@@ -1,0 +1,40 @@
+# try/bug_fixes/sorted_set_members_count_try.rb
+#
+# frozen_string_literal: true
+
+# Regression: SortedSet#members(n) / #revmembers(n) returned one fewer element
+# than requested because both #members and #membersraw decremented the count
+# (double-decrement). ListKey#members does not have this bug. A positive count
+# is a "give me N elements" request, so members(5) must return 5 elements.
+
+require_relative '../support/helpers/test_helpers'
+
+@zset = Familia::SortedSet.new('bug_fixes:zset:members_count')
+@zset.delete!
+(1..10).each { |i| @zset.add("m#{i.to_s.rjust(2, '0')}", i.to_f) }
+
+## members(n) returns exactly n elements (not n-1)
+@zset.members(5).size
+#=> 5
+
+## membersraw(n) returns exactly n elements (not n-1)
+@zset.membersraw(3).size
+#=> 3
+
+## revmembers(n) returns exactly n elements (not n-1)
+@zset.revmembers(4).size
+#=> 4
+
+## members(1) returns exactly 1 element (the lowest-scored)
+@zset.members(1)
+#=> ["m01"]
+
+## members with no argument returns all elements
+@zset.members.size
+#=> 10
+
+## members(n) returns the n lowest-scored members in order
+@zset.members(3)
+#=> ["m01", "m02", "m03"]
+
+@zset.delete!

--- a/try/bug_fixes/stale_unique_index_try.rb
+++ b/try/bug_fixes/stale_unique_index_try.rb
@@ -1,0 +1,54 @@
+# try/bug_fixes/stale_unique_index_try.rb
+#
+# frozen_string_literal: true
+
+# Regression: changing the value of a unique-indexed field and saving left the
+# OLD value's index entry orphaned. On save, only `add_to_class_<index>` ran
+# (HSET new -> id) and nothing removed the previous value's mapping. As a result
+# `find_by_<field>(old_value)` still resolved to the record (whose field had
+# changed), and the freed old value could not be reused by another record
+# (the unique guard saw the orphan and raised RecordExistsError).
+
+require_relative '../support/helpers/test_helpers'
+
+class ::StaleIdxUser < Familia::Horreum
+  feature :relationships
+  include Familia::Features::Relationships::Indexing
+
+  identifier_field :uid
+  field :uid
+  field :email
+
+  unique_index :email, :email_lookup
+end
+
+@u = StaleIdxUser.new(uid: 'su1', email: 'old@example.com')
+@u.save
+
+## sanity: the original email resolves before the change
+StaleIdxUser.find_by_email('old@example.com')&.uid
+#=> "su1"
+
+## after loading, changing the indexed field, and saving, the new value resolves
+@loaded = StaleIdxUser.find_by_id('su1')
+@loaded.email = 'new@example.com'
+@loaded.save
+StaleIdxUser.find_by_email('new@example.com')&.uid
+#=> "su1"
+
+## the index hashkey no longer contains the old value (no orphan)
+StaleIdxUser.email_lookup.get('old@example.com')
+#=> nil
+
+## find_by_<field>(old_value) no longer resolves to the (now-changed) record
+StaleIdxUser.find_by_email('old@example.com')&.uid
+#=> nil
+
+## the freed old value can be claimed by a different record
+@u2 = StaleIdxUser.new(uid: 'su2', email: 'old@example.com')
+@u2.save
+StaleIdxUser.find_by_email('old@example.com')&.uid
+#=> "su2"
+
+@u.destroy! rescue nil
+@u2.destroy! rescue nil

--- a/try/unit/horreum/auto_indexing_on_save_try.rb
+++ b/try/unit/horreum/auto_indexing_on_save_try.rb
@@ -101,13 +101,15 @@ AutoIndexUser.username_index.get('testuser')
 AutoIndexUser.email_index.get('test@example.com')
 #=> @user_id
 
-## Changing indexed field and saving adds new entry (old entry remains unless manually removed)
-# Note: Auto-indexing is idempotent addition only - updates require manual update_in_class_* calls
+## Changing a unique-indexed field and saving removes the stale entry
+# unique_index auto-update is old-value-aware (via dirty tracking): the previous
+# value's mapping is removed in the same save transaction so find_by_<field> can
+# never resolve a tombstone and the freed value can be reused.
 @user.email = 'newemail@example.com'
 @user.save
-# New email is indexed, but old email remains (expected behavior - use update_in_class_* for proper updates)
+# Old email mapping is gone; new email is indexed.
 [AutoIndexUser.email_index.has_key?('test@example.com'), AutoIndexUser.email_index.get('newemail@example.com') == @user_id]
-#=> [true, true]
+#=> [false, true]
 
 # =============================================
 # 2. Instance-Scoped Indexes (Manual Only)
@@ -155,14 +157,13 @@ AutoIndexUser.find_by_email('create@example.com')&.user_id
 AutoIndexUser.email_index.get('create@example.com')
 #=> @user2_id
 
-## Field update followed by save adds new entry (use update_in_class_* for proper updates)
+## Field update followed by save removes the old unique-index value automatically
 old_email = @user2.email
 @user2.email = 'updated@example.com'
 @user2.save
-# Both old and new emails are indexed (auto-indexing doesn't remove old values)
-# For proper updates that remove old values, use: @user2.update_in_class_email_index(old_email)
+# Old value mapping is removed in the same save; new value is indexed.
 [AutoIndexUser.email_index.has_key?(old_email), AutoIndexUser.email_index.get('updated@example.com') == @user2_id]
-#=> [true, true]
+#=> [false, true]
 
 # =============================================
 # 4. Integration with Other Features


### PR DESCRIPTION
This PR fixes four distinct bugs in the relationships and data-type subsystems that were discovered during code review:

## Summary
Four regressions affecting class-level indexing, permission queries, and sorted set operations are fixed with improved dirty-tracking awareness and corrected API usage.

## Key Changes

**1. SortedSet members count off-by-one**
- `SortedSet#members(n)` and `#revmembers(n)` returned `n-1` elements due to double-decrementing the count
- Both the wrapper methods and `membersraw`/`revmembersraw` were decrementing; now only the raw methods do
- Fixes: `lib/familia/data_type/types/sorted_set.rb`

**2. Permission query dead code**
- Generated `<collection>_with_permission` methods called non-existent `SortedSet#zrangebyscore` 
- Score-range queries cannot filter by permission bits (they live in the fractional part and aren't contiguous)
- Now fetches all members with scores and filters each via `ScoreEncoding.permission?`
- Fixes: `lib/familia/features/relationships/participation/target_methods.rb`

**3. Class-level destroy leaves orphaned index entries**
- `Model.destroy!(id)` did not clean unique-index entries (instance `#destroy!` did)
- Stale `find_by_<field>` could resolve deleted records; freed values couldn't be reused
- Now loads the record before the transaction and removes its index entries atomically
- Fixes: `lib/familia/horreum/management.rb`

**4. Unique index field updates leave stale entries**
- Changing a `unique_index` field and saving left the old value's mapping orphaned
- Auto-indexing on save is now old-value-aware via dirty tracking for unique indexes
- The previous value is removed in the same transaction; `multi_index` keeps add-only semantics
- Fixes: `lib/familia/horreum/persistence.rb` (new `apply_class_index_change` method)

## Implementation Details

- **Dirty tracking integration**: `auto_update_class_indexes` now captures `changed_fields` before the transaction to access old values (dirty tracking is cleared after save)
- **Unique vs multi index distinction**: New `apply_class_index_change` method routes unique indexes through `update_in_class_*` (old-value-aware) and multi indexes through `add_to_class_*` (add-only)
- **Transaction atomicity**: Index cleanup in `Model.destroy!` joins the existing transaction via `Fiber[:familia_transaction]` so remove+add operations commit together
- **Tryout coverage**: Four new tryout files demonstrate each fix with before/after assertions

## Testing
- Existing unit tests updated to reflect corrected behavior
- Four new tryout files validate each fix independently
- Changelog entry documents all four fixes and AI assistance

https://claude.ai/code/session_01VM5rftKoSdW5W1UvpQFCV1