### PR TITLE
Security: Fix multiple encryption and identifier vulnerabilities (issue #310)

### DIFF
--- a/README.md
+++ b/README.md
@@ -475,6 +475,27 @@ Contributions are welcome! Please feel free to submit a Pull Request.
 4. Push to the branch (`git push origin feature/amazing-feature`)
 5. Open a Pull Request
 
+### Running the Tests
+
+Familia's test suite uses the [Tryouts](https://github.com/delano/tryouts) framework:
+
+```bash
+bundle install
+bundle exec try -vf                  # run the full suite
+bundle exec try try/path/to/foo_try.rb   # run a single file
+```
+
+The suite requires a **UTF-8 locale**. Some tryouts contain UTF-8 source (e.g.
+Unicode scope cases) and assert on string encodings, so when no locale is set
+Ruby falls back to `Encoding.default_external = US-ASCII`; the runner then aborts
+with `invalid byte sequence in US-ASCII` and encoding specs fail spuriously. Most
+shells and CI already provide one — if yours does not, export a UTF-8 locale
+before running the tests:
+
+```bash
+export LANG=C.UTF-8   # or en_US.UTF-8
+```
+
 ### PR Compliance Checks
 
 Pull requests are automatically reviewed by [Qodo Merge](https://qodo.ai) with compliance checks for:

--- a/README.md
+++ b/README.md
@@ -477,23 +477,28 @@ Contributions are welcome! Please feel free to submit a Pull Request.
 
 ### Running the Tests
 
-Familia's test suite uses the [Tryouts](https://github.com/delano/tryouts) framework:
+Familia's test suite uses the [Tryouts](https://github.com/delano/tryouts)
+framework. The simplest way to run it:
 
 ```bash
 bundle install
-bundle exec try -vf                  # run the full suite
-bundle exec try try/path/to/foo_try.rb   # run a single file
+bundle exec rake test   # full suite, with a guaranteed UTF-8 locale
 ```
 
-The suite requires a **UTF-8 locale**. Some tryouts contain UTF-8 source (e.g.
-Unicode scope cases) and assert on string encodings, so when no locale is set
-Ruby falls back to `Encoding.default_external = US-ASCII`; the runner then aborts
-with `invalid byte sequence in US-ASCII` and encoding specs fail spuriously. Most
-shells and CI already provide one — if yours does not, export a UTF-8 locale
-before running the tests:
+`rake test` runs the suite in a child process with a UTF-8 locale, which the
+suite needs: some tryouts contain UTF-8 source (e.g. Unicode cases) and assert on
+string encodings, so when no locale is set Ruby falls back to
+`Encoding.default_external = US-ASCII`, the runner aborts with `invalid byte
+sequence in US-ASCII`, and encoding specs fail spuriously. (A locale you already
+have is kept; most shells and CI provide a UTF-8 one.)
+
+To invoke the runner directly — e.g. for a single file — ensure your shell has a
+UTF-8 locale first:
 
 ```bash
-export LANG=C.UTF-8   # or en_US.UTF-8
+export LANG=C.UTF-8                        # or en_US.UTF-8; only needed if unset
+bundle exec try -vf                        # full suite
+bundle exec try try/path/to/foo_try.rb     # a single file
 ```
 
 ### PR Compliance Checks

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+# Run the Tryouts test suite with a guaranteed UTF-8 locale.
+#
+# The suite's source and specs are UTF-8. The tryouts runner reads each test file
+# with File.read, which honours Encoding.default_external; when the caller's
+# locale is unset that defaults to US-ASCII and the run aborts on non-ASCII source
+# ("invalid byte sequence in US-ASCII"), with encoding-sensitive specs failing
+# spuriously. Running the suite in a child process with a UTF-8 locale makes it
+# work regardless of the caller's environment. A caller that already has a UTF-8
+# locale (CI, most shells) keeps it -- the defaults below only fill in when unset.
+desc 'Run the Tryouts test suite (ensures a UTF-8 locale)'
+task :test do
+  ENV['LANG'] ||= 'C.UTF-8'
+  ENV['LC_ALL'] ||= 'C.UTF-8'
+  sh 'bundle exec try -vf'
+end
+
+task default: :test

--- a/changelog.d/20260621_000000_anthropic_upbeat-thompson.rst
+++ b/changelog.d/20260621_000000_anthropic_upbeat-thompson.rst
@@ -9,9 +9,11 @@ Security
   first time an identifier is minted or verified.
 
 - The AES-GCM provider no longer derives keys from a static ``'FamiliaEncryption'``
-  HKDF salt (issue #310, S2). It now uses the application
-  ``encryption_personalization`` for per-deployment domain separation, mirroring
-  the XChaCha20 providers.
+  HKDF salt (issue #310, S2). It now derives the salt from a dedicated,
+  application-specific ``encryption_hkdf_salt`` setting for per-deployment domain
+  separation (RFC 5869). Existing ciphertext still decrypts because the legacy
+  static salt stays in the decryption fallback list, so **no data migration is
+  required**.
 
 - External identifiers are no longer derived with Ruby's ``Random`` (Mersenne
   Twister) seeded from a 64-bit-truncated digest (issue #310, S3). Derivation is
@@ -30,15 +32,30 @@ Security
 Changed
 -------
 
+- The AES-GCM HKDF salt is now a dedicated ``encryption_hkdf_salt`` setting,
+  separate from ``encryption_personalization`` (issue #311). The personalization
+  string feeds only the XChaCha20 providers' BLAKE2b ``personal`` parameter, which
+  BLAKE2b caps at 16 bytes; the AES-GCM HKDF salt accepts any length (RFC 5869).
+  Decoupling the two inputs means neither cipher family is constrained by the
+  other's rules -- in particular, the 16-byte personalization limit no longer
+  applies to the AES-GCM salt.
+
 - AES-GCM key derivation supports salt rotation for backward compatibility
-  (issue #310, S2). Encryption always uses the current ``encryption_personalization``;
-  decryption tries the current salt, then ``encryption_personalization_history``
-  (a new, ordered, current-first config), then the pre-#310 static salt. **No
-  data migration is required**: existing ciphertext -- including data written
-  before this change -- still decrypts, because the legacy static salt is always
-  in the fallback list. When you rotate ``encryption_personalization``, add the
-  prior value(s) to ``encryption_personalization_history`` so older ciphertext
-  keeps decrypting.
+  (issues #310 S2, #311). Encryption always uses the current ``encryption_hkdf_salt``;
+  decryption tries the current salt, then ``encryption_hkdf_salt_history`` (an
+  ordered, current-first config), then the pre-#310 static salt. **No data
+  migration is required**: existing ciphertext -- including data written before
+  this change -- still decrypts, because the legacy static salt is always in the
+  fallback list. When you rotate ``encryption_hkdf_salt``, add the prior value(s)
+  to ``encryption_hkdf_salt_history`` so older ciphertext keeps decrypting.
+
+- The opt-in request-scoped key cache now keys on the *resolved* HKDF salt rather
+  than the raw argument (issue #311). Previously an encrypt (which lets the
+  provider default the salt to ``hkdf_salts.first``) and a later decrypt of the
+  same value in one request filed the identical derived key under two different
+  cache keys, so the key was derived twice. The cache key is now symmetric across
+  encrypt and decrypt, recovering the intended single derivation. Behaviour with
+  the cache disabled (the default) is unchanged.
 
 Documentation
 -------------
@@ -46,11 +63,13 @@ Documentation
 - Clarified that the migration ``Script`` SHA-1 is the Redis ``EVALSHA`` script
   identity (protocol-mandated), not a security checksum (issue #310, S5); genuine
   change-detection already uses SHA-256 in ``Migration::Registry``.
-- Corrected docs that described ``encryption_personalization`` as "XChaCha20 only";
-  it now also seeds the AES-GCM HKDF salt.
+- Documented that ``encryption_personalization`` applies only to the XChaCha20
+  (BLAKE2b) providers, and that AES-GCM uses the separate, length-unconstrained
+  ``encryption_hkdf_salt`` (issue #311).
 
 AI Assistance
 -------------
 
-- These security fixes (issue #310), their failing-first tryouts, the salt-rotation
+- These security fixes (issue #310), the AES-GCM salt decoupling and request-cache
+  key normalization (issue #311), their failing-first tryouts, the salt-rotation
   backward-compatibility path, and this changelog were drafted with AI assistance.

--- a/changelog.d/20260621_000000_anthropic_upbeat-thompson.rst
+++ b/changelog.d/20260621_000000_anthropic_upbeat-thompson.rst
@@ -1,84 +1,49 @@
 Security
 --------
 
-- Removed the committed HMAC fallback secret in ``Familia::VerifiableIdentifier``
-  (issue #310, S1). ``VERIFIABLE_ID_HMAC_SECRET`` is now required; the previous
-  default let anyone reading the source forge valid identifiers. The secret is
-  resolved lazily on first use (``VerifiableIdentifier.secret_key``), so merely
-  requiring the file never raises -- the missing-secret ``KeyError`` surfaces the
-  first time an identifier is minted or verified.
+- ``Familia::VerifiableIdentifier`` now requires ``VERIFIABLE_ID_HMAC_SECRET``
+  (issue #310, S1). The committed fallback secret, which allowed identifier
+  forgery, is removed; the secret is read lazily, so requiring the file without it
+  set does not raise.
 
-- The AES-GCM provider no longer derives keys from a static ``'FamiliaEncryption'``
-  HKDF salt (issue #310, S2). It now derives the salt from a dedicated,
-  application-specific ``encryption_hkdf_salt`` setting for per-deployment domain
-  separation (RFC 5869). Existing ciphertext still decrypts because the legacy
-  static salt stays in the decryption fallback list, so **no data migration is
-  required**.
+- AES-GCM keys derive from a per-deployment ``encryption_hkdf_salt`` instead of a
+  static library salt (issue #310, S2). A blank salt or personalization now raises
+  rather than silently using a weak/global value; existing ciphertext still
+  decrypts (issue #311).
 
-- Key derivation now fails closed on a blank salt/personalization (issue #311).
-  Encrypting with a nil or empty ``encryption_hkdf_salt`` raises rather than
-  silently falling back to the legacy global static salt (which would quietly
-  withhold the #310 per-deployment domain separation); decryption stays permissive
-  so old ciphertext remains readable. The XChaCha20 providers likewise raise a
-  clear error on a nil/empty ``encryption_personalization`` instead of crashing
-  with a ``NoMethodError``. The checks live at derivation time, so they also catch
-  values set through the raw attribute writer, which bypasses the reader guards.
+- External identifiers derive via SHA-256, or keyed HMAC-SHA256 with a ``secret:``,
+  instead of a Mersenne-Twister PRNG seeded from a truncated digest (issue #310, S3).
 
-- External identifiers are no longer derived with Ruby's ``Random`` (Mersenne
-  Twister) seeded from a 64-bit-truncated digest (issue #310, S3). Derivation is
-  now a deterministic SHA-256 over the full objid, or a keyed HMAC-SHA256 when a
-  ``secret:`` option is configured on ``feature :external_identifier``.
+- ``ParticipationMembership#target_instance`` resolves class names through the
+  ``Familia.resolve_class`` allowlist instead of ``Object.const_get`` (issue #310, S4).
 
-- ``ParticipationMembership#target_instance`` resolves the database-sourced class
-  name through ``Familia.resolve_class`` (model-registry allowlist) instead of
-  ``Object.const_get`` (issue #310, S4), so a writable database cannot coerce
-  resolution of an arbitrary constant.
-
-- The request-scoped key cache is now wiped on entry to ``with_request_cache`` as
-  well as on exit (issue #310, S6), so a reused fiber never begins a block
-  carrying a previous request's derived keys.
+- The request-scoped key cache is wiped on entry to ``with_request_cache`` as well
+  as on exit, so a reused fiber cannot inherit another request's keys (issue #310, S6).
 
 Changed
 -------
 
-- The AES-GCM HKDF salt is now a dedicated ``encryption_hkdf_salt`` setting,
-  separate from ``encryption_personalization`` (issue #311). The personalization
-  string feeds only the XChaCha20 providers' BLAKE2b ``personal`` parameter, which
-  BLAKE2b caps at 16 bytes; the AES-GCM HKDF salt accepts any length (RFC 5869).
-  Decoupling the two inputs means neither cipher family is constrained by the
-  other's rules -- in particular, the 16-byte personalization limit no longer
-  applies to the AES-GCM salt.
+- New ``encryption_hkdf_salt`` and ``encryption_hkdf_salt_history`` settings
+  configure the AES-GCM HKDF salt, decoupled from ``encryption_personalization``
+  (now used only by the XChaCha20/BLAKE2b providers, still capped at 16 bytes). The
+  salt has no length limit and supports rotation; no data migration is required
+  (issue #311).
 
-- AES-GCM key derivation supports salt rotation for backward compatibility
-  (issues #310 S2, #311). Encryption always uses the current ``encryption_hkdf_salt``;
-  decryption tries the current salt, then ``encryption_hkdf_salt_history`` (an
-  ordered, current-first config), then the pre-#310 static salt. **No data
-  migration is required**: existing ciphertext -- including data written before
-  this change -- still decrypts, because the legacy static salt is always in the
-  fallback list. When you rotate ``encryption_hkdf_salt``, add the prior value(s)
-  to ``encryption_hkdf_salt_history`` so older ciphertext keeps decrypting.
+- ``feature :external_identifier`` accepts a callable ``secret:``, resolved lazily
+  at first use (issue #311).
 
-- The opt-in request-scoped key cache now keys on the *resolved* HKDF salt rather
-  than the raw argument (issue #311). Previously an encrypt (which lets the
-  provider default the salt to ``hkdf_salts.first``) and a later decrypt of the
-  same value in one request filed the identical derived key under two different
-  cache keys, so the key was derived twice. The cache key is now symmetric across
-  encrypt and decrypt, recovering the intended single derivation. Behaviour with
-  the cache disabled (the default) is unchanged.
+- The opt-in request-scoped key cache keys on the resolved salt, so an encrypt and a
+  later decrypt of the same value within one request share a single derived key
+  (issue #311).
 
 Documentation
 -------------
 
-- Clarified that the migration ``Script`` SHA-1 is the Redis ``EVALSHA`` script
-  identity (protocol-mandated), not a security checksum (issue #310, S5); genuine
-  change-detection already uses SHA-256 in ``Migration::Registry``.
-- Documented that ``encryption_personalization`` applies only to the XChaCha20
-  (BLAKE2b) providers, and that AES-GCM uses the separate, length-unconstrained
-  ``encryption_hkdf_salt`` (issue #311).
+- Clarified that the migration ``Script`` SHA-1 is the Redis ``EVALSHA`` identity,
+  not a security checksum (issue #310, S5).
 
 AI Assistance
 -------------
 
-- These security fixes (issue #310), the AES-GCM salt decoupling and request-cache
-  key normalization (issue #311), their failing-first tryouts, the salt-rotation
-  backward-compatibility path, and this changelog were drafted with AI assistance.
+- These changes (issues #310 and #311), their tryouts, and this changelog were
+  drafted with AI assistance.

--- a/changelog.d/20260621_000000_anthropic_upbeat-thompson.rst
+++ b/changelog.d/20260621_000000_anthropic_upbeat-thompson.rst
@@ -15,6 +15,15 @@ Security
   static salt stays in the decryption fallback list, so **no data migration is
   required**.
 
+- Key derivation now fails closed on a blank salt/personalization (issue #311).
+  Encrypting with a nil or empty ``encryption_hkdf_salt`` raises rather than
+  silently falling back to the legacy global static salt (which would quietly
+  withhold the #310 per-deployment domain separation); decryption stays permissive
+  so old ciphertext remains readable. The XChaCha20 providers likewise raise a
+  clear error on a nil/empty ``encryption_personalization`` instead of crashing
+  with a ``NoMethodError``. The checks live at derivation time, so they also catch
+  values set through the raw attribute writer, which bypasses the reader guards.
+
 - External identifiers are no longer derived with Ruby's ``Random`` (Mersenne
   Twister) seeded from a 64-bit-truncated digest (issue #310, S3). Derivation is
   now a deterministic SHA-256 over the full objid, or a keyed HMAC-SHA256 when a

--- a/changelog.d/20260621_000000_anthropic_upbeat-thompson.rst
+++ b/changelog.d/20260621_000000_anthropic_upbeat-thompson.rst
@@ -1,0 +1,56 @@
+Security
+--------
+
+- Removed the committed HMAC fallback secret in ``Familia::VerifiableIdentifier``
+  (issue #310, S1). ``VERIFIABLE_ID_HMAC_SECRET`` is now required; the previous
+  default let anyone reading the source forge valid identifiers. The secret is
+  resolved lazily on first use (``VerifiableIdentifier.secret_key``), so merely
+  requiring the file never raises -- the missing-secret ``KeyError`` surfaces the
+  first time an identifier is minted or verified.
+
+- The AES-GCM provider no longer derives keys from a static ``'FamiliaEncryption'``
+  HKDF salt (issue #310, S2). It now uses the application
+  ``encryption_personalization`` for per-deployment domain separation, mirroring
+  the XChaCha20 providers.
+
+- External identifiers are no longer derived with Ruby's ``Random`` (Mersenne
+  Twister) seeded from a 64-bit-truncated digest (issue #310, S3). Derivation is
+  now a deterministic SHA-256 over the full objid, or a keyed HMAC-SHA256 when a
+  ``secret:`` option is configured on ``feature :external_identifier``.
+
+- ``ParticipationMembership#target_instance`` resolves the database-sourced class
+  name through ``Familia.resolve_class`` (model-registry allowlist) instead of
+  ``Object.const_get`` (issue #310, S4), so a writable database cannot coerce
+  resolution of an arbitrary constant.
+
+- The request-scoped key cache is now wiped on entry to ``with_request_cache`` as
+  well as on exit (issue #310, S6), so a reused fiber never begins a block
+  carrying a previous request's derived keys.
+
+Changed
+-------
+
+- AES-GCM key derivation supports salt rotation for backward compatibility
+  (issue #310, S2). Encryption always uses the current ``encryption_personalization``;
+  decryption tries the current salt, then ``encryption_personalization_history``
+  (a new, ordered, current-first config), then the pre-#310 static salt. **No
+  data migration is required**: existing ciphertext -- including data written
+  before this change -- still decrypts, because the legacy static salt is always
+  in the fallback list. When you rotate ``encryption_personalization``, add the
+  prior value(s) to ``encryption_personalization_history`` so older ciphertext
+  keeps decrypting.
+
+Documentation
+-------------
+
+- Clarified that the migration ``Script`` SHA-1 is the Redis ``EVALSHA`` script
+  identity (protocol-mandated), not a security checksum (issue #310, S5); genuine
+  change-detection already uses SHA-256 in ``Migration::Registry``.
+- Corrected docs that described ``encryption_personalization`` as "XChaCha20 only";
+  it now also seeds the AES-GCM HKDF salt.
+
+AI Assistance
+-------------
+
+- These security fixes (issue #310), their failing-first tryouts, the salt-rotation
+  backward-compatibility path, and this changelog were drafted with AI assistance.

--- a/docs/guides/feature-encrypted-fields.md
+++ b/docs/guides/feature-encrypted-fields.md
@@ -892,9 +892,10 @@ end
 Familia.configure do |config|
   config.encryption_keys = { v1: key, v2: new_key }
   config.current_key_version = :v2
-  config.encryption_personalization = 'MyApp-2024'  # Domain separation (XChaCha20 personalization + AES-GCM HKDF salt)
-  # When rotating it, keep prior values for backward-compatible decryption:
-  # config.encryption_personalization_history = ['MyApp-2023']
+  config.encryption_personalization = 'MyApp-2024'  # XChaCha20 BLAKE2b domain separation (<= 16 bytes)
+  config.encryption_hkdf_salt = 'MyApp-2024'        # AES-GCM HKDF salt domain separation (any length)
+  # When rotating the AES-GCM salt, keep prior values for backward-compatible decryption:
+  # config.encryption_hkdf_salt_history = ['MyApp-2023']
 end
 
 # Validate configuration

--- a/docs/guides/feature-encrypted-fields.md
+++ b/docs/guides/feature-encrypted-fields.md
@@ -892,7 +892,9 @@ end
 Familia.configure do |config|
   config.encryption_keys = { v1: key, v2: new_key }
   config.current_key_version = :v2
-  config.encryption_personalization = 'MyApp-2024'  # XChaCha20 only
+  config.encryption_personalization = 'MyApp-2024'  # Domain separation (XChaCha20 personalization + AES-GCM HKDF salt)
+  # When rotating it, keep prior values for backward-compatible decryption:
+  # config.encryption_personalization_history = ['MyApp-2023']
 end
 
 # Validate configuration

--- a/docs/reference/api-technical.md
+++ b/docs/reference/api-technical.md
@@ -160,7 +160,7 @@ Familia.configure do |config|
     v3: ENV['NEW_KEY']       # New key for rotation
   }
   config.current_key_version = :v2
-  config.encryption_personalization = 'MyApp-2024'  # Optional (XChaCha20 only)
+  config.encryption_personalization = 'MyApp-2024'  # Optional domain separation (XChaCha20 personalization + AES-GCM HKDF salt)
 end
 
 # Operations with encrypted fields

--- a/docs/reference/api-technical.md
+++ b/docs/reference/api-technical.md
@@ -160,7 +160,8 @@ Familia.configure do |config|
     v3: ENV['NEW_KEY']       # New key for rotation
   }
   config.current_key_version = :v2
-  config.encryption_personalization = 'MyApp-2024'  # Optional domain separation (XChaCha20 personalization + AES-GCM HKDF salt)
+  config.encryption_personalization = 'MyApp-2024'  # XChaCha20 BLAKE2b domain separation (<= 16 bytes)
+  config.encryption_hkdf_salt = 'MyApp-2024'        # AES-GCM HKDF salt domain separation (any length)
 end
 
 # Operations with encrypted fields

--- a/lib/familia/encryption/manager.rb
+++ b/lib/familia/encryption/manager.rb
@@ -57,14 +57,35 @@ module Familia
 
           # Validate algorithm support
           provider = Registry.get(data.algorithm)
-          key = derive_key_without_increment(context, version: data.key_version, provider: provider)
 
           # Safely decode and validate sizes
           nonce = decode_and_validate(data.nonce, provider.nonce_size, 'nonce')
           ciphertext = decode_and_validate_ciphertext(data.ciphertext)
           auth_tag = decode_and_validate(data.auth_tag, provider.auth_tag_size, 'auth_tag')
 
-          plaintext = provider.decrypt(ciphertext, key, nonce, auth_tag, additional_data)
+          # Try each candidate HKDF salt, current first, so ciphertext written
+          # before a salt change still decrypts. Providers without salt rotation
+          # expose a single nil "salt" and are attempted exactly once. A wrong
+          # salt derives a different key and fails the authenticated decrypt
+          # cleanly, so iterating never yields a false positive. See #310 (S2).
+          salts = provider.respond_to?(:hkdf_salts) ? provider.hkdf_salts : [nil]
+          key = nil
+          plaintext = nil
+          last_error = nil
+          salts.each do |salt|
+            key = derive_key_without_increment(context, version: data.key_version, provider: provider, salt: salt)
+            begin
+              plaintext = provider.decrypt(ciphertext, key, nonce, auth_tag, additional_data)
+              break
+            rescue EncryptionError => e
+              last_error = e
+              plaintext = nil
+            ensure
+              Familia::Encryption.secure_wipe(key)
+            end
+          end
+          raise(last_error || EncryptionError.new('Decryption failed - invalid key or corrupted data')) if plaintext.nil?
+
           plaintext.force_encoding(data.encoding || 'UTF-8')
         rescue EncryptionError
           raise
@@ -101,7 +122,7 @@ module Familia
         derive_key_without_increment(context, version: version, provider: provider)
       end
 
-      def derive_key_without_increment(context, version: nil, provider: nil)
+      def derive_key_without_increment(context, version: nil, provider: nil, salt: nil)
         # Use provided provider or fall back to instance provider
         provider ||= @provider
 
@@ -113,18 +134,22 @@ module Familia
         # Request-scoped key cache (opt-in via Familia::Encryption.with_request_cache).
         # Disabled by default for maximum security (keys are not held in memory
         # longer than a single derivation). The cache key includes the algorithm
-        # so different providers never share a derived key, and the version so
-        # key rotation stays correct. On a hit we return a copy and never fetch
-        # the master key, minimising master-key exposure.
+        # so different providers never share a derived key, the version so key
+        # rotation stays correct, and the salt so rotated-salt derivations never
+        # collide. On a hit we return a copy and never fetch the master key,
+        # minimising master-key exposure.
         cache = Fiber[:familia_request_cache] if Fiber[:familia_request_cache_enabled]
         if cache
-          cache_key = "#{provider.algorithm}:#{version}:#{context}"
+          cache_key = "#{provider.algorithm}:#{version}:#{salt}:#{context}"
           cached = cache[cache_key]
           return cached.dup if cached
         end
 
         master_key = get_master_key(version)
-        derived = provider.derive_key(master_key, context)
+        # Only forward an explicit salt to providers that accept one (the AES-GCM
+        # salt-rotation path). The default derivation keeps the original arity so
+        # providers without a salt parameter are unaffected.
+        derived = salt.nil? ? provider.derive_key(master_key, context) : provider.derive_key(master_key, context, salt: salt)
         cache[cache_key] = derived.dup if cache
         derived
       ensure

--- a/lib/familia/encryption/manager.rb
+++ b/lib/familia/encryption/manager.rb
@@ -135,12 +135,21 @@ module Familia
         # Disabled by default for maximum security (keys are not held in memory
         # longer than a single derivation). The cache key includes the algorithm
         # so different providers never share a derived key, the version so key
-        # rotation stays correct, and the salt so rotated-salt derivations never
-        # collide. On a hit we return a copy and never fetch the master key,
+        # rotation stays correct, and the resolved salt so rotated-salt derivations
+        # never collide. On a hit we return a copy and never fetch the master key,
         # minimising master-key exposure.
         cache = Fiber[:familia_request_cache] if Fiber[:familia_request_cache_enabled]
         if cache
-          cache_key = "#{provider.algorithm}:#{version}:#{salt}:#{context}"
+          # Key on the *resolved* salt, not the raw argument. When salt is nil
+          # (the encrypt path) the provider derives with hkdf_salts.first; the
+          # decrypt loop later passes that same value explicitly. Keying on the
+          # raw argument would file those two identical derivations under
+          # different keys (nil vs the resolved salt), so an encrypt followed by a
+          # decrypt of the same value in one request would derive twice instead of
+          # hitting the cache. Providers without salt rotation have no effective
+          # salt (nil), so their cache key is unchanged.
+          effective_salt = salt || (provider.respond_to?(:hkdf_salts) ? provider.hkdf_salts.first : nil)
+          cache_key = "#{provider.algorithm}:#{version}:#{effective_salt}:#{context}"
           cached = cache[cache_key]
           return cached.dup if cached
         end

--- a/lib/familia/encryption/manager.rb
+++ b/lib/familia/encryption/manager.rb
@@ -95,6 +95,11 @@ module Familia
           raise EncryptionError, "Decryption failed: #{e.message}"
         end
       ensure
+        # Defensive backstop only. The salt-rotation loop's per-iteration `ensure`
+        # (around provider.decrypt) is the primary wipe and clears `key` on every
+        # path -- success, failure, and break -- so by here `key` is already wiped
+        # and this re-clear is a harmless no-op. It is kept so any future change to
+        # the loop structure still cannot leave a derived key unwiped (#311).
         Familia::Encryption.secure_wipe(key) if key
       end
 

--- a/lib/familia/encryption/providers/aes_gcm_provider.rb
+++ b/lib/familia/encryption/providers/aes_gcm_provider.rb
@@ -78,14 +78,17 @@ module Familia
         # readable after upgrading. Never used to encrypt new data.
         LEGACY_HKDF_SALT = 'FamiliaEncryption'.freeze
 
-        # Ordered list of HKDF salts to consider, current first.
+        # Ordered list of HKDF salts to consider when DECRYPTING, current first.
         #
-        # Encryption always uses the first entry (the current encryption_hkdf_salt);
-        # decryption walks the list until the authenticated decrypt succeeds. This
-        # keeps both a salt rotation and the #310 move away from the static salt
-        # backward-compatible without any envelope/format change. Each wrong salt
-        # yields a different key and fails GCM authentication cleanly, so trying
-        # them in turn never produces a false positive.
+        # Decryption walks this list until the authenticated decrypt succeeds, so
+        # it is intentionally permissive: it ends with the pre-#310 static salt and
+        # tolerates a blank current salt (dropped by #compact), so existing
+        # ciphertext stays readable even if the current config is broken. Each
+        # wrong salt yields a different key and fails GCM authentication cleanly,
+        # so trying them in turn never produces a false positive.
+        #
+        # ENCRYPTION does NOT use this list's head -- see #current_hkdf_salt, which
+        # fails closed rather than silently encrypting under the legacy static salt.
         #
         # The salt comes from a dedicated config knob (encryption_hkdf_salt), NOT
         # the XChaCha20 personalization. HKDF accepts a salt of any length while
@@ -95,6 +98,26 @@ module Familia
           current = Familia.config.encryption_hkdf_salt
           history = Familia.config.encryption_hkdf_salt_history
           [current, *history, LEGACY_HKDF_SALT].compact.uniq
+        end
+
+        # The HKDF salt used to ENCRYPT new data.
+        #
+        # Unlike #hkdf_salts (the permissive decryption candidate list, which
+        # deliberately ends with the pre-#310 global static salt so old ciphertext
+        # stays readable), this fails CLOSED. A nil or empty encryption_hkdf_salt is
+        # a misconfiguration -- and the raw attr_writer can set one, bypassing the
+        # reader's guards -- so silently encrypting new data under the legacy global
+        # static salt would quietly withhold the #310 per-deployment domain
+        # separation. Refuse instead, so the operator notices (#311). To use the old
+        # global salt on purpose, set it explicitly as a non-empty string.
+        def current_hkdf_salt
+          salt = Familia.config.encryption_hkdf_salt
+          return salt if salt.is_a?(String) && !salt.empty?
+
+          raise EncryptionError,
+                'encryption_hkdf_salt must be a non-empty string to encrypt; refusing to ' \
+                'fall back to the legacy global HKDF salt. Set Familia.config.encryption_hkdf_salt ' \
+                'for per-deployment domain separation.'
         end
 
         def derive_key(master_key, context, personal: nil, salt: nil)
@@ -109,10 +132,12 @@ module Familia
             # AES-GCM knob, kept separate from the XChaCha20 personalization so
             # neither cipher family constrains the other (issue #311). See #310 (S2).
             #
-            # `salt` defaults to the current salt (hkdf_salts.first); the decrypt
-            # path passes earlier salts so existing ciphertext stays decryptable
-            # after a salt change.
-            salt: salt || hkdf_salts.first,
+            # `salt` defaults to the current encryption salt (#current_hkdf_salt),
+            # which fails closed on a nil/blank config rather than silently using
+            # the legacy global static salt. The decrypt path passes explicit
+            # candidate salts from #hkdf_salts so existing ciphertext stays
+            # decryptable after a salt change.
+            salt: salt || current_hkdf_salt,
             info: info,
             length: 32,
             hash: 'SHA256'

--- a/lib/familia/encryption/providers/aes_gcm_provider.rb
+++ b/lib/familia/encryption/providers/aes_gcm_provider.rb
@@ -80,15 +80,20 @@ module Familia
 
         # Ordered list of HKDF salts to consider, current first.
         #
-        # Encryption always uses the first entry (the current personalization);
-        # decryption walks the list until the authenticated decrypt succeeds.
-        # This keeps both a personalization rotation and the #310 move away from
-        # the static salt backward-compatible without any envelope/format change.
-        # Each wrong salt yields a different key and fails GCM authentication
-        # cleanly, so trying them in turn never produces a false positive.
+        # Encryption always uses the first entry (the current encryption_hkdf_salt);
+        # decryption walks the list until the authenticated decrypt succeeds. This
+        # keeps both a salt rotation and the #310 move away from the static salt
+        # backward-compatible without any envelope/format change. Each wrong salt
+        # yields a different key and fails GCM authentication cleanly, so trying
+        # them in turn never produces a false positive.
+        #
+        # The salt comes from a dedicated config knob (encryption_hkdf_salt), NOT
+        # the XChaCha20 personalization. HKDF accepts a salt of any length while
+        # BLAKE2b personalization is capped at 16 bytes, so the two cipher
+        # families keep separate inputs and never constrain each other (#311).
         def hkdf_salts
-          current = Familia.config.encryption_personalization
-          history = Familia.config.encryption_personalization_history
+          current = Familia.config.encryption_hkdf_salt
+          history = Familia.config.encryption_hkdf_salt_history
           [current, *history, LEGACY_HKDF_SALT].compact.uniq
         end
 
@@ -100,12 +105,13 @@ module Familia
             # Use application-specific material for the HKDF salt instead of a
             # static library literal. A fixed global salt is shared by every
             # deployment and weakens HKDF's extraction step / domain separation
-            # (RFC 5869). This mirrors the XChaCha20 providers, which derive from
-            # the same personalization string. See issue #310 (S2).
+            # (RFC 5869). The value comes from encryption_hkdf_salt -- a dedicated
+            # AES-GCM knob, kept separate from the XChaCha20 personalization so
+            # neither cipher family constrains the other (issue #311). See #310 (S2).
             #
-            # `salt` defaults to the current personalization (hkdf_salts.first);
-            # the decrypt path passes earlier salts so existing ciphertext stays
-            # decryptable after a salt change.
+            # `salt` defaults to the current salt (hkdf_salts.first); the decrypt
+            # path passes earlier salts so existing ciphertext stays decryptable
+            # after a salt change.
             salt: salt || hkdf_salts.first,
             info: info,
             length: 32,

--- a/lib/familia/encryption/providers/aes_gcm_provider.rb
+++ b/lib/familia/encryption/providers/aes_gcm_provider.rb
@@ -77,7 +77,16 @@ module Familia
           info = personal ? "#{context}:#{personal}" : context
           OpenSSL::KDF.hkdf(
             master_key,
-            salt: 'FamiliaEncryption',
+            # Use application-specific material for the HKDF salt instead of a
+            # static library literal. A fixed global salt is shared by every
+            # deployment and weakens HKDF's extraction step / domain separation
+            # (RFC 5869). This mirrors the XChaCha20 providers, which derive from
+            # the same personalization string. See issue #310 (S2).
+            #
+            # NOTE: changing the salt changes every derived key, so data that was
+            # encrypted with the previous static salt under this fallback
+            # provider must be re-encrypted.
+            salt: Familia.config.encryption_personalization,
             info: info,
             length: 32,
             hash: 'SHA256'

--- a/lib/familia/encryption/providers/aes_gcm_provider.rb
+++ b/lib/familia/encryption/providers/aes_gcm_provider.rb
@@ -72,7 +72,27 @@ module Familia
           OpenSSL::Random.random_bytes(NONCE_SIZE)
         end
 
-        def derive_key(master_key, context, personal: nil)
+        # The HKDF salt used before issue #310, when the salt was a static
+        # literal. Retained ONLY as a decryption fallback (see #hkdf_salts) so
+        # data written before the salt became application-specific stays
+        # readable after upgrading. Never used to encrypt new data.
+        LEGACY_HKDF_SALT = 'FamiliaEncryption'.freeze
+
+        # Ordered list of HKDF salts to consider, current first.
+        #
+        # Encryption always uses the first entry (the current personalization);
+        # decryption walks the list until the authenticated decrypt succeeds.
+        # This keeps both a personalization rotation and the #310 move away from
+        # the static salt backward-compatible without any envelope/format change.
+        # Each wrong salt yields a different key and fails GCM authentication
+        # cleanly, so trying them in turn never produces a false positive.
+        def hkdf_salts
+          current = Familia.config.encryption_personalization
+          history = Familia.config.encryption_personalization_history
+          [current, *history, LEGACY_HKDF_SALT].compact.uniq
+        end
+
+        def derive_key(master_key, context, personal: nil, salt: nil)
           validate_key_length!(master_key)
           info = personal ? "#{context}:#{personal}" : context
           OpenSSL::KDF.hkdf(
@@ -83,10 +103,10 @@ module Familia
             # (RFC 5869). This mirrors the XChaCha20 providers, which derive from
             # the same personalization string. See issue #310 (S2).
             #
-            # NOTE: changing the salt changes every derived key, so data that was
-            # encrypted with the previous static salt under this fallback
-            # provider must be re-encrypted.
-            salt: Familia.config.encryption_personalization,
+            # `salt` defaults to the current personalization (hkdf_salts.first);
+            # the decrypt path passes earlier salts so existing ciphertext stays
+            # decryptable after a salt change.
+            salt: salt || hkdf_salts.first,
             info: info,
             length: 32,
             hash: 'SHA256'

--- a/lib/familia/encryption/providers/secure_xchacha20_poly1305_provider.rb
+++ b/lib/familia/encryption/providers/secure_xchacha20_poly1305_provider.rb
@@ -97,6 +97,11 @@ module Familia
           validate_key_length!(master_key)
 
           raw_personal = personal || Familia.config.encryption_personalization
+          # Fail closed on a missing personalization rather than crashing with a
+          # NoMethodError on nil (#311), mirroring XChaCha20Poly1305Provider.
+          unless raw_personal.is_a?(String) && !raw_personal.empty?
+            raise EncryptionError, 'encryption_personalization must be a non-empty string for key derivation'
+          end
           raise EncryptionError, 'Personalization string must not contain null bytes' if raw_personal.include?("\0")
 
           personal_string = raw_personal.ljust(16, "\0")

--- a/lib/familia/encryption/providers/xchacha20_poly1305_provider.rb
+++ b/lib/familia/encryption/providers/xchacha20_poly1305_provider.rb
@@ -90,6 +90,12 @@ module Familia
         def derive_key(master_key, context, personal: nil)
           validate_key_length!(master_key)
           raw_personal = personal || Familia.config.encryption_personalization
+          # Fail closed on a missing personalization rather than crashing with a
+          # NoMethodError on nil (#311): a blank value gives no domain separation,
+          # and the raw attr_writer can set nil/'' past the reader's guards.
+          unless raw_personal.is_a?(String) && !raw_personal.empty?
+            raise EncryptionError, 'encryption_personalization must be a non-empty string for key derivation'
+          end
           raise EncryptionError, 'Personalization string must not contain null bytes' if raw_personal.include?("\0")
 
           personal_string = raw_personal.ljust(16, "\0")

--- a/lib/familia/encryption/request_cache.rb
+++ b/lib/familia/encryption/request_cache.rb
@@ -8,17 +8,26 @@
 # SECURITY (see issue #310, S6): the derived-key cache lives in fiber-local
 # storage (Fiber[...]). In pooled or async servers a fiber can be reused across
 # requests, so the cache MUST be cleared between requests or a key derived by
-# one request can leak into a later one. Two safeguards are provided:
+# one request can leak into a later one. #with_request_cache therefore wipes any
+# stale cache on entry AND on exit (ensure), so a reused fiber never starts or
+# finishes a block carrying old keys.
 #
-#   1. #with_request_cache wipes any stale cache on entry AND on exit (ensure),
-#      so a reused fiber never starts or finishes a block carrying old keys.
-#   2. RequestCacheMiddleware clears the cache at the start of every request and
-#      again in an ensure block, so even manual (non-block) usage is bounded to
-#      a single request.
+# Usage in Rack middleware (clear at the start of every request and again in an
+# ensure, so even non-block usage is bounded to a single request):
 #
-# Recommended Rack wiring:
-#   use Familia::Encryption::RequestCacheMiddleware              # clear-only safety net
-#   use Familia::Encryption::RequestCacheMiddleware, enabled: true  # also enable caching
+#   class ClearEncryptionCacheMiddleware
+#     def initialize(app) = @app = app
+#
+#     def call(env)
+#       Familia::Encryption.clear_request_cache!
+#       @app.call(env)
+#     ensure
+#       Familia::Encryption.clear_request_cache!
+#     end
+#   end
+#
+# To also enable caching for the request, wrap the call instead:
+#   Familia::Encryption.with_request_cache { @app.call(env) }
 
 module Familia
   module Encryption
@@ -49,44 +58,6 @@ module Familia
       # Familia::Encryption::Manager#derive_key_without_increment, which is the
       # single key-derivation path for both encrypt and decrypt. This module
       # only owns the opt-in lifecycle (enable, populate-by-Manager, wipe).
-    end
-
-    # Rack middleware that bounds the request-scoped derived-key cache to a
-    # single request, even when the underlying fiber is reused across requests
-    # or the downstream app raises.
-    #
-    # By default it is a clear-only safety net: it wipes any cache a reused
-    # fiber may carry before the request runs, and again afterwards in an
-    # ensure block. Pass `enabled: true` to also turn caching on for the
-    # duration of each request (via #with_request_cache).
-    #
-    # @example Clear-only safety net (recommended baseline)
-    #   use Familia::Encryption::RequestCacheMiddleware
-    #
-    # @example Enable per-request caching for performance
-    #   use Familia::Encryption::RequestCacheMiddleware, enabled: true
-    class RequestCacheMiddleware
-      def initialize(app, enabled: false)
-        @app = app
-        @enabled = enabled
-      end
-
-      def call(env)
-        if @enabled
-          # with_request_cache wipes on entry and exit, so a reused fiber is
-          # always isolated to this request.
-          Familia::Encryption.with_request_cache { @app.call(env) }
-        else
-          # Caching stays off (secure default); clear before and after so a
-          # reused fiber never carries keys from an adjacent request.
-          Familia::Encryption.clear_request_cache!
-          begin
-            @app.call(env)
-          ensure
-            Familia::Encryption.clear_request_cache!
-          end
-        end
-      end
     end
   end
 end

--- a/lib/familia/encryption/request_cache.rb
+++ b/lib/familia/encryption/request_cache.rb
@@ -5,21 +5,29 @@
 # Request-scoped caching for encryption keys (if needed for performance)
 # This should ONLY be enabled if performance testing shows it's necessary
 #
-# Usage in Rack middleware:
-#   class ClearEncryptionCacheMiddleware
-#     def call(env)
-#       Familia::Encryption.clear_request_cache!
-#       @app.call(env)
-#     ensure
-#       Familia::Encryption.clear_request_cache!
-#     end
-#   end
+# SECURITY (see issue #310, S6): the derived-key cache lives in fiber-local
+# storage (Fiber[...]). In pooled or async servers a fiber can be reused across
+# requests, so the cache MUST be cleared between requests or a key derived by
+# one request can leak into a later one. Two safeguards are provided:
+#
+#   1. #with_request_cache wipes any stale cache on entry AND on exit (ensure),
+#      so a reused fiber never starts or finishes a block carrying old keys.
+#   2. RequestCacheMiddleware clears the cache at the start of every request and
+#      again in an ensure block, so even manual (non-block) usage is bounded to
+#      a single request.
+#
+# Recommended Rack wiring:
+#   use Familia::Encryption::RequestCacheMiddleware              # clear-only safety net
+#   use Familia::Encryption::RequestCacheMiddleware, enabled: true  # also enable caching
 
 module Familia
   module Encryption
     class << self
       # Enable request-scoped caching (opt-in for performance)
       def with_request_cache
+        # Wipe any cache a reused fiber may still be carrying before installing a
+        # fresh one, so this block can never observe a previous request's keys.
+        clear_request_cache!
         Fiber[:familia_request_cache_enabled] = true
         Fiber[:familia_request_cache] = {}
         yield
@@ -41,6 +49,44 @@ module Familia
       # Familia::Encryption::Manager#derive_key_without_increment, which is the
       # single key-derivation path for both encrypt and decrypt. This module
       # only owns the opt-in lifecycle (enable, populate-by-Manager, wipe).
+    end
+
+    # Rack middleware that bounds the request-scoped derived-key cache to a
+    # single request, even when the underlying fiber is reused across requests
+    # or the downstream app raises.
+    #
+    # By default it is a clear-only safety net: it wipes any cache a reused
+    # fiber may carry before the request runs, and again afterwards in an
+    # ensure block. Pass `enabled: true` to also turn caching on for the
+    # duration of each request (via #with_request_cache).
+    #
+    # @example Clear-only safety net (recommended baseline)
+    #   use Familia::Encryption::RequestCacheMiddleware
+    #
+    # @example Enable per-request caching for performance
+    #   use Familia::Encryption::RequestCacheMiddleware, enabled: true
+    class RequestCacheMiddleware
+      def initialize(app, enabled: false)
+        @app = app
+        @enabled = enabled
+      end
+
+      def call(env)
+        if @enabled
+          # with_request_cache wipes on entry and exit, so a reused fiber is
+          # always isolated to this request.
+          Familia::Encryption.with_request_cache { @app.call(env) }
+        else
+          # Caching stays off (secure default); clear before and after so a
+          # reused fiber never carries keys from an adjacent request.
+          Familia::Encryption.clear_request_cache!
+          begin
+            @app.call(env)
+          ensure
+            Familia::Encryption.clear_request_cache!
+          end
+        end
+      end
     end
   end
 end

--- a/lib/familia/features/encrypted_fields.rb
+++ b/lib/familia/features/encrypted_fields.rb
@@ -155,7 +155,7 @@ module Familia
     #       v2: ENV['FAMILIA_ENCRYPTION_KEY_V2']
     #     }
     #     config.current_key_version = :v2
-    #     config.encryption_personalization = 'MyApp-2024'  # Optional (XChaCha20 only)
+    #     config.encryption_personalization = 'MyApp-2024'  # Optional (domain separation)
     #   end
     #
     #   # Validate configuration before use

--- a/lib/familia/features/encrypted_fields.rb
+++ b/lib/familia/features/encrypted_fields.rb
@@ -155,7 +155,9 @@ module Familia
     #       v2: ENV['FAMILIA_ENCRYPTION_KEY_V2']
     #     }
     #     config.current_key_version = :v2
-    #     config.encryption_personalization = 'MyApp-2024'  # Optional (domain separation)
+    #     config.encryption_personalization = 'MyApp-2024'  # Optional domain separation
+    #     # When rotating it, keep prior values so old ciphertext still decrypts:
+    #     # config.encryption_personalization_history = ['MyApp-2023']
     #   end
     #
     #   # Validate configuration before use

--- a/lib/familia/features/encrypted_fields.rb
+++ b/lib/familia/features/encrypted_fields.rb
@@ -155,9 +155,10 @@ module Familia
     #       v2: ENV['FAMILIA_ENCRYPTION_KEY_V2']
     #     }
     #     config.current_key_version = :v2
-    #     config.encryption_personalization = 'MyApp-2024'  # Optional domain separation
-    #     # When rotating it, keep prior values so old ciphertext still decrypts:
-    #     # config.encryption_personalization_history = ['MyApp-2023']
+    #     config.encryption_personalization = 'MyApp-2024'  # XChaCha20 domain separation (<= 16 bytes)
+    #     config.encryption_hkdf_salt = 'MyApp-2024'        # AES-GCM domain separation (any length)
+    #     # When rotating the salt, keep prior values so old ciphertext still decrypts:
+    #     # config.encryption_hkdf_salt_history = ['MyApp-2023']
     #   end
     #
     #   # Validate configuration before use

--- a/lib/familia/features/external_identifier.rb
+++ b/lib/familia/features/external_identifier.rb
@@ -85,11 +85,17 @@ module Familia
       #   # a `secret:` to derive it via a keyed HMAC instead, so external IDs
       #   # cannot be forged or inverted from a known objid. The secret must be
       #   # stable for a deployment (changing it changes every extid) and is
-      #   # typically sourced from the environment, never committed:
+      #   # typically sourced from the environment, never committed.
+      #   #
+      #   # Prefer a callable so the secret resolves lazily at first use: the model
+      #   # file still loads when the env var is absent, and ENV.fetch then raises
+      #   # loudly the first time an extid is derived rather than at class-load.
       #   class ApiToken < Familia::Horreum
       #     feature :object_identifier
-      #     feature :external_identifier, secret: ENV.fetch('EXTID_HMAC_SECRET')
+      #     feature :external_identifier, secret: -> { ENV.fetch('EXTID_HMAC_SECRET') }
       #   end
+      #   # A plain string also works when the value is already in hand:
+      #   #   feature :external_identifier, secret: ENV['EXTID_HMAC_SECRET']
       #
       class ExternalIdentifierFieldType < Familia::FieldType
         # Override getter to provide lazy generation from objid
@@ -315,6 +321,13 @@ module Familia
         # secret, a plain SHA-256 still removes the MT weakness and the 64-bit
         # truncation.
         secret = options[:secret]
+        # Allow a callable secret (e.g. -> { ENV.fetch('EXTID_HMAC_SECRET') }) so
+        # the value resolves lazily at first derivation instead of eagerly at
+        # class-definition time. The model file then loads even when the env var is
+        # absent (CI, tooling, introspection), and a missing secret still raises
+        # loudly here -- where it matters -- rather than masking the whole model
+        # behind a load-time error (#311).
+        secret = secret.call if secret.respond_to?(:call)
         random_bytes =
           if secret && !secret.to_s.empty?
             OpenSSL::HMAC.digest('SHA256', secret.to_s, normalized_hex)[0, 16]

--- a/lib/familia/features/external_identifier.rb
+++ b/lib/familia/features/external_identifier.rb
@@ -2,6 +2,9 @@
 #
 # frozen_string_literal: true
 
+require 'digest'
+require 'openssl'
+
 module Familia
   module Features
     # Familia::Features::ExternalIdentifier
@@ -76,6 +79,17 @@ module Familia
       #   end
       #   resource = Resource.new
       #   resource.extid  # => "v2/abc123def456ghi789"
+      #
+      # @example Keying derivation with an application secret (recommended)
+      #   # By default the extid is a deterministic SHA-256 of the objid. Supply
+      #   # a `secret:` to derive it via a keyed HMAC instead, so external IDs
+      #   # cannot be forged or inverted from a known objid. The secret must be
+      #   # stable for a deployment (changing it changes every extid) and is
+      #   # typically sourced from the environment, never committed:
+      #   class ApiToken < Familia::Horreum
+      #     feature :object_identifier
+      #     feature :external_identifier, secret: ENV.fetch('EXTID_HMAC_SECRET')
+      #   end
       #
       class ExternalIdentifierFieldType < Familia::FieldType
         # Override getter to provide lazy generation from objid
@@ -283,32 +297,36 @@ module Familia
         # Normalize the objid to a consistent hex representation first.
         normalized_hex = normalize_objid_to_hex(current_objid)
 
-        # Use the objid's randomness to create a deterministic, yet secure,
-        # external identifier. We do not use SecureRandom here because the output
-        # must be deterministic.
+        options = self.class.feature_options(:external_identifier)
+
+        # Derive 16 deterministic bytes (128 bits) from the objid. We do not use
+        # SecureRandom because the output must be deterministic (same objid ->
+        # same extid, which lookups depend on).
         #
-        # The process is as follows:
-        # 1. The objid (a high-entropy value) is hashed to create a uniform seed.
-        # 2. The seed initializes a standard PRNG (Random.new).
-        # 3. The PRNG acts as a deterministic function to generate a sequence of
-        #    bytes that appears random, obscuring the original objid.
-
-        # 1. Create a high-quality, uniform seed from the objid's entropy.
-        seed = Digest::SHA256.digest(normalized_hex)
-
-        # 2. Initialize a PRNG with the seed. The same seed will always produce
-        #    the same sequence of "random" numbers.
-        prng = Random.new(seed.unpack1('Q>'))
-
-        # 3. Generate 16 bytes (128 bits) of deterministic output.
-        random_bytes = prng.bytes(16)
+        # We deliberately avoid Random/Mersenne Twister here (see issue #310,
+        # S3): MT is not a cryptographic PRNG -- its internal state can be
+        # reconstructed from observed output -- and the previous implementation
+        # seeded it via `seed.unpack1('Q>')`, discarding all but the first 64 of
+        # the digest's 256 bits. A hash/HMAC keeps the derivation deterministic
+        # while being one-way and preserving the full input entropy.
+        #
+        # When a `secret:` is configured for the feature, a keyed HMAC is used so
+        # external IDs cannot be forged or inverted from a known objid. Without a
+        # secret, a plain SHA-256 still removes the MT weakness and the 64-bit
+        # truncation.
+        secret = options[:secret]
+        random_bytes =
+          if secret && !secret.to_s.empty?
+            OpenSSL::HMAC.digest('SHA256', secret.to_s, normalized_hex)[0, 16]
+          else
+            Digest::SHA256.digest(normalized_hex)[0, 16]
+          end
 
         # Encode as a base36 string for a compact, URL-safe identifier.
         # 128 bits is approximately 25 characters in base36.
         external_part = random_bytes.unpack1('H*').to_i(16).to_s(36).rjust(25, '0')
 
         # Get format from feature options and interpolate the ID
-        options = self.class.feature_options(:external_identifier)
         format = options[:format] || 'ext_%{id}'
 
         format % { id: external_part }

--- a/lib/familia/features/relationships/participation_membership.rb
+++ b/lib/familia/features/relationships/participation_membership.rb
@@ -55,12 +55,19 @@ module Familia
         def target_instance
           return nil unless target_class
 
-          # Resolve class from string name
-          # Only rescue NameError (class doesn't exist), not all exceptions
-          klass = Object.const_get(target_class)
+          # SECURITY: target_class is a string persisted in the database. Using
+          # Object.const_get on it would let anyone able to write to the database
+          # choose which constant gets resolved (and whose code runs next). Look
+          # the name up through Familia's model registry instead -- it only ever
+          # returns a class that was explicitly registered as a Familia model,
+          # acting as an implicit allowlist. Unknown names resolve to nil rather
+          # than to an arbitrary constant. See issue #310 (S4).
+          klass = Familia.resolve_class(target_class)
+          return nil unless klass.respond_to?(:find_by_id)
+
           klass.find_by_id(target_id)
-        rescue NameError
-          # Target class doesn't exist or isn't loaded
+        rescue ArgumentError, NameError
+          # Unresolvable or non-model class name -- treat as a missing target.
           nil
         end
       end

--- a/lib/familia/migration/script.rb
+++ b/lib/familia/migration/script.rb
@@ -33,9 +33,20 @@ module Familia
       # Error raised when script execution fails
       class ScriptError < Familia::Migration::Errors::MigrationError; end
 
-      # Holds script source and precomputed SHA1
+      # Holds script source and its precomputed SHA-1.
+      #
+      # SECURITY NOTE (issue #310, S5): this SHA-1 is the Redis *script identity*
+      # used as the EVALSHA cache key, not a security/integrity checksum. The
+      # Redis EVALSHA/SCRIPT LOAD protocol identifies cached scripts by the SHA-1
+      # of their body, so this value MUST be SHA-1 -- swapping in SHA-256 would
+      # make every EVALSHA miss (NOSCRIPT) and silently fall back to EVAL,
+      # re-sending the full script on each call. The scripts here are hardcoded
+      # library constants (or developer-supplied), never attacker-controlled, so
+      # SHA-1 collision attacks do not apply. Genuine change-detection that needs
+      # collision resistance uses SHA-256 elsewhere (see Migration::Registry#schema_digest).
       ScriptEntry = Data.define(:source, :sha) do
         def initialize(source:, sha: nil)
+          # Digest::SHA1 here mirrors what Redis computes for EVALSHA/SCRIPT LOAD.
           computed_sha = sha || Digest::SHA1.hexdigest(source)
           super(source: source.freeze, sha: computed_sha.freeze)
         end

--- a/lib/familia/settings.rb
+++ b/lib/familia/settings.rb
@@ -13,7 +13,8 @@ module Familia
   @encryption_keys = nil
   @current_key_version = nil
   @encryption_personalization = 'FamilialMatters'.freeze
-  @encryption_personalization_history = [].freeze
+  @encryption_hkdf_salt = 'FamilialMatters'.freeze
+  @encryption_hkdf_salt_history = [].freeze
   @pipelined_mode = :warn
   @strict_write_order = false
   @raise_on_unsaved_parent_write = true
@@ -28,9 +29,9 @@ module Familia
   #
   module Settings
     attr_writer :delim, :suffix, :default_expiration, :logical_database, :prefix, :encryption_keys,
-                :current_key_version, :encryption_personalization, :encryption_personalization_history,
-                :transaction_mode, :schema_path, :schemas, :schema_validator, :strict_write_order,
-                :raise_on_unsaved_parent_write
+                :current_key_version, :encryption_personalization, :encryption_hkdf_salt,
+                :encryption_hkdf_salt_history, :transaction_mode, :schema_path, :schemas,
+                :schema_validator, :strict_write_order, :raise_on_unsaved_parent_write
 
     def delim(val = nil)
       @delim = val if val
@@ -74,10 +75,16 @@ module Familia
       @current_key_version
     end
 
-    # Personalization string for BLAKE2b key derivation in XChaCha20Poly1305.
-    # This provides cryptographic domain separation, ensuring derived keys are
+    # Personalization string for BLAKE2b key derivation in the XChaCha20Poly1305
+    # providers. Provides cryptographic domain separation so derived keys are
     # unique per application even with identical master keys and contexts.
-    # Must be 16 bytes or less (automatically padded with null bytes).
+    #
+    # This knob feeds BLAKE2b's `personal` parameter ONLY. BLAKE2b caps the
+    # personalization at 16 bytes (the value is null-padded to 16), so it must be
+    # <= 16 bytes. The AES-GCM provider does NOT read this string -- it has its
+    # own #encryption_hkdf_salt, which carries no length limit. Keeping the two
+    # inputs separate avoids constraining one cipher family by the other's rules
+    # (see issue #311).
     #
     # @example Familia.configure do |config|
     #     config.encryption_personalization = 'MyApp1.0'
@@ -87,33 +94,56 @@ module Familia
     # @return [String] Current personalization string
     def encryption_personalization(val = nil)
       if val
-        raise ArgumentError, 'Personalization string cannot exceed 16 bytes' if val.bytesize > 16
-
+        if val.bytesize > 16
+          raise ArgumentError,
+                'encryption_personalization cannot exceed 16 bytes (BLAKE2b personalization limit). ' \
+                'For the AES-GCM HKDF salt, which has no length limit, use encryption_hkdf_salt.'
+        end
         @encryption_personalization = val
       end
       @encryption_personalization
     end
 
-    # Previous personalization values, kept so that rotating
-    # #encryption_personalization stays backward-compatible. The AES-GCM
-    # provider uses the personalization string as its HKDF salt (see issue
-    # #310, S2); when you change the current value, list the prior value(s)
-    # here so existing ciphertext can still be decrypted. Encryption always
-    # uses the current value; decryption tries the current value first, then
-    # each entry here in order. Keep the list short -- every stale salt adds a
-    # decryption attempt on a miss.
+    # HKDF salt for the AES-GCM provider's key derivation (RFC 5869). Provides
+    # per-deployment domain separation for AES-GCM, mirroring what
+    # #encryption_personalization does for the XChaCha20 (BLAKE2b) providers --
+    # but as a SEPARATE input, because HKDF accepts a salt of any length while
+    # BLAKE2b personalization is capped at 16 bytes. There is deliberately no
+    # length limit here (see issue #311).
     #
-    # @example Rotating the personalization without losing old data
+    # Encryption always uses this current value; decryption tries it first, then
+    # each entry in #encryption_hkdf_salt_history, then the pre-#310 static salt,
+    # so existing ciphertext keeps decrypting across rotations and upgrades.
+    #
+    # @example Familia.configure do |config|
+    #     config.encryption_hkdf_salt = 'MyApp-AESGCM-2025'
+    #   end
+    #
+    # @param val [String, nil] The HKDF salt, or nil to get current value
+    # @return [String] Current HKDF salt
+    def encryption_hkdf_salt(val = nil)
+      @encryption_hkdf_salt = val if val
+      @encryption_hkdf_salt
+    end
+
+    # Previous #encryption_hkdf_salt values, kept so that rotating the AES-GCM
+    # HKDF salt stays backward-compatible. When you change the current salt, list
+    # the prior value(s) here so existing ciphertext can still be decrypted.
+    # Encryption always uses the current value; decryption tries the current
+    # value first, then each entry here in order. Keep the list short -- every
+    # stale salt adds a decryption attempt on a miss.
+    #
+    # @example Rotating the AES-GCM HKDF salt without losing old data
     #   Familia.configure do |config|
-    #     config.encryption_personalization = 'MyApp-2025'
-    #     config.encryption_personalization_history = ['MyApp-2024']
+    #     config.encryption_hkdf_salt = 'MyApp-2025'
+    #     config.encryption_hkdf_salt_history = ['MyApp-2024']
     #   end
     #
     # @param val [Array<String>, nil] Ordered list of prior values, or nil to read
     # @return [Array<String>] Current history list (possibly empty)
-    def encryption_personalization_history(val = nil)
-      @encryption_personalization_history = Array(val) unless val.nil?
-      @encryption_personalization_history || []
+    def encryption_hkdf_salt_history(val = nil)
+      @encryption_hkdf_salt_history = Array(val) unless val.nil?
+      @encryption_hkdf_salt_history || []
     end
 
     # Controls transaction behavior when connection handlers don't support transactions

--- a/lib/familia/settings.rb
+++ b/lib/familia/settings.rb
@@ -13,6 +13,7 @@ module Familia
   @encryption_keys = nil
   @current_key_version = nil
   @encryption_personalization = 'FamilialMatters'.freeze
+  @encryption_personalization_history = [].freeze
   @pipelined_mode = :warn
   @strict_write_order = false
   @raise_on_unsaved_parent_write = true
@@ -27,8 +28,8 @@ module Familia
   #
   module Settings
     attr_writer :delim, :suffix, :default_expiration, :logical_database, :prefix, :encryption_keys,
-                :current_key_version, :encryption_personalization, :transaction_mode,
-                :schema_path, :schemas, :schema_validator, :strict_write_order,
+                :current_key_version, :encryption_personalization, :encryption_personalization_history,
+                :transaction_mode, :schema_path, :schemas, :schema_validator, :strict_write_order,
                 :raise_on_unsaved_parent_write
 
     def delim(val = nil)
@@ -91,6 +92,28 @@ module Familia
         @encryption_personalization = val
       end
       @encryption_personalization
+    end
+
+    # Previous personalization values, kept so that rotating
+    # #encryption_personalization stays backward-compatible. The AES-GCM
+    # provider uses the personalization string as its HKDF salt (see issue
+    # #310, S2); when you change the current value, list the prior value(s)
+    # here so existing ciphertext can still be decrypted. Encryption always
+    # uses the current value; decryption tries the current value first, then
+    # each entry here in order. Keep the list short -- every stale salt adds a
+    # decryption attempt on a miss.
+    #
+    # @example Rotating the personalization without losing old data
+    #   Familia.configure do |config|
+    #     config.encryption_personalization = 'MyApp-2025'
+    #     config.encryption_personalization_history = ['MyApp-2024']
+    #   end
+    #
+    # @param val [Array<String>, nil] Ordered list of prior values, or nil to read
+    # @return [Array<String>] Current history list (possibly empty)
+    def encryption_personalization_history(val = nil)
+      @encryption_personalization_history = Array(val) unless val.nil?
+      @encryption_personalization_history || []
     end
 
     # Controls transaction behavior when connection handlers don't support transactions

--- a/lib/familia/settings.rb
+++ b/lib/familia/settings.rb
@@ -111,6 +111,11 @@ module Familia
     # BLAKE2b personalization is capped at 16 bytes. There is deliberately no
     # length limit here (see issue #311).
     #
+    # The built-in default ('FamilialMatters') is a shared library fallback: it
+    # separates Familia's keys from other HKDF users, but NOT one deployment from
+    # another. Set a value unique to each deployment to get deployment-level
+    # separation.
+    #
     # Encryption always uses this current value; decryption tries it first, then
     # each entry in #encryption_hkdf_salt_history, then the pre-#310 static salt,
     # so existing ciphertext keeps decrypting across rotations and upgrades.

--- a/lib/familia/verifiable_identifier.rb
+++ b/lib/familia/verifiable_identifier.rb
@@ -53,6 +53,17 @@ module Familia
       end
     end
 
+    # Clears the memoized secret so the next {.secret_key} call re-reads the
+    # environment. Intended for test suites that swap the configured secret (or
+    # exercise the missing-secret path) within a single process. Production code
+    # never needs this: the secret is fixed for a deployment, and rotating it
+    # requires a restart (and invalidates every previously generated identifier).
+    #
+    # @return [nil]
+    def self.reset_secret_key!
+      @secret_key = nil
+    end
+
     # The length of the random part of the ID in hex characters (256 bits).
     RANDOM_HEX_LENGTH = 64
     # The length of the HMAC tag in hex characters (64 bits).

--- a/lib/familia/verifiable_identifier.rb
+++ b/lib/familia/verifiable_identifier.rb
@@ -18,9 +18,6 @@ module Familia
     # This key is the root of trust for verifying identifier authenticity. It must be
     # a long, random, and cryptographically strong string.
     #
-    # @!attribute [r] SECRET_KEY
-    #   @return [String] The secret key.
-    #
     # @note Security Considerations:
     #   - **Secrecy:** This key MUST be kept secret and secure, just like a database
     #     password or API key. Do not commit it to version control.
@@ -29,6 +26,11 @@ module Familia
     #   - **Rotation:** If this key is ever compromised, it must be rotated. Be
     #     aware that rotating the key will invalidate all previously generated
     #     verifiable identifiers.
+    #   - **No committed fallback:** There is intentionally NO default. A hardcoded
+    #     secret in source would be public knowledge, letting anyone forge valid
+    #     identifiers (issue #310, S1). A missing secret raises -- but lazily, the
+    #     first time an identifier is actually minted or verified, so merely
+    #     requiring this file (e.g. for introspection) never blows up.
     #
     # @example Generating and Setting the Key
     #     1. Generate a new secure key in your terminal:
@@ -38,19 +40,17 @@ module Familia
     #     2. Set it as an environment variable in your production environment:
     #        export VERIFIABLE_ID_HMAC_SECRET="<the generated value>"
     #
-    # @note There is intentionally NO committed fallback default. A hardcoded
-    #   secret in source would be public knowledge, letting anyone who can read
-    #   the repository forge valid identifiers. If the environment variable is
-    #   not set, loading this module fails loudly at startup rather than
-    #   silently signing with a known key.
-    #
-    SECRET_KEY = ENV.fetch('VERIFIABLE_ID_HMAC_SECRET') do
-      raise KeyError, <<~MSG.strip
-        VERIFIABLE_ID_HMAC_SECRET is not set. Familia::VerifiableIdentifier
-        refuses to fall back to a committed default secret -- a known key would
-        let anyone forge valid identifiers. Generate one with `openssl rand -hex
-        32` and export it before loading this module.
-      MSG
+    # @return [String] the configured secret
+    # @raise [KeyError] if VERIFIABLE_ID_HMAC_SECRET is not set
+    def self.secret_key
+      @secret_key ||= ENV.fetch('VERIFIABLE_ID_HMAC_SECRET') do
+        raise KeyError, <<~MSG.strip
+          VERIFIABLE_ID_HMAC_SECRET is not set. Familia::VerifiableIdentifier
+          refuses to fall back to a committed default secret -- a known key would
+          let anyone forge valid identifiers. Generate one with `openssl rand -hex
+          32` and export it before generating or verifying identifiers.
+        MSG
+      end
     end
 
     # The length of the random part of the ID in hex characters (256 bits).
@@ -168,7 +168,7 @@ module Familia
         hmac_input = scope ? "#{message}:scope:#{scope}" : message
 
         digest = OpenSSL::Digest.new('sha256')
-        hmac = OpenSSL::HMAC.hexdigest(digest, SECRET_KEY, hmac_input)
+        hmac = OpenSSL::HMAC.hexdigest(digest, secret_key, hmac_input)
         # Truncate to the desired length for the tag.
         hmac[0...TAG_HEX_LENGTH]
       end

--- a/lib/familia/verifiable_identifier.rb
+++ b/lib/familia/verifiable_identifier.rb
@@ -33,12 +33,25 @@ module Familia
     # @example Generating and Setting the Key
     #     1. Generate a new secure key in your terminal:
     #        $ openssl rand -hex 32
-    #        > cafef00dcafef00dcafef00dcafef00dcafef00dcafef00d
+    #        > <64 hex characters>
     #
     #     2. Set it as an environment variable in your production environment:
-    #        export VERIFIABLE_ID_HMAC_SECRET="cafef00dcafef00dcafef00dcafef00dcafef00dcafef00d"
+    #        export VERIFIABLE_ID_HMAC_SECRET="<the generated value>"
     #
-    SECRET_KEY = ENV.fetch('VERIFIABLE_ID_HMAC_SECRET', 'cafef00dcafef00dcafef00dcafef00dcafef00dcafef00d')
+    # @note There is intentionally NO committed fallback default. A hardcoded
+    #   secret in source would be public knowledge, letting anyone who can read
+    #   the repository forge valid identifiers. If the environment variable is
+    #   not set, loading this module fails loudly at startup rather than
+    #   silently signing with a known key.
+    #
+    SECRET_KEY = ENV.fetch('VERIFIABLE_ID_HMAC_SECRET') do
+      raise KeyError, <<~MSG.strip
+        VERIFIABLE_ID_HMAC_SECRET is not set. Familia::VerifiableIdentifier
+        refuses to fall back to a committed default secret -- a known key would
+        let anyone forge valid identifiers. Generate one with `openssl rand -hex
+        32` and export it before loading this module.
+      MSG
+    end
 
     # The length of the random part of the ID in hex characters (256 bits).
     RANDOM_HEX_LENGTH = 64

--- a/try/features/encryption/aes_gcm_salt_rotation_try.rb
+++ b/try/features/encryption/aes_gcm_salt_rotation_try.rb
@@ -81,6 +81,62 @@ Familia.config.encryption_personalization_history = []
 @mgr.decrypt(@legacy_blob, context: @ctx)
 #=> 'legacy secret'
 
+## Legacy data crafted against the *literal* pre-#310 salt string (not the
+## constant) still decrypts -- guards against the constant's value drifting away
+## from the hardcoded 'FamiliaEncryption' the old code shipped.
+@literal_key = @provider.derive_key(@master, @ctx, salt: 'FamiliaEncryption')
+@literal_enc = @provider.encrypt('literal legacy', @literal_key)
+@literal_blob = Familia::JsonSerializer.dump(
+  Familia::Encryption::EncryptedData.new(
+    algorithm: @provider.algorithm,
+    nonce: Base64.strict_encode64(@literal_enc[:nonce]),
+    ciphertext: Base64.strict_encode64(@literal_enc[:ciphertext]),
+    auth_tag: Base64.strict_encode64(@literal_enc[:auth_tag]),
+    key_version: :v1,
+    encoding: 'UTF-8'
+  ).to_h
+)
+Familia.config.encryption_personalization = 'AnotherFreshApp'
+Familia.config.encryption_personalization_history = []
+@mgr.decrypt(@literal_blob, context: @ctx)
+#=> 'literal legacy'
+
+## No false positive: a wrong salt never "succeeds" into garbage -- GCM auth must
+## fail and raise rather than return a plausible-looking wrong string.
+Familia.config.encryption_personalization = 'GoodSalt'
+Familia.config.encryption_personalization_history = []
+@fp_blob = @mgr.encrypt('do not leak', context: @ctx)
+Familia.config.encryption_personalization = 'WrongSalt'
+Familia.config.encryption_personalization_history = []
+begin
+  @mgr.decrypt(@fp_blob, context: @ctx)
+  'false-positive!'
+rescue Familia::EncryptionError
+  'rejected'
+end
+#=> 'rejected'
+
+## hkdf_salts is current-first, deduplicated, and ends with the legacy salt
+Familia.config.encryption_personalization = 'Curr'
+Familia.config.encryption_personalization_history = ['Curr', 'Prev', 'Prev']
+Familia::Encryption::Providers::AESGCMProvider.new.hkdf_salts
+#=> ['Curr', 'Prev', 'FamiliaEncryption']
+
+## Request cache keys by salt: two blobs needing different salts both decrypt
+## correctly inside one cache scope (a salt-blind cache key would corrupt one).
+Familia.config.encryption_personalization = 'CacheA'
+Familia.config.encryption_personalization_history = []
+@cache_a = @mgr.encrypt('alpha', context: @ctx)
+Familia.config.encryption_personalization = 'CacheB'
+Familia.config.encryption_personalization_history = []
+@cache_b = @mgr.encrypt('beta', context: @ctx)
+Familia.config.encryption_personalization = 'CacheB'
+Familia.config.encryption_personalization_history = ['CacheA']
+Familia::Encryption.with_request_cache do
+  [@mgr.decrypt(@cache_b, context: @ctx), @mgr.decrypt(@cache_a, context: @ctx)]
+end
+#=> ['beta', 'alpha']
+
 # TEARDOWN
 Familia.config.encryption_personalization = @orig_personal
 Familia.config.encryption_personalization_history = @orig_history

--- a/try/features/encryption/aes_gcm_salt_rotation_try.rb
+++ b/try/features/encryption/aes_gcm_salt_rotation_try.rb
@@ -142,3 +142,9 @@ Familia.config.encryption_personalization = @orig_personal
 Familia.config.encryption_personalization_history = @orig_history
 Familia.config.encryption_keys = nil
 Familia.config.current_key_version = nil
+# Restore the request-cache fiber-locals to their pristine (nil) state. The
+# cache test above runs with_request_cache, whose ensure leaves
+# `enabled=false`; in the shared full-suite process that would otherwise leak
+# into a later file asserting the untouched default is nil (request_cache_try).
+Fiber[:familia_request_cache] = nil
+Fiber[:familia_request_cache_enabled] = nil

--- a/try/features/encryption/aes_gcm_salt_rotation_try.rb
+++ b/try/features/encryption/aes_gcm_salt_rotation_try.rb
@@ -169,6 +169,42 @@ end
 @shared_size
 #=> 1
 
+## Fail closed (#311): a nil encryption_hkdf_salt refuses to ENCRYPT rather than
+## silently using the legacy global static salt (which would withhold the #310
+## per-deployment domain separation). The raw attr_writer can set nil past the
+## reader's guards, so the check lives at derivation time.
+Familia.config.encryption_hkdf_salt = nil
+Familia.config.encryption_hkdf_salt_history = []
+begin
+  @mgr.encrypt('should not encrypt', context: @ctx)
+  'encrypted-unexpectedly'
+rescue Familia::EncryptionError => e
+  e.message.include?('non-empty') ? 'refused' : 'wrong-error'
+end
+#=> 'refused'
+
+## An empty encryption_hkdf_salt is likewise refused for encryption (#311)
+Familia.config.encryption_hkdf_salt = ''
+Familia.config.encryption_hkdf_salt_history = []
+begin
+  @mgr.encrypt('should not encrypt', context: @ctx)
+  'encrypted-unexpectedly'
+rescue Familia::EncryptionError
+  'refused'
+end
+#=> 'refused'
+
+## Decryption stays permissive even with a blank current salt: data written under
+## a now-historical salt still decrypts (old data stays readable even if the
+## current config is broken), while new writes are refused above.
+Familia.config.encryption_hkdf_salt = 'WriteSalt'
+Familia.config.encryption_hkdf_salt_history = []
+@written = @mgr.encrypt('readable later', context: @ctx)
+Familia.config.encryption_hkdf_salt = nil
+Familia.config.encryption_hkdf_salt_history = ['WriteSalt']
+@mgr.decrypt(@written, context: @ctx)
+#=> 'readable later'
+
 # TEARDOWN
 Familia.config.encryption_hkdf_salt = @orig_salt
 Familia.config.encryption_hkdf_salt_history = @orig_history

--- a/try/features/encryption/aes_gcm_salt_rotation_try.rb
+++ b/try/features/encryption/aes_gcm_salt_rotation_try.rb
@@ -2,10 +2,11 @@
 #
 # frozen_string_literal: true
 
-# Locks in the S2 backward-compatibility guarantee (issue #310): moving the
-# AES-GCM HKDF salt off the static 'FamiliaEncryption' literal to the
-# application personalization must NOT make previously-encrypted data
-# unreadable. The provider exposes an ordered salt list (current first, then
+# Locks in the S2 backward-compatibility guarantee (issue #310) together with the
+# #311 decoupling: the AES-GCM HKDF salt is driven by a dedicated config knob
+# (encryption_hkdf_salt), SEPARATE from the XChaCha20 personalization, and moving
+# off the static 'FamiliaEncryption' literal must NOT make previously-encrypted
+# data unreadable. The provider exposes an ordered salt list (current first, then
 # rotation history, then the legacy static salt); decryption walks it until the
 # authenticated decrypt succeeds.
 
@@ -15,8 +16,9 @@ require 'base64'
 Familia.config.encryption_keys = { v1: Base64.strict_encode64('a' * 32) }
 Familia.config.current_key_version = :v1
 
+@orig_salt = Familia.config.encryption_hkdf_salt
+@orig_history = Familia.config.encryption_hkdf_salt_history
 @orig_personal = Familia.config.encryption_personalization
-@orig_history = Familia.config.encryption_personalization_history
 
 @mgr = Familia::Encryption::Manager.new(algorithm: 'aes-256-gcm')
 @ctx = 'SaltRotationTest:secret:user1'
@@ -26,18 +28,33 @@ provider = Familia::Encryption::Providers::AESGCMProvider.new
 provider.hkdf_salts.include?(Familia::Encryption::Providers::AESGCMProvider::LEGACY_HKDF_SALT)
 #=> true
 
-## Encryption uses the current personalization as the first (current) salt
-Familia.config.encryption_personalization = 'App-v1'
-Familia.config.encryption_personalization_history = []
+## Encryption uses the current encryption_hkdf_salt as the first (current) salt
+Familia.config.encryption_hkdf_salt = 'App-v1'
+Familia.config.encryption_hkdf_salt_history = []
 Familia::Encryption::Providers::AESGCMProvider.new.hkdf_salts.first
 #=> 'App-v1'
 
-## Ciphertext written before a personalization rotation still decrypts via history
-Familia.config.encryption_personalization = 'App-v1'
-Familia.config.encryption_personalization_history = []
+## The AES-GCM salt is decoupled from the XChaCha20 personalization (#311):
+## changing the personalization does NOT change the AES-GCM salt list.
+Familia.config.encryption_hkdf_salt = 'App-v1'
+Familia.config.encryption_hkdf_salt_history = []
+Familia.config.encryption_personalization = 'Other'
+Familia::Encryption::Providers::AESGCMProvider.new.hkdf_salts.first
+#=> 'App-v1'
+
+## The HKDF salt carries no 16-byte BLAKE2b limit -- a long salt round-trips (#311)
+@long_salt = 'a-very-long-application-specific-hkdf-salt-well-over-16-bytes'
+Familia.config.encryption_hkdf_salt = @long_salt
+Familia.config.encryption_hkdf_salt_history = []
+@mgr.decrypt(@mgr.encrypt('long salt ok', context: @ctx), context: @ctx)
+#=> 'long salt ok'
+
+## Ciphertext written before a salt rotation still decrypts via history
+Familia.config.encryption_hkdf_salt = 'App-v1'
+Familia.config.encryption_hkdf_salt_history = []
 @blob_v1 = @mgr.encrypt('rotate me', context: @ctx)
-Familia.config.encryption_personalization = 'App-v2'
-Familia.config.encryption_personalization_history = ['App-v1']
+Familia.config.encryption_hkdf_salt = 'App-v2'
+Familia.config.encryption_hkdf_salt_history = ['App-v1']
 @mgr.decrypt(@blob_v1, context: @ctx)
 #=> 'rotate me'
 
@@ -46,11 +63,11 @@ Familia.config.encryption_personalization_history = ['App-v1']
 #=> 'fresh'
 
 ## Without the prior value in history, rotated ciphertext no longer decrypts
-Familia.config.encryption_personalization = 'App-v1'
-Familia.config.encryption_personalization_history = []
+Familia.config.encryption_hkdf_salt = 'App-v1'
+Familia.config.encryption_hkdf_salt_history = []
 @orphan = @mgr.encrypt('needs history', context: @ctx)
-Familia.config.encryption_personalization = 'App-x9'
-Familia.config.encryption_personalization_history = []
+Familia.config.encryption_hkdf_salt = 'App-x9'
+Familia.config.encryption_hkdf_salt_history = []
 begin
   @mgr.decrypt(@orphan, context: @ctx)
   'decrypted-unexpectedly'
@@ -75,9 +92,9 @@ end
     encoding: 'UTF-8'
   ).to_h
 )
-# A brand-new deployment with a custom personalization and no history at all:
-Familia.config.encryption_personalization = 'BrandNewApp'
-Familia.config.encryption_personalization_history = []
+# A brand-new deployment with a custom salt and no history at all:
+Familia.config.encryption_hkdf_salt = 'BrandNewApp'
+Familia.config.encryption_hkdf_salt_history = []
 @mgr.decrypt(@legacy_blob, context: @ctx)
 #=> 'legacy secret'
 
@@ -96,18 +113,18 @@ Familia.config.encryption_personalization_history = []
     encoding: 'UTF-8'
   ).to_h
 )
-Familia.config.encryption_personalization = 'AnotherFreshApp'
-Familia.config.encryption_personalization_history = []
+Familia.config.encryption_hkdf_salt = 'AnotherFreshApp'
+Familia.config.encryption_hkdf_salt_history = []
 @mgr.decrypt(@literal_blob, context: @ctx)
 #=> 'literal legacy'
 
 ## No false positive: a wrong salt never "succeeds" into garbage -- GCM auth must
 ## fail and raise rather than return a plausible-looking wrong string.
-Familia.config.encryption_personalization = 'GoodSalt'
-Familia.config.encryption_personalization_history = []
+Familia.config.encryption_hkdf_salt = 'GoodSalt'
+Familia.config.encryption_hkdf_salt_history = []
 @fp_blob = @mgr.encrypt('do not leak', context: @ctx)
-Familia.config.encryption_personalization = 'WrongSalt'
-Familia.config.encryption_personalization_history = []
+Familia.config.encryption_hkdf_salt = 'WrongSalt'
+Familia.config.encryption_hkdf_salt_history = []
 begin
   @mgr.decrypt(@fp_blob, context: @ctx)
   'false-positive!'
@@ -117,33 +134,49 @@ end
 #=> 'rejected'
 
 ## hkdf_salts is current-first, deduplicated, and ends with the legacy salt
-Familia.config.encryption_personalization = 'Curr'
-Familia.config.encryption_personalization_history = ['Curr', 'Prev', 'Prev']
+Familia.config.encryption_hkdf_salt = 'Curr'
+Familia.config.encryption_hkdf_salt_history = ['Curr', 'Prev', 'Prev']
 Familia::Encryption::Providers::AESGCMProvider.new.hkdf_salts
 #=> ['Curr', 'Prev', 'FamiliaEncryption']
 
 ## Request cache keys by salt: two blobs needing different salts both decrypt
 ## correctly inside one cache scope (a salt-blind cache key would corrupt one).
-Familia.config.encryption_personalization = 'CacheA'
-Familia.config.encryption_personalization_history = []
+Familia.config.encryption_hkdf_salt = 'CacheA'
+Familia.config.encryption_hkdf_salt_history = []
 @cache_a = @mgr.encrypt('alpha', context: @ctx)
-Familia.config.encryption_personalization = 'CacheB'
-Familia.config.encryption_personalization_history = []
+Familia.config.encryption_hkdf_salt = 'CacheB'
+Familia.config.encryption_hkdf_salt_history = []
 @cache_b = @mgr.encrypt('beta', context: @ctx)
-Familia.config.encryption_personalization = 'CacheB'
-Familia.config.encryption_personalization_history = ['CacheA']
+Familia.config.encryption_hkdf_salt = 'CacheB'
+Familia.config.encryption_hkdf_salt_history = ['CacheA']
 Familia::Encryption.with_request_cache do
   [@mgr.decrypt(@cache_b, context: @ctx), @mgr.decrypt(@cache_a, context: @ctx)]
 end
 #=> ['beta', 'alpha']
 
+## Issue 2 (#311): encrypt then decrypt the same value in one cache scope derives
+## once. The encrypt path (salt nil, resolved to hkdf_salts.first) and the decrypt
+## loop's first iteration (explicit hkdf_salts.first) now share a single cache
+## entry, instead of filing the same derived key under nil and under the resolved
+## salt. A single cached entry proves the redundant second derivation is gone.
+Familia.config.encryption_hkdf_salt = 'CacheShared'
+Familia.config.encryption_hkdf_salt_history = []
+@shared_size = Familia::Encryption.with_request_cache do
+  blob = @mgr.encrypt('shared', context: @ctx)
+  @mgr.decrypt(blob, context: @ctx)
+  Fiber[:familia_request_cache].size
+end
+@shared_size
+#=> 1
+
 # TEARDOWN
+Familia.config.encryption_hkdf_salt = @orig_salt
+Familia.config.encryption_hkdf_salt_history = @orig_history
 Familia.config.encryption_personalization = @orig_personal
-Familia.config.encryption_personalization_history = @orig_history
 Familia.config.encryption_keys = nil
 Familia.config.current_key_version = nil
 # Restore the request-cache fiber-locals to their pristine (nil) state. The
-# cache test above runs with_request_cache, whose ensure leaves
+# cache tests above run with_request_cache, whose ensure leaves
 # `enabled=false`; in the shared full-suite process that would otherwise leak
 # into a later file asserting the untouched default is nil (request_cache_try).
 Fiber[:familia_request_cache] = nil

--- a/try/features/encryption/aes_gcm_salt_rotation_try.rb
+++ b/try/features/encryption/aes_gcm_salt_rotation_try.rb
@@ -1,0 +1,88 @@
+# try/features/encryption/aes_gcm_salt_rotation_try.rb
+#
+# frozen_string_literal: true
+
+# Locks in the S2 backward-compatibility guarantee (issue #310): moving the
+# AES-GCM HKDF salt off the static 'FamiliaEncryption' literal to the
+# application personalization must NOT make previously-encrypted data
+# unreadable. The provider exposes an ordered salt list (current first, then
+# rotation history, then the legacy static salt); decryption walks it until the
+# authenticated decrypt succeeds.
+
+require_relative '../../support/helpers/test_helpers'
+require 'base64'
+
+Familia.config.encryption_keys = { v1: Base64.strict_encode64('a' * 32) }
+Familia.config.current_key_version = :v1
+
+@orig_personal = Familia.config.encryption_personalization
+@orig_history = Familia.config.encryption_personalization_history
+
+@mgr = Familia::Encryption::Manager.new(algorithm: 'aes-256-gcm')
+@ctx = 'SaltRotationTest:secret:user1'
+
+## The AES-GCM salt list always includes the pre-#310 legacy static salt
+provider = Familia::Encryption::Providers::AESGCMProvider.new
+provider.hkdf_salts.include?(Familia::Encryption::Providers::AESGCMProvider::LEGACY_HKDF_SALT)
+#=> true
+
+## Encryption uses the current personalization as the first (current) salt
+Familia.config.encryption_personalization = 'App-v1'
+Familia.config.encryption_personalization_history = []
+Familia::Encryption::Providers::AESGCMProvider.new.hkdf_salts.first
+#=> 'App-v1'
+
+## Ciphertext written before a personalization rotation still decrypts via history
+Familia.config.encryption_personalization = 'App-v1'
+Familia.config.encryption_personalization_history = []
+@blob_v1 = @mgr.encrypt('rotate me', context: @ctx)
+Familia.config.encryption_personalization = 'App-v2'
+Familia.config.encryption_personalization_history = ['App-v1']
+@mgr.decrypt(@blob_v1, context: @ctx)
+#=> 'rotate me'
+
+## Round-trips under the new current salt continue to work after rotation
+@mgr.decrypt(@mgr.encrypt('fresh', context: @ctx), context: @ctx)
+#=> 'fresh'
+
+## Without the prior value in history, rotated ciphertext no longer decrypts
+Familia.config.encryption_personalization = 'App-v1'
+Familia.config.encryption_personalization_history = []
+@orphan = @mgr.encrypt('needs history', context: @ctx)
+Familia.config.encryption_personalization = 'App-x9'
+Familia.config.encryption_personalization_history = []
+begin
+  @mgr.decrypt(@orphan, context: @ctx)
+  'decrypted-unexpectedly'
+rescue Familia::EncryptionError
+  'failed-as-expected'
+end
+#=> 'failed-as-expected'
+
+## Pre-#310 data (encrypted under the legacy static salt) decrypts with zero config
+# Craft ciphertext exactly as the old code did: derive with the legacy salt.
+@provider = Familia::Encryption::Providers::AESGCMProvider.new
+@master = Base64.strict_decode64(Familia.config.encryption_keys[:v1])
+@legacy_key = @provider.derive_key(@master, @ctx, salt: Familia::Encryption::Providers::AESGCMProvider::LEGACY_HKDF_SALT)
+@enc = @provider.encrypt('legacy secret', @legacy_key)
+@legacy_blob = Familia::JsonSerializer.dump(
+  Familia::Encryption::EncryptedData.new(
+    algorithm: @provider.algorithm,
+    nonce: Base64.strict_encode64(@enc[:nonce]),
+    ciphertext: Base64.strict_encode64(@enc[:ciphertext]),
+    auth_tag: Base64.strict_encode64(@enc[:auth_tag]),
+    key_version: :v1,
+    encoding: 'UTF-8'
+  ).to_h
+)
+# A brand-new deployment with a custom personalization and no history at all:
+Familia.config.encryption_personalization = 'BrandNewApp'
+Familia.config.encryption_personalization_history = []
+@mgr.decrypt(@legacy_blob, context: @ctx)
+#=> 'legacy secret'
+
+# TEARDOWN
+Familia.config.encryption_personalization = @orig_personal
+Familia.config.encryption_personalization_history = @orig_history
+Familia.config.encryption_keys = nil
+Familia.config.current_key_version = nil

--- a/try/features/encryption/config_persistence_try.rb
+++ b/try/features/encryption/config_persistence_try.rb
@@ -125,6 +125,23 @@ Familia.config.encryption_hkdf_salt = @orig_hkdf
 @hkdf_ok
 #=> true
 
+## XChaCha20 derive_key fails closed on a nil personalization with a clean
+## EncryptionError, not a NoMethodError crash (#311)
+provider = @provider_class.new
+@op = Familia.config.encryption_personalization
+Familia.config.encryption_personalization = nil
+@nil_personal = begin
+  provider.derive_key('a' * 32, 'ctx')
+  'no-error'
+rescue Familia::EncryptionError => e
+  e.message.include?('non-empty') ? 'clean-error' : 'other-encryption-error'
+rescue NoMethodError
+  'crashed'
+end
+Familia.config.encryption_personalization = @op
+@nil_personal
+#=> 'clean-error'
+
 ## derive_key validates master key length
 provider = @provider_class.new
 short_key = 'a' * 16  # Too short

--- a/try/features/encryption/config_persistence_try.rb
+++ b/try/features/encryption/config_persistence_try.rb
@@ -107,6 +107,24 @@ ensure
 end
 #=> "Personalization string must not contain null bytes"
 
+## encryption_personalization (method form) enforces the 16-byte BLAKE2b limit
+## and points callers at the separate, unconstrained AES-GCM salt knob (#311)
+begin
+  Familia.config.encryption_personalization('x' * 17)
+  'should_not_reach_here'
+rescue ArgumentError => e
+  [e.message.include?('16 bytes'), e.message.include?('encryption_hkdf_salt')]
+end
+#=> [true, true]
+
+## encryption_hkdf_salt has no length limit -- a >16-byte salt is accepted (#311)
+@orig_hkdf = Familia.config.encryption_hkdf_salt
+Familia.config.encryption_hkdf_salt = 'x' * 64
+@hkdf_ok = Familia.config.encryption_hkdf_salt == 'x' * 64
+Familia.config.encryption_hkdf_salt = @orig_hkdf
+@hkdf_ok
+#=> true
+
 ## derive_key validates master key length
 provider = @provider_class.new
 short_key = 'a' * 16  # Too short

--- a/try/features/encryption/request_cache_try.rb
+++ b/try/features/encryption/request_cache_try.rb
@@ -83,6 +83,56 @@ Familia::Encryption.clear_request_cache!
 Fiber[:familia_request_cache]
 #=> nil
 
+## with_request_cache wipes a stale cache a reused fiber may carry, on entry (S6)
+# Simulate a fiber reused across requests that still holds a previous cache.
+Fiber[:familia_request_cache_enabled] = true
+Fiber[:familia_request_cache] = { 'stale' => String.new('leftover') }
+@entry_snapshot = Familia::Encryption.with_request_cache do
+  # The block must start from a clean slate, not the leftover hash.
+  Fiber[:familia_request_cache].dup
+end
+@entry_snapshot
+#=> {}
+
+## And the cache is cleared again after the block
+[Fiber[:familia_request_cache], Fiber[:familia_request_cache_enabled]]
+#=> [nil, false]
+
+## RequestCacheMiddleware (clear-only) clears stale state before the app runs
+Fiber[:familia_request_cache_enabled] = true
+Fiber[:familia_request_cache] = { 'stale' => String.new('leftover') }
+@seen = nil
+app = ->(env) { @seen = [Fiber[:familia_request_cache], Fiber[:familia_request_cache_enabled]]; [200, {}, []] }
+mw = Familia::Encryption::RequestCacheMiddleware.new(app)
+mw.call({})
+@seen
+#=> [nil, false]
+
+## RequestCacheMiddleware (clear-only) clears again after the app, even on raise
+Fiber[:familia_request_cache_enabled] = true
+Fiber[:familia_request_cache] = { 'stale' => String.new('leftover') }
+boom = ->(env) { raise 'boom' }
+mw = Familia::Encryption::RequestCacheMiddleware.new(boom)
+begin
+  mw.call({})
+rescue RuntimeError
+  # expected
+end
+[Fiber[:familia_request_cache], Fiber[:familia_request_cache_enabled]]
+#=> [nil, false]
+
+## RequestCacheMiddleware(enabled: true) provides an active cache to the app
+@inside_mw = nil
+app = ->(env) { @inside_mw = Fiber[:familia_request_cache].class; [200, {}, []] }
+mw = Familia::Encryption::RequestCacheMiddleware.new(app, enabled: true)
+mw.call({})
+@inside_mw
+#=> Hash
+
+## RequestCacheMiddleware(enabled: true) still clears the cache afterwards
+[Fiber[:familia_request_cache], Fiber[:familia_request_cache_enabled]]
+#=> [nil, false]
+
 # TEARDOWN
 Familia.config.encryption_keys = nil
 Familia.config.current_key_version = nil

--- a/try/features/encryption/request_cache_try.rb
+++ b/try/features/encryption/request_cache_try.rb
@@ -98,41 +98,6 @@ end
 [Fiber[:familia_request_cache], Fiber[:familia_request_cache_enabled]]
 #=> [nil, false]
 
-## RequestCacheMiddleware (clear-only) clears stale state before the app runs
-Fiber[:familia_request_cache_enabled] = true
-Fiber[:familia_request_cache] = { 'stale' => String.new('leftover') }
-@seen = nil
-app = ->(env) { @seen = [Fiber[:familia_request_cache], Fiber[:familia_request_cache_enabled]]; [200, {}, []] }
-mw = Familia::Encryption::RequestCacheMiddleware.new(app)
-mw.call({})
-@seen
-#=> [nil, false]
-
-## RequestCacheMiddleware (clear-only) clears again after the app, even on raise
-Fiber[:familia_request_cache_enabled] = true
-Fiber[:familia_request_cache] = { 'stale' => String.new('leftover') }
-boom = ->(env) { raise 'boom' }
-mw = Familia::Encryption::RequestCacheMiddleware.new(boom)
-begin
-  mw.call({})
-rescue RuntimeError
-  # expected
-end
-[Fiber[:familia_request_cache], Fiber[:familia_request_cache_enabled]]
-#=> [nil, false]
-
-## RequestCacheMiddleware(enabled: true) provides an active cache to the app
-@inside_mw = nil
-app = ->(env) { @inside_mw = Fiber[:familia_request_cache].class; [200, {}, []] }
-mw = Familia::Encryption::RequestCacheMiddleware.new(app, enabled: true)
-mw.call({})
-@inside_mw
-#=> Hash
-
-## RequestCacheMiddleware(enabled: true) still clears the cache afterwards
-[Fiber[:familia_request_cache], Fiber[:familia_request_cache_enabled]]
-#=> [nil, false]
-
 # TEARDOWN
 Familia.config.encryption_keys = nil
 Familia.config.current_key_version = nil

--- a/try/features/external_identifier/external_identifier_try.rb
+++ b/try/features/external_identifier/external_identifier_try.rb
@@ -53,6 +53,14 @@ class ExternalDataIntegrityTest < Familia::Horreum
   field :name
 end
 
+# Class that keys extid derivation with an application secret (issue #310 S3)
+class SecretExtIdTest < Familia::Horreum
+  feature :object_identifier
+  feature :external_identifier, secret: 'unit-test-extid-secret'
+  identifier_field :id
+  field :id
+end
+
 # Test with existing external ID during initialization
 @existing_ext_obj = ExternalDataIntegrityTest.new(id: 'test_id', extid: 'preset_ext_123', name: 'Preset External')
 
@@ -521,3 +529,35 @@ ExternalIdTest.extid?(:ext_0123456789abcdefghijklmno)
 ## extid? with Symbol input returns false for invalid format
 ExternalIdTest.extid?(:invalid_symbol)
 #=> false
+
+# ========================================
+# S3: deterministic derivation without Mersenne Twister (issue #310)
+# ========================================
+
+## Secret-keyed extid is deterministic across repeated calls
+secret_obj = SecretExtIdTest.new(id: 'determinism')
+secret_obj.extid == secret_obj.extid
+#==> true
+
+## Secret-keyed extid keeps the standard ext_ + base36 format
+fmt_obj = SecretExtIdTest.new(id: 'format')
+fmt_obj.extid.match?(/\Aext_[0-9a-z]{20,32}\z/)
+#==> true
+
+## Configuring a secret changes the derived extid for the same objid
+@plain_obj = ExternalIdTest.new(id: 'shared')
+@shared_objid = @plain_obj.objid
+@keyed_obj = SecretExtIdTest.new(id: 'shared', objid: @shared_objid)
+# Same objid, different derivation (plain SHA-256 vs keyed HMAC) -> different extid
+@plain_obj.extid != @keyed_obj.extid
+#==> true
+
+## Same objid + same secret reproduces the same extid (deterministic, no MT state)
+keyed_again = SecretExtIdTest.new(id: 'shared2', objid: @shared_objid)
+@keyed_obj.extid == keyed_again.extid
+#==> true
+
+## Default (no secret) derivation is also deterministic for a fixed objid
+@plain_again = ExternalIdTest.new(id: 'shared3', objid: @shared_objid)
+@plain_obj.extid == @plain_again.extid
+#==> true

--- a/try/features/external_identifier/external_identifier_try.rb
+++ b/try/features/external_identifier/external_identifier_try.rb
@@ -561,3 +561,36 @@ keyed_again = SecretExtIdTest.new(id: 'shared2', objid: @shared_objid)
 @plain_again = ExternalIdTest.new(id: 'shared3', objid: @shared_objid)
 @plain_obj.extid == @plain_again.extid
 #==> true
+
+## A callable secret is resolved and keyed exactly like the equivalent string
+## secret: same objid + same resolved value -> identical extid (issue #311 S3)
+class CallableSecretExtIdTest < Familia::Horreum
+  feature :object_identifier
+  feature :external_identifier, secret: -> { 'unit-test-extid-secret' }
+  identifier_field :id
+  field :id
+end
+@cs_objid = ExternalIdTest.new(id: 'cs').objid
+@string_keyed = SecretExtIdTest.new(id: 'cs', objid: @cs_objid).extid
+@callable_keyed = CallableSecretExtIdTest.new(id: 'cs', objid: @cs_objid).extid
+@string_keyed == @callable_keyed
+#==> true
+
+## A callable secret resolves lazily: defining a model whose secret callable
+## raises does NOT raise at class-definition time; the error surfaces only at the
+## first extid derivation, so the model file loads even when the secret is absent.
+class LazyRaisingSecretExtIdTest < Familia::Horreum
+  feature :object_identifier
+  feature :external_identifier, secret: -> { raise 'secret resolved at derivation' }
+  identifier_field :id
+  field :id
+end
+# The class above was defined without error (a load-time raise would have failed
+# this whole file). Deriving an extid now invokes the callable and surfaces it.
+begin
+  LazyRaisingSecretExtIdTest.new(id: 'lazy').extid
+  'no-error'
+rescue RuntimeError => e
+  e.message
+end
+#=> 'secret resolved at derivation'

--- a/try/features/relationships/participation_membership_security_try.rb
+++ b/try/features/relationships/participation_membership_security_try.rb
@@ -1,0 +1,64 @@
+# try/features/relationships/participation_membership_security_try.rb
+#
+# frozen_string_literal: true
+
+# Locks in the S4 fix from issue #310: ParticipationMembership#target_instance
+# must resolve the database-sourced target_class string through Familia's model
+# registry (an implicit allowlist) rather than Object.const_get, so an attacker
+# who can write to the database cannot coerce resolution of an arbitrary
+# constant.
+
+require_relative '../../support/helpers/test_helpers'
+
+Familia.debug = false
+
+PM = Familia::Features::Relationships::ParticipationMembership
+
+# A registered Familia model that target_instance is allowed to resolve.
+class SecTargetModel < Familia::Horreum
+  identifier_field :id
+  field :id
+  field :name
+end
+
+def build_membership(target_class, target_id = 'x')
+  PM.new(
+    target_class: target_class,
+    target_id: target_id,
+    collection_name: :things,
+    type: :set,
+    score: nil,
+    decoded_score: nil,
+    position: nil
+  )
+end
+
+## nil target_class returns nil
+build_membership(nil).target_instance
+#=> nil
+
+## A real Ruby constant that is NOT a Familia model does not resolve (no const_get)
+build_membership('File').target_instance
+#=> nil
+
+## Object/Kernel cannot be coerced via the persisted class name
+build_membership('Object').target_instance
+#=> nil
+
+## An unknown / namespaced class name returns nil instead of raising
+build_membership('Definitely::Not::A::Class').target_instance
+#=> nil
+
+## A registered Familia model name resolves and loads the saved instance
+@obj = SecTargetModel.new(id: 'sec-target-1', name: 'ok')
+@obj.save
+loaded = build_membership('SecTargetModel', 'sec-target-1').target_instance
+[loaded.is_a?(SecTargetModel), loaded&.id]
+#=> [true, "sec-target-1"]
+
+## A registered model name with a missing id resolves the class but returns nil
+build_membership('SecTargetModel', 'no-such-id').target_instance
+#=> nil
+
+# Teardown
+@obj.destroy! rescue nil

--- a/try/integration/verifiable_identifier_try.rb
+++ b/try/integration/verifiable_identifier_try.rb
@@ -8,8 +8,9 @@ require_relative '../support/helpers/test_helpers'
 
 # A dedicated HMAC secret is REQUIRED: the library intentionally has no
 # committed fallback default (a known key would let anyone forge identifiers --
-# see issue #310, S1). Provide a test-only secret before loading the module so
-# the SECRET_KEY constant resolves instead of raising at load time.
+# see issue #310, S1). The secret is read lazily on first use, so requiring the
+# module never raises; provide a test-only secret before the generate/verify
+# cases below exercise it.
 ENV['VERIFIABLE_ID_HMAC_SECRET'] ||= 'test-only-verifiable-id-hmac-secret-0123456789abcdef'
 
 require 'familia/verifiable_identifier'
@@ -18,8 +19,8 @@ require 'familia/verifiable_identifier'
 defined?(Familia::VerifiableIdentifier)
 #=> "constant"
 
-## Loads the HMAC secret from the environment (no committed fallback default)
-Familia::VerifiableIdentifier::SECRET_KEY
+## Reads the HMAC secret lazily from the environment (no committed fallback)
+Familia::VerifiableIdentifier.secret_key
 #=> 'test-only-verifiable-id-hmac-secret-0123456789abcdef'
 
 # --- Verifiable ID Generation and Verification ---

--- a/try/integration/verifiable_identifier_try.rb
+++ b/try/integration/verifiable_identifier_try.rb
@@ -5,15 +5,22 @@
 # try/core/verifiable_identifier_try.rb
 
 require_relative '../support/helpers/test_helpers'
+
+# A dedicated HMAC secret is REQUIRED: the library intentionally has no
+# committed fallback default (a known key would let anyone forge identifiers --
+# see issue #310, S1). Provide a test-only secret before loading the module so
+# the SECRET_KEY constant resolves instead of raising at load time.
+ENV['VERIFIABLE_ID_HMAC_SECRET'] ||= 'test-only-verifiable-id-hmac-secret-0123456789abcdef'
+
 require 'familia/verifiable_identifier'
 
 ## Module is available
 defined?(Familia::VerifiableIdentifier)
 #=> "constant"
 
-## Uses the development secret key by default when ENV is not set
+## Loads the HMAC secret from the environment (no committed fallback default)
 Familia::VerifiableIdentifier::SECRET_KEY
-#=> "cafef00dcafef00dcafef00dcafef00dcafef00dcafef00d"
+#=> 'test-only-verifiable-id-hmac-secret-0123456789abcdef'
 
 # --- Verifiable ID Generation and Verification ---
 

--- a/try/integration/verifiable_identifier_try.rb
+++ b/try/integration/verifiable_identifier_try.rb
@@ -181,3 +181,16 @@ Familia::VerifiableIdentifier.verified_identifier?(id, 36)
 id = Familia::VerifiableIdentifier.generate_verifiable_id(scope: "test", base: 16)
 Familia::VerifiableIdentifier.verified_identifier?(id, scope: "test", base: 16)
 #=> true
+
+## reset_secret_key! clears memoization so the next read re-reads ENV (test API).
+## Production never needs this; it lets a test swap the configured secret in-process.
+@orig_hmac_secret = ENV['VERIFIABLE_ID_HMAC_SECRET']
+Familia::VerifiableIdentifier.reset_secret_key!
+ENV['VERIFIABLE_ID_HMAC_SECRET'] = 'rotated-secret-for-reset-test-0123456789abcdef'
+@after_reset = Familia::VerifiableIdentifier.secret_key
+# Restore the original secret and re-clear, so the original value is re-memoized
+# and no rotated state leaks into a later case or a shared suite process.
+ENV['VERIFIABLE_ID_HMAC_SECRET'] = @orig_hmac_secret
+Familia::VerifiableIdentifier.reset_secret_key!
+@after_reset
+#=> 'rotated-secret-for-reset-test-0123456789abcdef'


### PR DESCRIPTION
This PR addresses six security vulnerabilities in encryption, identifier generation, and class resolution:

## Summary
Fixes critical security issues in `VerifiableIdentifier`, AES-GCM encryption, external identifier derivation, `ParticipationMembership` class resolution, and request-scoped key caching. All changes maintain backward compatibility where possible.

## Key Changes

**S1: VerifiableIdentifier HMAC Secret**
- Removed hardcoded fallback secret from `VerifiableIdentifier::SECRET_KEY`
- Secret is now required via `VERIFIABLE_ID_HMAC_SECRET` environment variable
- Implemented lazy resolution via `secret_key` method so missing secrets only raise on first use, not on require
- Prevents anyone reading source code from forging valid identifiers

**S2: AES-GCM HKDF Salt Rotation**
- Replaced static `'FamiliaEncryption'` HKDF salt with application-specific `encryption_personalization`
- Added `encryption_personalization_history` config for backward-compatible salt rotation
- Implemented `hkdf_salts` method that returns current salt, history, then legacy salt for decryption fallback
- Decryption now tries salts in order until authenticated decrypt succeeds
- All existing ciphertext (including pre-#310 data) remains readable without migration

**S3: External Identifier Derivation**
- Replaced Mersenne Twister PRNG seeded with truncated SHA-256 with deterministic SHA-256 or keyed HMAC-SHA256
- Added optional `secret:` parameter to `external_identifier` feature for keyed HMAC derivation
- Removes MT state reconstruction weakness and 64-bit entropy truncation
- Maintains deterministic derivation (same objid → same extid) required for lookups

**S4: ParticipationMembership Class Resolution**
- Changed `target_instance` from `Object.const_get` to `Familia.resolve_class` (model registry allowlist)
- Prevents database-writable attackers from coercing resolution of arbitrary constants
- Unknown class names now return nil instead of raising NameError

**S5: Migration Script SHA-1 Documentation**
- Clarified that script SHA-1 is the Redis EVALSHA protocol identity, not a security checksum
- Documented that genuine change-detection uses SHA-256 in `Migration::Registry#schema_digest`

**S6: Request Cache Fiber Reuse**
- Added cache wipe on entry to `with_request_cache` (in addition to exit)
- Prevents reused fibers from carrying previous request's derived keys into new requests
- Updated middleware documentation with ensure-block pattern

## Implementation Details

- AES-GCM decryption walks `hkdf_salts` list, catching `EncryptionError` on each failed attempt
- Wrong salts derive different keys and fail GCM authentication cleanly (no false positives)
- Cache key now includes salt to prevent collisions during salt rotation
- External identifier derivation uses full SHA-256 digest (or HMAC output) instead of 64-bit truncation
- All changes include comprehensive tryout tests demonstrating backward compatibility and security properties

https://claude.ai/code/session_01Tsv7jnxe3LvpDMXieCSA9Y