### PR TITLE
Add bundler/gem_tasks requirement to Rakefile

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,15 @@
 # frozen_string_literal: true
 
+# Bundler's standard gem tasks: build / install / release (and release:*).
+#
+# The release-gem.yml workflow publishes via the `rubygems/release-gem` action,
+# which runs `bundle exec rake release`. That task only exists when this file
+# requires bundler/gem_tasks; without it the release job fails with
+# "Don't know how to build task 'release'". `rake` lives in the (non-optional)
+# :development, :test Gemfile group, so the release job's default `bundle install`
+# already provides it -- no BUNDLE_WITH opt-in is needed here.
+require 'bundler/gem_tasks'
+
 # Run the Tryouts test suite with a guaranteed UTF-8 locale.
 #
 # The suite's source and specs are UTF-8. The tryouts runner reads each test file


### PR DESCRIPTION
## Summary
Added the `require 'bundler/gem_tasks'` statement to the Rakefile to enable standard Bundler gem tasks (build, install, release).

## Changes
- Added `require 'bundler/gem_tasks'` to load Bundler's standard gem task definitions
- Included detailed comments explaining why this requirement is necessary for the release workflow

## Implementation Details
The `bundler/gem_tasks` requirement is essential for the `release-gem.yml` workflow, which publishes the gem via the `rubygems/release-gem` action by running `bundle exec rake release`. Without this requirement, the release job would fail with a "Don't know how to build task 'release'" error. Since `rake` is already available in the development/test Gemfile groups, no additional bundle configuration is needed.

https://claude.ai/code/session_01JtCGmiCP4SAjNfqUodNqtq