### PR TITLE
ci: Claude model selection + workflow standardization

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -4,6 +4,16 @@ on:
   pull_request:
     types: [opened, synchronize, labeled]
   workflow_dispatch:
+    inputs:
+      model:
+        description: "Claude model for this run (overrides the CLAUDE_MODEL repo variable)"
+        type: choice
+        required: false
+        default: claude-opus-4-6
+        options:
+          - claude-opus-4-6
+          - claude-sonnet-4-6
+          - claude-haiku-4-5-20251001
 
 jobs:
   claude-review:
@@ -22,7 +32,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.3
         with:
           fetch-depth: 1
 
@@ -31,6 +41,13 @@ jobs:
         uses: anthropics/claude-code-action@beta
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+
+          # Primary model precedence: the workflow_dispatch "model" input (manual
+          # runs) -> the CLAUDE_MODEL repo variable -> this built-in default.
+          # Pinning a current id avoids the action's frozen default, which 404s
+          # ("model: claude-sonnet-4-20250514"). Fall back to Sonnet on overload.
+          model: "${{ inputs.model || vars.CLAUDE_MODEL || 'claude-opus-4-6' }}"
+          fallback_model: "${{ vars.CLAUDE_FALLBACK_MODEL || 'claude-sonnet-4-6' }}"
 
           # Optional: Use sticky comments to make Claude reuse the same comment on subsequent pushes to the same PR
           use_sticky_comment: true

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -26,15 +26,22 @@ jobs:
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.3
         with:
           fetch-depth: 1
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@beta
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+
+          # Primary model: set the CLAUDE_MODEL repo variable to override without
+          # editing this file. Pinning a current id avoids the action's frozen
+          # default, which 404s ("model: claude-sonnet-4-20250514"). Fall back to
+          # Sonnet if the primary is unavailable or overloaded.
+          model: "${{ vars.CLAUDE_MODEL || 'claude-opus-4-6' }}"
+          fallback_model: "${{ vars.CLAUDE_FALLBACK_MODEL || 'claude-sonnet-4-6' }}"
 
           # This is an optional setting that allows Claude to read CI results on PRs
           additional_permissions: |


### PR DESCRIPTION
## Summary

Two parts: catch the Claude workflows up to configurable model selection, and standardize the rest of the workflow suite with rhales/otto.

### 1. Claude model selection
- `claude.yml` / `claude-code-review.yml` — pin a primary `model` via `CLAUDE_MODEL` (default `claude-opus-4-6`), add `fallback_model` via `CLAUDE_FALLBACK_MODEL` (→ `claude-sonnet-4-6`), and a `workflow_dispatch` model choice input on the review workflow.
- `claude.yml` — `anthropics/claude-code-action@v1` → `@beta` and `actions/checkout@v4` → `@v6.0.3` (familia was the lone outlier).

### 2. Workflow standardization
- **`ruby-lint.yml`** (new) — runs RuboCop across Ruby 3.2–4.0, informational (`continue-on-error`). The repo shipped a `.rubocop.yml` but never ran it in CI.
- **`docs.yml` → `yardoc.yml`** — renamed and switched to the shared YARD workflow that builds from the committed `.yardopts` (now `--output-dir doc`) and deploys to Pages.
- **`code-smells.yml`** — `actions/checkout` v4 → v6.0.3.
- **`release-gem.yml`** — build on Ruby **3.3** (was 3.2) to match otto/rhales.
- **`claude-code-review.yml`** — port the **fork/bot guard**.

## ⚠️ Two behavior changes worth a look
1. **Docs custom domain:** docs are served at https://delanotes.com/familia via org-level GitHub Pages (project-pages path), so renaming the local output dir `public` → `doc` does **not** change the URL. Verified locally: `yard 0.9.44` emits `doc/index.html` + 250 HTML files, no `public/`. Final confirmation happens on the post-merge `main` deploy.
2. **Bot reviews disabled:** the fork/bot guard skips `*[bot]` actors, which **supersedes `allowed_bots: "*"`** (removed). Bot-authored PRs (qodo/dependabot) will no longer be auto-reviewed. If you want to keep reviewing bot PRs, say so and I'll drop the bot half of the guard for familia (keeping the fork guard).

The review `if:` now also gates `synchronize` re-reviews on the `claude-review` label (matching rhales/otto), instead of reviewing every push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P9DBMriY9snxDUEAG7EJE4