### PR TITLE
Add encryption upgrade proof: AES-256-GCM → XChaCha20-Poly1305

### DIFF
--- a/examples/encryption_upgrade_proof/.gitignore
+++ b/examples/encryption_upgrade_proof/.gitignore
@@ -1,0 +1,3 @@
+state/
+gemfiles/*.lock
+gemfiles/.bundle/

--- a/examples/encryption_upgrade_proof/README.md
+++ b/examples/encryption_upgrade_proof/README.md
@@ -1,0 +1,84 @@
+# Encryption Upgrade Proof: AES-256-GCM → XChaCha20-Poly1305
+
+Executable proof that Familia's encryption envelope design permits enabling
+XChaCha20-Poly1305 (by installing `rbnacl`/libsodium) while every existing
+AES-256-GCM envelope remains decryptable — including envelopes written by
+the **released familia 2.10.1 gem**, envelopes written under the pre-#310
+static HKDF salt, and envelopes written under a retired master key version.
+
+```
+./run.sh
+```
+
+## What is being proven
+
+The envelope stored in the database is self-describing JSON:
+
+```json
+{
+  "algorithm":   "aes-256-gcm | xchacha20poly1305",
+  "nonce":       "<base64>",
+  "ciphertext":  "<base64>",
+  "auth_tag":    "<base64>",
+  "key_version": "v1 | v2 | ...",
+  "encoding":    "UTF-8",
+  "envelope_version": 2,
+  "aad_fields":  ["..."]        // v2 envelopes, when aad_fields are used
+}
+```
+
+Two properties make the upgrade safe:
+
+1. **Write path**: `Registry.default_provider` picks the highest-priority
+   *available* provider. Installing rbnacl flips new writes to
+   XChaCha20-Poly1305 with zero application changes.
+2. **Read path**: `Manager#decrypt` selects the provider from the
+   *envelope's* `algorithm` field and derives the key with **that
+   provider's** KDF (HKDF-SHA256 for AES-GCM, keyed BLAKE2b for XChaCha),
+   using the *envelope's* `key_version` to pick the master key. The default
+   provider is never consulted on the read path.
+
+## Phases
+
+Each phase runs in its own process under its own Gemfile; envelopes travel
+between phases via `state/*.json`, simulating data at rest in the database.
+
+| Phase | Environment | Simulates |
+|---|---|---|
+| 0 | familia **2.10.1** (released), OpenSSL only | Production today: all data AES-256-GCM under the static `'FamiliaEncryption'` HKDF salt |
+| 1 | this checkout, OpenSSL only | Upgrading the gem before installing libsodium |
+| 2 | this checkout + rbnacl | The target state: XChaCha writes, universal reads |
+| 3 | this checkout, rbnacl removed | Rollback / mixed-fleet hazard |
+
+Phase 2 additionally proves, by independent recomputation with raw
+RbNaCl/OpenSSL primitives (outside familia's code paths):
+
+- the XChaCha data key is literally
+  `BLAKE2b(context, key: master_key, personal: personalization)`;
+- the AES data key is literally
+  `HKDF-SHA256(master_key, salt: hkdf_salt, info: context)`;
+- nonces are unique per encryption operation;
+- AAD binding, per-record key contexts, auth-tag verification, and
+  algorithm-relabeling resistance all hold.
+
+## Hazards the proof documents (deliberately, as passing checks)
+
+These are *current behaviors* pinned by the proof so that any future change
+shows up as a failing check. See the accompanying findings report for the
+recommendations.
+
+- **Personalization is unrotatable**: changing
+  `encryption_personalization` breaks all existing XChaCha ciphertext; there
+  is no history/fallback mechanism (unlike `encryption_hkdf_salt_history`).
+  Pick the value *before* the first XChaCha write and treat it as permanent.
+- **Wiping the current HKDF salt strands current-salt data**: the decrypt
+  fallback list rescues legacy-salt envelopes, not envelopes written under
+  the salt you just removed.
+- **Envelope-lookalike plaintext is stored verbatim**: a plaintext that is
+  valid envelope JSON is treated as already-encrypted by the field setter
+  and is never encrypted.
+- **The upgrade is a one-way door**: once one XChaCha envelope exists,
+  every process that may read it needs libsodium. Nodes without it fail
+  cleanly (`Familia::EncryptionError: Unsupported algorithm`) but they fail.
+  Deploy libsodium to the whole fleet atomically, or accept read errors
+  during the rollout window.

--- a/examples/encryption_upgrade_proof/common.rb
+++ b/examples/encryption_upgrade_proof/common.rb
@@ -1,0 +1,83 @@
+# examples/encryption_upgrade_proof/common.rb
+#
+# frozen_string_literal: true
+
+# Shared fixtures and a micro assertion harness for the encryption upgrade
+# proof phases. Each phase runs in its own process under its own Gemfile
+# (see run.sh), so this file is loaded fresh per phase.
+
+require 'json'
+require 'base64'
+require 'digest'
+require 'openssl'
+require 'fileutils'
+require 'familia'
+
+module Proof
+  STATE_DIR = ENV['PROOF_STATE_DIR'] || File.join(__dir__, 'state')
+
+  # Mirrors how onetimesecret derives its Familia master keys
+  # (lib/onetime/initializers/configure_familia.rb): v1 is the legacy
+  # SHA-256 digest of the site secret, v2 is HKDF-derived. Both are
+  # base64-encoded 32-byte keys.
+  SITE_SECRET = 'proof-fixture-site-secret'
+  V1_KEY = Base64.strict_encode64(Digest::SHA256.digest(SITE_SECRET))
+  V2_KEY = Base64.strict_encode64(
+    OpenSSL::KDF.hkdf(SITE_SECRET, salt: 'proof-fixture', info: 'familia_enc', length: 32, hash: 'SHA256')
+  )
+
+  @checks = []
+
+  module_function
+
+  def configure!(current: :v2)
+    Familia.config.encryption_keys = { v1: V1_KEY, v2: V2_KEY }
+    Familia.config.current_key_version = current
+  end
+
+  def save_state(name, data)
+    FileUtils.mkdir_p(STATE_DIR)
+    File.write(File.join(STATE_DIR, "#{name}.json"), JSON.pretty_generate(data))
+  end
+
+  def load_state(name)
+    JSON.parse(File.read(File.join(STATE_DIR, "#{name}.json")))
+  end
+
+  # Expect the block to return a truthy value.
+  def check(desc)
+    result = yield
+    record(desc, !!result, result.inspect)
+  rescue StandardError => e
+    record(desc, false, "#{e.class}: #{e.message}")
+  end
+
+  # Expect the block to raise error_class (optionally matching message_pattern).
+  def check_raises(desc, error_class, message_pattern = nil)
+    yield
+    record(desc, false, 'no exception raised')
+  rescue error_class => e
+    if message_pattern && e.message !~ message_pattern
+      record(desc, false, "raised #{error_class} but message #{e.message.inspect} !~ #{message_pattern.inspect}")
+    else
+      record(desc, true, "#{e.class}: #{e.message}")
+    end
+  rescue StandardError => e
+    record(desc, false, "wrong error: #{e.class}: #{e.message}")
+  end
+
+  def record(desc, ok, detail)
+    @checks << ok
+    status = ok ? 'PASS' : 'FAIL'
+    puts format('  [%<status>s] %<desc>s%<extra>s',
+                status: status, desc: desc, extra: ok ? '' : " -- #{detail}")
+    ok
+  end
+
+  def finish!(phase)
+    total = @checks.size
+    failed = @checks.count { |c| !c }
+    puts "\n#{phase}: #{total - failed}/#{total} checks passed"
+    exit(failed.zero? ? 0 : 1)
+  end
+end

--- a/examples/encryption_upgrade_proof/gemfiles/Gemfile.dev-no-libsodium
+++ b/examples/encryption_upgrade_proof/gemfiles/Gemfile.dev-no-libsodium
@@ -1,0 +1,4 @@
+# This checkout, without rbnacl: AES-256-GCM is the only provider.
+source 'https://rubygems.org'
+
+gem 'familia', path: '../../..'

--- a/examples/encryption_upgrade_proof/gemfiles/Gemfile.dev-with-libsodium
+++ b/examples/encryption_upgrade_proof/gemfiles/Gemfile.dev-with-libsodium
@@ -1,0 +1,5 @@
+# This checkout, with rbnacl: XChaCha20-Poly1305 becomes the default provider.
+source 'https://rubygems.org'
+
+gem 'familia', path: '../../..'
+gem 'rbnacl', '~> 7.1', '>= 7.1.1'

--- a/examples/encryption_upgrade_proof/gemfiles/Gemfile.production-today
+++ b/examples/encryption_upgrade_proof/gemfiles/Gemfile.production-today
@@ -1,0 +1,4 @@
+# The released gem onetimesecret pins in production, no rbnacl.
+source 'https://rubygems.org'
+
+gem 'familia', '2.10.1'

--- a/examples/encryption_upgrade_proof/model.rb
+++ b/examples/encryption_upgrade_proof/model.rb
@@ -1,0 +1,32 @@
+# examples/encryption_upgrade_proof/model.rb
+#
+# frozen_string_literal: true
+
+# Field-level proof models. No database connection is required: the proof
+# exercises encryption through the field setter/getter (ConcealedString)
+# without ever calling save.
+
+module ProofApp
+  # Mirrors the shape of Onetime::Secret: a single encrypted field with no
+  # aad_fields and no key_material, identified by an objid assigned at
+  # creation time.
+  class Secret < Familia::Horreum
+    feature :encrypted_fields
+
+    identifier_field :objid
+    field :objid
+    field :owner_id
+    encrypted_field :ciphertext
+  end
+
+  # Exercises the aad_fields code path (SHA-256 digest AAD binding extra
+  # field values), which Onetime::Secret does not use today.
+  class Document < Familia::Horreum
+    feature :encrypted_fields
+
+    identifier_field :docid
+    field :docid
+    field :owner_id
+    encrypted_field :content, aad_fields: [:owner_id]
+  end
+end

--- a/examples/encryption_upgrade_proof/phase0_production_today.rb
+++ b/examples/encryption_upgrade_proof/phase0_production_today.rb
@@ -1,0 +1,90 @@
+# examples/encryption_upgrade_proof/phase0_production_today.rb
+#
+# frozen_string_literal: true
+
+# Phase 0 -- "production today"
+#
+# Runs against the RELEASED familia 2.10.1 gem (what onetimesecret pins in
+# production) with no rbnacl/libsodium. Every envelope written here is
+# AES-256-GCM, keyed via HKDF-SHA256 with the static pre-#310 salt
+# ('FamiliaEncryption') that 2.10.1 hardcodes. These envelopes are the
+# ground-truth fixtures the later phases must keep decrypting.
+
+require_relative 'common'
+require_relative 'model'
+
+expected = ENV.fetch('PROOF_EXPECT_VERSION', '2.10.1')
+abort "phase0 expects familia #{expected}, got #{Familia::VERSION}" unless Familia::VERSION == expected
+
+Proof.configure!
+
+puts "== Phase 0: production baseline (familia #{Familia::VERSION}, OpenSSL only) =="
+
+Familia::Encryption::Registry.setup!
+Proof.check('rbnacl absent: only aes-256-gcm registers') do
+  Familia::Encryption::Registry.providers.keys == ['aes-256-gcm']
+end
+Proof.check('default algorithm is aes-256-gcm') do
+  Familia::Encryption.status[:default_algorithm] == 'aes-256-gcm'
+end
+
+envelopes = []
+
+# --- Manager-level envelope under the current (v2) master key --------------
+ctx = 'ProofApp::Secret:ciphertext:sec_alpha'
+pt  = 'the eagle lands at midnight'
+env = Familia::Encryption.encrypt(pt, context: ctx, additional_data: ctx)
+
+Proof.check('manager envelope declares aes-256-gcm') { JSON.parse(env)['algorithm'] == 'aes-256-gcm' }
+Proof.check('manager envelope records key_version v2') { JSON.parse(env)['key_version'].to_s == 'v2' }
+Proof.check('manager envelope roundtrips in-place') do
+  Familia::Encryption.decrypt(env, context: ctx, additional_data: ctx) == pt
+end
+envelopes << { 'label' => 'manager-aes-v2', 'level' => 'manager', 'context' => ctx,
+               'aad' => ctx, 'plaintext' => pt, 'envelope' => env }
+
+# --- Manager-level envelope under the OLD (v1) master key ------------------
+# Simulates the oldest production data: written when current_key_version was v1.
+Proof.configure!(current: :v1)
+ctx_v1 = 'ProofApp::Secret:ciphertext:sec_bravo'
+pt_v1  = 'older data under the legacy v1 master key'
+env_v1 = Familia::Encryption.encrypt(pt_v1, context: ctx_v1, additional_data: ctx_v1)
+Proof.configure!(current: :v2)
+
+Proof.check('v1-keyed envelope records key_version v1') { JSON.parse(env_v1)['key_version'].to_s == 'v1' }
+Proof.check('v1-keyed envelope decrypts while current version is v2') do
+  Familia::Encryption.decrypt(env_v1, context: ctx_v1, additional_data: ctx_v1) == pt_v1
+end
+envelopes << { 'label' => 'manager-aes-v1', 'level' => 'manager', 'context' => ctx_v1,
+               'aad' => ctx_v1, 'plaintext' => pt_v1, 'envelope' => env_v1 }
+
+# --- Field-level envelope through the Horreum encrypted_field path ---------
+secret = ProofApp::Secret.new(objid: 'sec_alpha', owner_id: 'cust_1')
+secret.ciphertext = 'kept between us'
+field_env = secret.ciphertext.encrypted_value
+
+Proof.check('field envelope declares aes-256-gcm') { JSON.parse(field_env)['algorithm'] == 'aes-256-gcm' }
+Proof.check('field envelope is a v2 self-describing envelope') { JSON.parse(field_env)['envelope_version'] == 2 }
+Proof.check('field value reveals through ConcealedString') do
+  secret.ciphertext.reveal { |plain| plain == 'kept between us' }
+end
+envelopes << { 'label' => 'field-secret-aes', 'level' => 'field', 'model' => 'Secret',
+               'objid' => 'sec_alpha', 'owner_id' => 'cust_1',
+               'plaintext' => 'kept between us', 'envelope' => field_env }
+
+# --- Field-level envelope with aad_fields -----------------------------------
+doc = ProofApp::Document.new(docid: 'doc_1', owner_id: 'cust_9')
+doc.content = 'classified paragraph'
+doc_env = doc.content.encrypted_value
+
+Proof.check('aad_fields envelope records its aad field list') do
+  JSON.parse(doc_env)['aad_fields'] == ['owner_id']
+end
+envelopes << { 'label' => 'field-document-aes', 'level' => 'field', 'model' => 'Document',
+               'docid' => 'doc_1', 'owner_id' => 'cust_9',
+               'plaintext' => 'classified paragraph', 'envelope' => doc_env }
+
+Proof.save_state('phase0', 'familia_version' => Familia::VERSION, 'envelopes' => envelopes)
+puts "  (#{envelopes.size} fixture envelopes written to state/phase0.json)"
+
+Proof.finish!('Phase 0')

--- a/examples/encryption_upgrade_proof/phase0_production_today.rb
+++ b/examples/encryption_upgrade_proof/phase0_production_today.rb
@@ -18,6 +18,16 @@ abort "phase0 expects familia #{expected}, got #{Familia::VERSION}" unless Famil
 
 Proof.configure!
 
+# Offline fallback (see run.sh): when the released 2.10.1 gem can't be
+# installed, phase 0 runs against this checkout instead. This checkout
+# defaults to the post-#310 salt ('FamilialMatters'), not 2.10.1's hardcoded
+# 'FamiliaEncryption' -- force the old salt so fixtures seeded this way are
+# byte-for-byte what 2.10.1 would have produced, and phase 1's nil-salt
+# fallback assertions (which specifically target legacy-salt data) still hold.
+if ENV['PROOF_FORCE_LEGACY_SALT'] && Familia.config.respond_to?(:encryption_hkdf_salt=)
+  Familia.config.encryption_hkdf_salt = 'FamiliaEncryption'
+end
+
 puts "== Phase 0: production baseline (familia #{Familia::VERSION}, OpenSSL only) =="
 
 Familia::Encryption::Registry.setup!

--- a/examples/encryption_upgrade_proof/phase1_gem_upgrade_no_libsodium.rb
+++ b/examples/encryption_upgrade_proof/phase1_gem_upgrade_no_libsodium.rb
@@ -1,0 +1,99 @@
+# examples/encryption_upgrade_proof/phase1_gem_upgrade_no_libsodium.rb
+#
+# frozen_string_literal: true
+
+# Phase 1 -- "upgrade the familia gem, nothing else"
+#
+# Runs against the local familia checkout (2.11.x) WITHOUT rbnacl. This is
+# the intermediate deployment state: the library upgraded, libsodium still
+# absent. Everything must keep working exactly as before, and every envelope
+# written by the released 2.10.1 gem (phase 0) must still decrypt -- across
+# the HKDF salt change between the two versions (2.10.1 hardcoded
+# 'FamiliaEncryption'; 2.11.x defaults to 'FamilialMatters' and keeps the old
+# value as a decrypt-time fallback).
+
+require_relative 'common'
+require_relative 'model'
+
+abort "phase1 expects familia >= 2.11, got #{Familia::VERSION}" if Familia::VERSION < '2.11'
+
+Proof.configure!
+
+puts "== Phase 1: gem upgraded to #{Familia::VERSION}, still no rbnacl =="
+
+Familia::Encryption::Registry.setup!
+Proof.check('rbnacl absent: only aes-256-gcm registers') do
+  Familia::Encryption::Registry.providers.keys == ['aes-256-gcm']
+end
+Proof.check('default algorithm remains aes-256-gcm') do
+  Familia::Encryption.status[:default_algorithm] == 'aes-256-gcm'
+end
+Proof.check('current HKDF salt differs from the salt 2.10.1 encrypted under') do
+  Familia.config.encryption_hkdf_salt == 'FamilialMatters'
+end
+
+# --- Every 2.10.1 envelope must still decrypt -------------------------------
+phase0 = Proof.load_state('phase0')
+phase0['envelopes'].each do |rec|
+  case rec['level']
+  when 'manager'
+    Proof.check("2.10.1 envelope '#{rec['label']}' decrypts after gem upgrade (salt fallback)") do
+      Familia::Encryption.decrypt(rec['envelope'], context: rec['context'],
+                                                   additional_data: rec['aad']) == rec['plaintext']
+    end
+  when 'field'
+    Proof.check("2.10.1 envelope '#{rec['label']}' rehydrates + reveals after gem upgrade") do
+      obj = if rec['model'] == 'Secret'
+              ProofApp::Secret.new(objid: rec['objid'], owner_id: rec['owner_id'])
+            else
+              ProofApp::Document.new(docid: rec['docid'], owner_id: rec['owner_id'])
+            end
+      field = rec['model'] == 'Secret' ? :ciphertext : :content
+      obj.send(:"#{field}=", rec['envelope']) # setter recognizes envelope JSON: rehydration, no re-encrypt
+      obj.send(field).reveal { |plain| plain == rec['plaintext'] }
+    end
+  end
+end
+
+# --- New writes still work and are still AES --------------------------------
+envelopes = []
+ctx = 'ProofApp::Secret:ciphertext:sec_charlie'
+pt  = 'written by 2.11 before libsodium arrives'
+env = Familia::Encryption.encrypt(pt, context: ctx, additional_data: ctx)
+Proof.check('new envelope still declares aes-256-gcm') { JSON.parse(env)['algorithm'] == 'aes-256-gcm' }
+Proof.check('new envelope roundtrips') do
+  Familia::Encryption.decrypt(env, context: ctx, additional_data: ctx) == pt
+end
+envelopes << { 'label' => 'manager-aes-211', 'level' => 'manager', 'context' => ctx,
+               'aad' => ctx, 'plaintext' => pt, 'envelope' => env }
+
+# --- The #311 fail-closed guard on a broken salt config ---------------------
+begin
+  Familia.encryption_hkdf_salt = nil # attr_writer bypasses the reader's guards
+  Proof.check_raises('encrypting with a nil HKDF salt fails closed (issue #311 guard)',
+                     Familia::EncryptionError, /encryption_hkdf_salt/) do
+    Familia::Encryption.encrypt('x', context: ctx, additional_data: ctx)
+  end
+  # The decrypt fallback list drops the blank current salt and keeps the
+  # legacy entries, so LEGACY-salt ciphertext survives a broken config...
+  legacy = phase0['envelopes'].find { |r| r['label'] == 'manager-aes-v2' }
+  Proof.check('legacy-salt ciphertext still decrypts with a nil current salt (fallback list)') do
+    Familia::Encryption.decrypt(legacy['envelope'], context: legacy['context'],
+                                                    additional_data: legacy['aad']) == legacy['plaintext']
+  end
+  # ...but ciphertext written under the wiped CURRENT salt does not: the nil
+  # salt is compacted away, so its derivation input is simply gone. The
+  # comment on AESGCMProvider#hkdf_salts ("existing ciphertext stays readable
+  # even if the current config is broken") only holds for legacy-salt data.
+  Proof.check_raises('current-salt ciphertext does NOT survive wiping the current salt (documented gap)',
+                     Familia::EncryptionError) do
+    Familia::Encryption.decrypt(env, context: ctx, additional_data: ctx)
+  end
+ensure
+  Familia.encryption_hkdf_salt = 'FamilialMatters'
+end
+
+Proof.save_state('phase1', 'familia_version' => Familia::VERSION, 'envelopes' => envelopes)
+puts "  (#{envelopes.size} fixture envelopes written to state/phase1.json)"
+
+Proof.finish!('Phase 1')

--- a/examples/encryption_upgrade_proof/phase1_gem_upgrade_no_libsodium.rb
+++ b/examples/encryption_upgrade_proof/phase1_gem_upgrade_no_libsodium.rb
@@ -15,7 +15,7 @@
 require_relative 'common'
 require_relative 'model'
 
-abort "phase1 expects familia >= 2.11, got #{Familia::VERSION}" if Familia::VERSION < '2.11'
+abort "phase1 expects familia >= 2.11, got #{Familia::VERSION}" if Gem::Version.new(Familia::VERSION) < Gem::Version.new('2.11')
 
 Proof.configure!
 

--- a/examples/encryption_upgrade_proof/phase2_libsodium_enabled.rb
+++ b/examples/encryption_upgrade_proof/phase2_libsodium_enabled.rb
@@ -20,7 +20,7 @@
 require_relative 'common'
 require_relative 'model'
 
-abort "phase2 expects familia >= 2.11, got #{Familia::VERSION}" if Familia::VERSION < '2.11'
+abort "phase2 expects familia >= 2.11, got #{Familia::VERSION}" if Gem::Version.new(Familia::VERSION) < Gem::Version.new('2.11')
 abort 'phase2 expects rbnacl to be loadable' unless defined?(RbNaCl)
 
 Proof.configure!

--- a/examples/encryption_upgrade_proof/phase2_libsodium_enabled.rb
+++ b/examples/encryption_upgrade_proof/phase2_libsodium_enabled.rb
@@ -1,0 +1,297 @@
+# examples/encryption_upgrade_proof/phase2_libsodium_enabled.rb
+#
+# frozen_string_literal: true
+
+# Phase 2 -- "the upgrade": familia 2.11.x WITH rbnacl/libsodium installed.
+#
+# This is the target production state. It must hold simultaneously that:
+#   1. XChaCha20-Poly1305 becomes the default write algorithm with zero
+#      application code changes (provider priority),
+#   2. every envelope ever written by AES-256-GCM -- including ones written
+#      by the released 2.10.1 gem under the old static HKDF salt, and ones
+#      written under the retired v1 master key -- still decrypts, because the
+#      envelope is self-describing (algorithm + key_version) and the decrypt
+#      path derives keys with the envelope's own provider, not the default,
+#   3. the DPA's security claims hold: per-operation random nonces, BLAKE2b
+#      key derivation from master secret + class/identifier context, AAD
+#      binding that makes ciphertext non-transplantable, and authenticated
+#      failure on any tamper.
+
+require_relative 'common'
+require_relative 'model'
+
+abort "phase2 expects familia >= 2.11, got #{Familia::VERSION}" if Familia::VERSION < '2.11'
+abort 'phase2 expects rbnacl to be loadable' unless defined?(RbNaCl)
+
+Proof.configure!
+
+puts "== Phase 2: familia #{Familia::VERSION} + rbnacl (libsodium #{RbNaCl::Sodium::Version::STRING}) =="
+
+Familia::Encryption::Registry.setup!
+
+# --- 1. Automatic upgrade of the default provider ---------------------------
+Proof.check('both providers register') do
+  Familia::Encryption::Registry.providers.keys.sort == ['aes-256-gcm', 'xchacha20poly1305']
+end
+Proof.check('default algorithm flips to xchacha20poly1305 (no app change)') do
+  Familia::Encryption.status[:default_algorithm] == 'xchacha20poly1305'
+end
+
+# --- 2. Backward compatibility: every prior envelope decrypts ---------------
+%w[phase0 phase1].each do |phase|
+  state = Proof.load_state(phase)
+  from = "#{phase}/familia-#{state['familia_version']}"
+  state['envelopes'].each do |rec|
+    case rec['level']
+    when 'manager'
+      Proof.check("#{from} envelope '#{rec['label']}' decrypts with XChaCha default active") do
+        Familia::Encryption.decrypt(rec['envelope'], context: rec['context'],
+                                                     additional_data: rec['aad']) == rec['plaintext']
+      end
+    when 'field'
+      Proof.check("#{from} envelope '#{rec['label']}' rehydrates + reveals") do
+        obj = if rec['model'] == 'Secret'
+                ProofApp::Secret.new(objid: rec['objid'], owner_id: rec['owner_id'])
+              else
+                ProofApp::Document.new(docid: rec['docid'], owner_id: rec['owner_id'])
+              end
+        field = rec['model'] == 'Secret' ? :ciphertext : :content
+        obj.send(:"#{field}=", rec['envelope'])
+        obj.send(field).reveal { |plain| plain == rec['plaintext'] }
+      end
+    end
+  end
+end
+
+# --- 3. New writes are XChaCha20-Poly1305 ------------------------------------
+ctx = 'ProofApp::Secret:ciphertext:sec_delta'
+pt  = 'fresh data written after the upgrade'
+env = Familia::Encryption.encrypt(pt, context: ctx, additional_data: ctx)
+parsed = JSON.parse(env)
+
+Proof.check('new envelope declares xchacha20poly1305') { parsed['algorithm'] == 'xchacha20poly1305' }
+Proof.check('new envelope uses a 24-byte (192-bit) nonce') do
+  Base64.strict_decode64(parsed['nonce']).bytesize == 24
+end
+Proof.check('new envelope uses a 16-byte Poly1305 tag') do
+  Base64.strict_decode64(parsed['auth_tag']).bytesize == 16
+end
+Proof.check('new envelope records key_version v2') { parsed['key_version'].to_s == 'v2' }
+Proof.check('new envelope roundtrips') do
+  Familia::Encryption.decrypt(env, context: ctx, additional_data: ctx) == pt
+end
+
+# --- 4. Independent recomputation of the key derivation (DPA claim) ---------
+# Prove, without going through familia's decrypt path, that the XChaCha key is
+# exactly BLAKE2b(context, key: master_key, personal: personalization): derive
+# it by hand with RbNaCl and open the envelope directly with libsodium.
+Proof.check('XChaCha key is literally BLAKE2b(master_key, context, personalization)') do
+  master  = Base64.strict_decode64(Proof::V2_KEY)
+  derived = RbNaCl::Hash.blake2b(ctx.dup.force_encoding('BINARY'),
+                                 key: master, digest_size: 32,
+                                 personal: Familia.config.encryption_personalization.ljust(16, "\0"))
+  box = RbNaCl::AEAD::XChaCha20Poly1305IETF.new(derived)
+  combined = Base64.strict_decode64(parsed['ciphertext']) + Base64.strict_decode64(parsed['auth_tag'])
+  box.decrypt(Base64.strict_decode64(parsed['nonce']), combined, ctx) == pt
+end
+
+# The AES path, by contrast, derives with HKDF-SHA256 -- NOT BLAKE2b. Prove it
+# the same way for an AES envelope written in phase 1 (salt 'FamilialMatters').
+aes_rec = Proof.load_state('phase1')['envelopes'].find { |r| r['label'] == 'manager-aes-211' }
+Proof.check('AES-256-GCM key is HKDF-SHA256(master_key, salt, context) -- not BLAKE2b') do
+  master  = Base64.strict_decode64(Proof::V2_KEY)
+  aes_env = JSON.parse(aes_rec['envelope'])
+  derived = OpenSSL::KDF.hkdf(master, salt: 'FamilialMatters', info: aes_rec['context'],
+                              length: 32, hash: 'SHA256')
+  cipher = OpenSSL::Cipher.new('aes-256-gcm').decrypt
+  cipher.key = derived
+  cipher.iv = Base64.strict_decode64(aes_env['nonce'])
+  cipher.auth_tag = Base64.strict_decode64(aes_env['auth_tag'])
+  cipher.auth_data = aes_rec['aad']
+  (cipher.update(Base64.strict_decode64(aes_env['ciphertext'])) + cipher.final) == aes_rec['plaintext']
+end
+
+# --- 5. Per-operation random nonces ------------------------------------------
+Proof.check('500 encryptions of the same value yield 500 distinct nonces and ciphertexts') do
+  seen_nonces = {}
+  seen_cts = {}
+  500.times do
+    e = JSON.parse(Familia::Encryption.encrypt(pt, context: ctx, additional_data: ctx))
+    seen_nonces[e['nonce']] = true
+    seen_cts[e['ciphertext']] = true
+  end
+  seen_nonces.size == 500 && seen_cts.size == 500
+end
+
+# --- 6. Field-level: new writes upgrade, old records re-encrypt --------------
+secret = ProofApp::Secret.new(objid: 'sec_delta', owner_id: 'cust_1')
+secret.ciphertext = 'field-level secret after upgrade'
+field_env = secret.ciphertext.encrypted_value
+
+Proof.check('field envelope declares xchacha20poly1305') do
+  JSON.parse(field_env)['algorithm'] == 'xchacha20poly1305'
+end
+Proof.check('rehydrating an envelope does NOT re-encrypt it (byte-identical passthrough)') do
+  again = ProofApp::Secret.new(objid: 'sec_delta', owner_id: 'cust_1')
+  again.ciphertext = field_env
+  again.ciphertext.encrypted_value == field_env
+end
+
+# Take the 2.10.1-written field envelope and upgrade it in place, the way a
+# migration (re_encrypt_fields! + save) would.
+legacy_rec = Proof.load_state('phase0')['envelopes'].find { |r| r['label'] == 'field-secret-aes' }
+migrated = ProofApp::Secret.new(objid: legacy_rec['objid'], owner_id: legacy_rec['owner_id'])
+migrated.ciphertext = legacy_rec['envelope']
+Proof.check('re_encrypt_fields! upgrades a 2.10.1 AES envelope to XChaCha in place') do
+  migrated.re_encrypt_fields!
+  upgraded = JSON.parse(migrated.ciphertext.encrypted_value)
+  upgraded['algorithm'] == 'xchacha20poly1305' &&
+    upgraded['key_version'].to_s == 'v2' &&
+    migrated.ciphertext.reveal { |plain| plain == legacy_rec['plaintext'] }
+end
+
+# --- 7. Tamper and transplant resistance -------------------------------------
+flip = lambda do |b64|
+  raw = Base64.strict_decode64(b64)
+  raw[0] = (raw[0].ord ^ 0x01).chr
+  Base64.strict_encode64(raw)
+end
+
+tampered = parsed.merge('ciphertext' => flip.call(parsed['ciphertext']))
+Proof.check_raises('flipping one ciphertext bit fails authentication', Familia::EncryptionError) do
+  Familia::Encryption.decrypt(JSON.generate(tampered), context: ctx, additional_data: ctx)
+end
+
+Proof.check_raises('decrypting with the wrong AAD fails (AAD is authenticated)', Familia::EncryptionError) do
+  Familia::Encryption.decrypt(env, context: ctx, additional_data: 'ProofApp::Secret:ciphertext:OTHER')
+end
+
+Proof.check_raises('decrypting under another record\'s context fails (per-record keys)',
+                   Familia::EncryptionError) do
+  other = 'ProofApp::Secret:ciphertext:sec_zulu'
+  Familia::Encryption.decrypt(env, context: other, additional_data: other)
+end
+
+Proof.check_raises('field-level transplant: envelope moved to another objid fails to reveal',
+                   Familia::EncryptionError) do
+  thief = ProofApp::Secret.new(objid: 'sec_zulu', owner_id: 'cust_1')
+  thief.ciphertext = field_env
+  thief.ciphertext.reveal { |plain| plain }
+end
+
+Proof.check_raises('sharing a ConcealedString object across records trips context isolation',
+                   Familia::EncryptionError, /Context isolation violation/) do
+  owner = ProofApp::Secret.new(objid: 'sec_delta', owner_id: 'cust_1')
+  owner.ciphertext = field_env
+  thief = ProofApp::Secret.new(objid: 'sec_zulu', owner_id: 'cust_1')
+  thief.instance_variable_set(:@ciphertext, owner.ciphertext)
+  thief.ciphertext
+end
+
+# AAD-only mismatch, isolated from key derivation: Document binds owner_id via
+# aad_fields; docid (the KDF context) stays identical, only the AAD changes.
+doc_rec = Proof.load_state('phase0')['envelopes'].find { |r| r['label'] == 'field-document-aes' }
+Proof.check_raises('changing an aad_fields value alone breaks decryption (KDF context unchanged)',
+                   Familia::EncryptionError) do
+  altered = ProofApp::Document.new(docid: doc_rec['docid'], owner_id: 'cust_ATTACKER')
+  altered.content = doc_rec['envelope']
+  altered.content.reveal { |plain| plain }
+end
+Proof.check('...while the correct owner_id still reveals') do
+  intact = ProofApp::Document.new(docid: doc_rec['docid'], owner_id: doc_rec['owner_id'])
+  intact.content = doc_rec['envelope']
+  intact.content.reveal { |plain| plain == doc_rec['plaintext'] }
+end
+
+# --- 8. Algorithm-confusion resistance ---------------------------------------
+aes_env_parsed = JSON.parse(aes_rec['envelope'])
+relabeled = aes_env_parsed.merge('algorithm' => 'xchacha20poly1305')
+Proof.check_raises('relabeling an AES envelope as XChaCha fails (nonce size check)',
+                   Familia::EncryptionError) do
+  Familia::Encryption.decrypt(JSON.generate(relabeled),
+                              context: aes_rec['context'], additional_data: aes_rec['aad'])
+end
+
+relabeled_back = parsed.merge('algorithm' => 'aes-256-gcm')
+Proof.check_raises('relabeling an XChaCha envelope as AES fails (nonce size check)',
+                   Familia::EncryptionError) do
+  Familia::Encryption.decrypt(JSON.generate(relabeled_back), context: ctx, additional_data: ctx)
+end
+
+Proof.check_raises('an unknown algorithm is rejected cleanly', Familia::EncryptionError,
+                   /Unsupported algorithm/) do
+  Familia::Encryption.decrypt(JSON.generate(parsed.merge('algorithm' => 'rot13')),
+                              context: ctx, additional_data: ctx)
+end
+
+# --- 9. Config-rotation behaviors (hazards the envelope does NOT cover) ------
+# The envelope does not record the BLAKE2b personalization: changing it breaks
+# decryption of all existing XChaCha data, and there is no history/fallback
+# mechanism (unlike the AES HKDF salt). This documents the hazard.
+begin
+  Familia.encryption_personalization = 'DifferentApp'
+  Proof.check_raises('changing encryption_personalization breaks existing XChaCha data (no fallback!)',
+                     Familia::EncryptionError) do
+    Familia::Encryption.decrypt(env, context: ctx, additional_data: ctx)
+  end
+ensure
+  Familia.encryption_personalization = 'FamilialMatters'
+end
+Proof.check('restoring the personalization restores decryption') do
+  Familia::Encryption.decrypt(env, context: ctx, additional_data: ctx) == pt
+end
+
+# The AES HKDF salt, by contrast, DOES rotate safely via the history list.
+begin
+  Familia.encryption_hkdf_salt = 'RotatedSalt-2026'
+  Familia.encryption_hkdf_salt_history = ['FamilialMatters']
+  Proof.check('after salt rotation, envelopes under the previous salt decrypt via history') do
+    Familia::Encryption.decrypt(aes_rec['envelope'], context: aes_rec['context'],
+                                                     additional_data: aes_rec['aad']) == aes_rec['plaintext']
+  end
+  legacy_manager = Proof.load_state('phase0')['envelopes'].find { |r| r['label'] == 'manager-aes-v2' }
+  Proof.check('...and 2.10.1 envelopes under the pre-#310 static salt decrypt via the built-in fallback') do
+    Familia::Encryption.decrypt(legacy_manager['envelope'], context: legacy_manager['context'],
+                                                            additional_data: legacy_manager['aad']) == legacy_manager['plaintext']
+  end
+ensure
+  Familia.encryption_hkdf_salt = 'FamilialMatters'
+  Familia.encryption_hkdf_salt_history = []
+end
+
+# --- 10. Documented edge behaviors -------------------------------------------
+Proof.check('encrypting an empty string returns nil (stored as no-value)') do
+  Familia::Encryption.encrypt('', context: ctx).nil?
+end
+
+# In-band signaling hazard: a PLAINTEXT that happens to look like an envelope
+# is treated as already-encrypted by the field setter and stored VERBATIM --
+# i.e. never encrypted. See the findings report; this check documents the
+# current behavior so any future fix will show up as a diff here.
+lookalike = JSON.generate(
+  'algorithm' => 'aes-256-gcm',
+  'nonce' => Base64.strict_encode64(OpenSSL::Random.random_bytes(12)),
+  'ciphertext' => Base64.strict_encode64('attacker controlled bytes'),
+  'auth_tag' => Base64.strict_encode64(OpenSSL::Random.random_bytes(16)),
+  'key_version' => 'v2'
+)
+Proof.check('HAZARD (documented): plaintext shaped like an envelope is stored verbatim, unencrypted') do
+  s = ProofApp::Secret.new(objid: 'sec_hazard', owner_id: 'cust_1')
+  s.ciphertext = lookalike
+  s.ciphertext.encrypted_value == lookalike # byte-identical: no encryption happened
+end
+
+# --- Persist fixtures for the rollback phase ---------------------------------
+Proof.save_state('phase2',
+                 'familia_version' => Familia::VERSION,
+                 'envelopes' => [
+                   { 'label' => 'manager-xchacha', 'level' => 'manager', 'context' => ctx,
+                     'aad' => ctx, 'plaintext' => pt, 'envelope' => env },
+                   { 'label' => 'field-secret-xchacha', 'level' => 'field', 'model' => 'Secret',
+                     'objid' => 'sec_delta', 'owner_id' => 'cust_1',
+                     'plaintext' => 'field-level secret after upgrade', 'envelope' => field_env },
+                   aes_rec,
+                 ])
+puts '  (fixtures written to state/phase2.json)'
+
+Proof.finish!('Phase 2')

--- a/examples/encryption_upgrade_proof/phase3_rollback_hazard.rb
+++ b/examples/encryption_upgrade_proof/phase3_rollback_hazard.rb
@@ -1,0 +1,56 @@
+# examples/encryption_upgrade_proof/phase3_rollback_hazard.rb
+#
+# frozen_string_literal: true
+
+# Phase 3 -- "the one-way door": remove rbnacl again after XChaCha data exists.
+#
+# This phase demonstrates the operational hazard of the upgrade: once any
+# envelope has been written as xchacha20poly1305, every node that can be asked
+# to decrypt it MUST have rbnacl/libsodium. A node without it fails cleanly
+# (Familia::EncryptionError, no garbage plaintext) -- but it fails. The same
+# applies to a mixed fleet mid-rolling-deploy: an upgraded node writes
+# XChaCha, a not-yet-upgraded node cannot read it.
+#
+# AES envelopes remain readable throughout, so rollback only strands data
+# written after the upgrade.
+
+require_relative 'common'
+require_relative 'model'
+
+abort "phase3 expects familia >= 2.11, got #{Familia::VERSION}" if Familia::VERSION < '2.11'
+abort 'phase3 expects rbnacl to be ABSENT' if defined?(RbNaCl)
+
+Proof.configure!
+
+puts "== Phase 3: rollback / mixed-fleet hazard (familia #{Familia::VERSION}, rbnacl removed) =="
+
+Familia::Encryption::Registry.setup!
+Proof.check('only aes-256-gcm registers again') do
+  Familia::Encryption::Registry.providers.keys == ['aes-256-gcm']
+end
+
+phase2 = Proof.load_state('phase2')
+xchacha_manager = phase2['envelopes'].find { |r| r['label'] == 'manager-xchacha' }
+xchacha_field   = phase2['envelopes'].find { |r| r['label'] == 'field-secret-xchacha' }
+aes_rec         = phase2['envelopes'].find { |r| r['label'] == 'manager-aes-211' }
+
+Proof.check_raises('XChaCha envelope fails CLEANLY without rbnacl (no silent garbage)',
+                   Familia::EncryptionError, /Unsupported algorithm/) do
+  Familia::Encryption.decrypt(xchacha_manager['envelope'],
+                              context: xchacha_manager['context'],
+                              additional_data: xchacha_manager['aad'])
+end
+
+Proof.check_raises('field-level rehydration of an XChaCha envelope fails loudly at wrap time',
+                   Familia::EncryptionError, /Unsupported algorithm/) do
+  s = ProofApp::Secret.new(objid: xchacha_field['objid'], owner_id: xchacha_field['owner_id'])
+  s.ciphertext = xchacha_field['envelope']
+  s.ciphertext.reveal { |plain| plain }
+end
+
+Proof.check('AES envelopes written before and during the upgrade still decrypt') do
+  Familia::Encryption.decrypt(aes_rec['envelope'], context: aes_rec['context'],
+                                                   additional_data: aes_rec['aad']) == aes_rec['plaintext']
+end
+
+Proof.finish!('Phase 3')

--- a/examples/encryption_upgrade_proof/phase3_rollback_hazard.rb
+++ b/examples/encryption_upgrade_proof/phase3_rollback_hazard.rb
@@ -17,7 +17,7 @@
 require_relative 'common'
 require_relative 'model'
 
-abort "phase3 expects familia >= 2.11, got #{Familia::VERSION}" if Familia::VERSION < '2.11'
+abort "phase3 expects familia >= 2.11, got #{Familia::VERSION}" if Gem::Version.new(Familia::VERSION) < Gem::Version.new('2.11')
 abort 'phase3 expects rbnacl to be ABSENT' if defined?(RbNaCl)
 
 Proof.configure!

--- a/examples/encryption_upgrade_proof/run.sh
+++ b/examples/encryption_upgrade_proof/run.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+#
+# Encryption upgrade proof: AES-256-GCM -> XChaCha20-Poly1305
+#
+# Runs four phases, each in its own process under its own Gemfile, passing
+# ciphertext envelopes between phases through state/*.json:
+#
+#   Phase 0  familia 2.10.1 (released), OpenSSL only   -> writes AES envelopes
+#   Phase 1  this checkout, OpenSSL only               -> reads 0, writes AES
+#   Phase 2  this checkout + rbnacl/libsodium          -> reads 0+1, writes XChaCha
+#   Phase 3  this checkout, rbnacl removed again       -> reads 2 (rollback hazard)
+#
+# Requires: ruby + bundler, libsodium installed system-wide for phase 2,
+# network access for the initial `bundle install` of each Gemfile.
+
+set -euo pipefail
+cd "$(dirname "$0")"
+
+export PROOF_STATE_DIR="${PROOF_STATE_DIR:-$PWD/state}"
+rm -rf "$PROOF_STATE_DIR"
+mkdir -p "$PROOF_STATE_DIR"
+
+run_phase() {
+  local gemfile="$1" script="$2"
+  echo
+  echo "──────────────────────────────────────────────────────────────"
+  echo "  $script  (BUNDLE_GEMFILE=$gemfile)"
+  echo "──────────────────────────────────────────────────────────────"
+  (
+    export BUNDLE_GEMFILE="$PWD/gemfiles/$gemfile"
+    bundle check >/dev/null 2>&1 || bundle install --quiet
+    bundle exec ruby "$script"
+  )
+}
+
+if run_phase Gemfile.production-today phase0_production_today.rb; then
+  phase0_ok=1
+else
+  # Phase 0 needs the released 2.10.1 gem from rubygems; if it cannot be
+  # installed (offline), fall back to seeding the fixtures with this
+  # checkout's AES provider instead. The remaining phases still prove the
+  # envelope contract, just not against the released gem's bytes.
+  echo "!! phase 0 (released 2.10.1) unavailable -- seeding fixtures with the local checkout instead"
+  PROOF_EXPECT_VERSION="$(ruby -r./../../lib/familia/version -e 'puts Familia::VERSION' 2>/dev/null || true)"
+  export PROOF_EXPECT_VERSION
+  run_phase Gemfile.dev-no-libsodium phase0_production_today.rb
+fi
+
+run_phase Gemfile.dev-no-libsodium  phase1_gem_upgrade_no_libsodium.rb
+run_phase Gemfile.dev-with-libsodium phase2_libsodium_enabled.rb
+run_phase Gemfile.dev-no-libsodium  phase3_rollback_hazard.rb
+
+echo
+echo "All phases passed."

--- a/examples/encryption_upgrade_proof/run.sh
+++ b/examples/encryption_upgrade_proof/run.sh
@@ -17,8 +17,12 @@ set -euo pipefail
 cd "$(dirname "$0")"
 
 export PROOF_STATE_DIR="${PROOF_STATE_DIR:-$PWD/state}"
-rm -rf "$PROOF_STATE_DIR"
-mkdir -p "$PROOF_STATE_DIR"
+if [[ -z "$PROOF_STATE_DIR" || "$PROOF_STATE_DIR" == "/" ]]; then
+  echo "PROOF_STATE_DIR is unsafe ('$PROOF_STATE_DIR') -- refusing to rm -rf it" >&2
+  exit 1
+fi
+rm -rf -- "$PROOF_STATE_DIR"
+mkdir -p -- "$PROOF_STATE_DIR"
 
 run_phase() {
   local gemfile="$1" script="$2"
@@ -43,7 +47,9 @@ else
   echo "!! phase 0 (released 2.10.1) unavailable -- seeding fixtures with the local checkout instead"
   PROOF_EXPECT_VERSION="$(ruby -r./../../lib/familia/version -e 'puts Familia::VERSION' 2>/dev/null || true)"
   export PROOF_EXPECT_VERSION
+  export PROOF_FORCE_LEGACY_SALT=1
   run_phase Gemfile.dev-no-libsodium phase0_production_today.rb
+  unset PROOF_FORCE_LEGACY_SALT
 fi
 
 run_phase Gemfile.dev-no-libsodium  phase1_gem_upgrade_no_libsodium.rb

--- a/try/features/encryption/algorithm_upgrade_try.rb
+++ b/try/features/encryption/algorithm_upgrade_try.rb
@@ -1,0 +1,116 @@
+# try/features/encryption/algorithm_upgrade_try.rb
+#
+# frozen_string_literal: true
+
+# Locks in the algorithm-upgrade contract: installing rbnacl flips the DEFAULT
+# write algorithm to XChaCha20-Poly1305 (provider priority), while every
+# existing AES-256-GCM envelope keeps decrypting because the read path selects
+# the provider (and that provider's KDF) from the envelope's own `algorithm`
+# field -- never from the default provider. This is the exact upgrade path an
+# application takes when it adds libsodium to a deployment whose data at rest
+# is entirely AES-256-GCM (see examples/encryption_upgrade_proof for the
+# multi-process version that also runs against the released 2.10.1 gem).
+#
+# Also pins the cross-provider confusion property: relabeling an envelope's
+# algorithm between the two REGISTERED providers is rejected (nonce-size
+# validation), not just relabeling to an unknown algorithm.
+#
+# No database writes: everything here exercises the in-memory field path.
+
+require_relative '../../support/helpers/test_helpers'
+require 'base64'
+
+Familia.config.encryption_keys = {
+  v1: Base64.strict_encode64('a' * 32),
+  v2: Base64.strict_encode64('b' * 32),
+}
+Familia.config.current_key_version = :v2
+
+class AlgorithmUpgradeSecret < Familia::Horreum
+  feature :encrypted_fields
+  identifier_field :objid
+  field :objid
+  encrypted_field :ciphertext
+end
+
+@aes_mgr = Familia::Encryption::Manager.new(algorithm: 'aes-256-gcm')
+# Build the context exactly as EncryptedFieldType#build_context does, from the
+# class's runtime name (tryouts may namespace classes defined in a try file).
+@ctx = "#{AlgorithmUpgradeSecret.name}:ciphertext:sec_1"
+# With no aad_fields, EncryptedFieldType#build_aad is the same plain-joined
+# string as the context -- craft envelopes exactly as the field path would.
+@aes_envelope = @aes_mgr.encrypt('pre-upgrade secret', context: @ctx, additional_data: @ctx)
+
+## With rbnacl loaded, the registry's default is XChaCha20-Poly1305 by priority
+Familia::Encryption::Registry.setup!
+Familia::Encryption::Registry.default_provider.algorithm
+#=> 'xchacha20poly1305'
+
+## ...and it wins because its priority outranks AES-GCM's
+[Familia::Encryption::Providers::XChaCha20Poly1305Provider.priority,
+ Familia::Encryption::Providers::AESGCMProvider.priority]
+#=> [100, 50]
+
+## Field-level POSITIVE cross-algorithm read: an AES envelope injected into a
+## record (as DB hydration does) reveals fine while the default is XChaCha
+@record = AlgorithmUpgradeSecret.new(objid: 'sec_1')
+@record.ciphertext = @aes_envelope
+@record.ciphertext.reveal { |plaintext| plaintext }
+#=> 'pre-upgrade secret'
+
+## The injected envelope is passed through byte-identically (no re-encryption)
+@record.ciphertext.encrypted_value.equal?(@aes_envelope) ||
+  @record.ciphertext.encrypted_value == @aes_envelope
+#=> true
+
+## New assignments through the same field now encrypt with XChaCha20-Poly1305
+@fresh = AlgorithmUpgradeSecret.new(objid: 'sec_2')
+@fresh.ciphertext = 'post-upgrade secret'
+Familia::JsonSerializer.parse(@fresh.ciphertext.encrypted_value)['algorithm']
+#=> 'xchacha20poly1305'
+
+## re_encrypt_fields! upgrades an AES envelope to the current algorithm in place
+@migrate = AlgorithmUpgradeSecret.new(objid: 'sec_1')
+@migrate.ciphertext = @aes_envelope
+@migrate.re_encrypt_fields!
+Familia::JsonSerializer.parse(@migrate.ciphertext.encrypted_value)['algorithm']
+#=> 'xchacha20poly1305'
+
+## ...preserving the plaintext across the algorithm upgrade
+@migrate.ciphertext.reveal { |plaintext| plaintext }
+#=> 'pre-upgrade secret'
+
+## Cross-version AND cross-algorithm at once: an AES envelope under the retired
+## v1 master key still decrypts while current config is v2 + XChaCha default
+Familia.config.current_key_version = :v1
+@aes_v1 = @aes_mgr.encrypt('oldest data', context: @ctx, additional_data: @ctx)
+Familia.config.current_key_version = :v2
+Familia::Encryption.decrypt(@aes_v1, context: @ctx, additional_data: @ctx)
+#=> 'oldest data'
+
+## Relabeling an AES envelope as xchacha20poly1305 (both providers registered)
+## is rejected: the 12-byte GCM nonce fails the XChaCha 24-byte size check
+@relabeled = Familia::JsonSerializer.parse(@aes_envelope).merge('algorithm' => 'xchacha20poly1305')
+begin
+  Familia::Encryption.decrypt(Familia::JsonSerializer.dump(@relabeled),
+                              context: @ctx, additional_data: @ctx)
+  'decrypted-unexpectedly'
+rescue Familia::EncryptionError
+  'failed-as-expected'
+end
+#=> 'failed-as-expected'
+
+## ...and the reverse relabeling (XChaCha envelope marked aes-256-gcm) fails too
+@xchacha_envelope = Familia::Encryption.encrypt('fresh', context: @ctx, additional_data: @ctx)
+@relabeled_back = Familia::JsonSerializer.parse(@xchacha_envelope).merge('algorithm' => 'aes-256-gcm')
+begin
+  Familia::Encryption.decrypt(Familia::JsonSerializer.dump(@relabeled_back),
+                              context: @ctx, additional_data: @ctx)
+  'decrypted-unexpectedly'
+rescue Familia::EncryptionError
+  'failed-as-expected'
+end
+#=> 'failed-as-expected'
+
+# Restore config for any subsequent try files sharing the process.
+Familia.config.current_key_version = :v2


### PR DESCRIPTION
## Summary

This PR adds a comprehensive, executable proof that Familia's encryption envelope design safely supports upgrading from AES-256-GCM to XChaCha20-Poly1305 (via rbnacl/libsodium installation) while maintaining backward compatibility with all existing ciphertext, including envelopes written by the released 2.10.1 gem.

## Key Changes

- **Multi-phase proof framework** (`examples/encryption_upgrade_proof/`):
  - Phase 0: Baseline with released familia 2.10.1 (OpenSSL only) — establishes ground-truth AES-256-GCM envelopes
  - Phase 1: Gem upgrade without libsodium — verifies backward compatibility and HKDF salt migration
  - Phase 2: Gem + rbnacl installed — proves XChaCha becomes default write algorithm while all prior envelopes decrypt
  - Phase 3: Rollback scenario — documents the one-way-door operational hazard

- **Comprehensive verification** in Phase 2:
  - Default algorithm automatically flips to XChaCha20-Poly1305 via provider priority (zero app changes)
  - Every AES envelope from phases 0 and 1 decrypts correctly
  - New writes use XChaCha with 24-byte nonces and proper key derivation
  - Independent cryptographic validation: XChaCha keys are `BLAKE2b(context, key: master_key, personal: personalization)` and AES keys are `HKDF-SHA256(master_key, salt, context)`
  - Per-operation random nonces, AAD binding, tamper detection, and algorithm-confusion resistance all verified
  - Field-level re-encryption and migration paths tested

- **Documented hazards** (deliberately pinned as passing checks):
  - Personalization is unrotatable (no fallback mechanism like HKDF salt history)
  - Wiping the current HKDF salt strands current-salt data
  - Envelope-lookalike plaintext is stored verbatim, unencrypted
  - Upgrade is one-way: nodes without libsodium fail cleanly on XChaCha envelopes

- **Test infrastructure**:
  - `run.sh`: Orchestrates all four phases in separate processes with isolated Gemfiles
  - `common.rb`: Shared assertion harness and fixture management
  - `model.rb`: Proof models (Secret, Document) exercising field-level encryption
  - Multiple Gemfiles for different dependency configurations

- **Try file** (`try/features/encryption/algorithm_upgrade_try.rb`):
  - In-process demonstration of the upgrade contract
  - Validates cross-algorithm reads, field re-encryption, and algorithm-confusion resistance

https://claude.ai/code/session_01UWrr4PuBGb1by2jF6PLFE5