### PR TITLE
Reject blank VERIFIABLE_ID_HMAC_SECRET, not just missing (#335)

### DIFF
--- a/lib/familia/verifiable_identifier.rb
+++ b/lib/familia/verifiable_identifier.rb
@@ -43,16 +43,18 @@ module Familia
     # @return [String] the configured secret
     # @raise [KeyError] if VERIFIABLE_ID_HMAC_SECRET is unset or blank
     def self.secret_key
-      # Treat a present-but-empty value the same as absent. ENV.fetch only fires
+      # Treat a present-but-blank value the same as absent. ENV.fetch only fires
       # its default block when the key is missing, so a blank
-      # VERIFIABLE_ID_HMAC_SECRET="" would otherwise sail through and HMAC every
-      # identifier under an empty key -- silently reintroducing the forgeable-key
-      # weakness #310 S1 closed. This bites container setups that inject
-      # `VERIFIABLE_ID_HMAC_SECRET=${VERIFIABLE_ID_HMAC_SECRET:-}`, which supplies
-      # an empty string whenever the outer variable is unset. Fail closed on both.
+      # VERIFIABLE_ID_HMAC_SECRET="" (or a whitespace-only "   ", e.g. from a YAML
+      # parser or templating tool) would otherwise sail through and HMAC every
+      # identifier under an effectively empty key -- silently reintroducing the
+      # forgeable-key weakness #310 S1 closed. This bites container setups that
+      # inject `VERIFIABLE_ID_HMAC_SECRET=${VERIFIABLE_ID_HMAC_SECRET:-}`, which
+      # supplies an empty string whenever the outer variable is unset. strip.empty?
+      # fails closed on nil, "", and all-whitespace alike.
       @secret_key ||= begin
         value = ENV.fetch('VERIFIABLE_ID_HMAC_SECRET', nil)
-        if value.nil? || value.empty?
+        if value.nil? || value.strip.empty?
           raise KeyError, <<~MSG.strip
             VERIFIABLE_ID_HMAC_SECRET is not set (or is blank). Familia::VerifiableIdentifier
             refuses to fall back to a committed default or empty secret -- a known or empty

--- a/lib/familia/verifiable_identifier.rb
+++ b/lib/familia/verifiable_identifier.rb
@@ -28,9 +28,9 @@ module Familia
     #     verifiable identifiers.
     #   - **No committed fallback:** There is intentionally NO default. A hardcoded
     #     secret in source would be public knowledge, letting anyone forge valid
-    #     identifiers (issue #310, S1). A missing secret raises -- but lazily, the
-    #     first time an identifier is actually minted or verified, so merely
-    #     requiring this file (e.g. for introspection) never blows up.
+    #     identifiers (issue #310, S1). A missing OR blank secret raises -- but
+    #     lazily, the first time an identifier is actually minted or verified, so
+    #     merely requiring this file (e.g. for introspection) never blows up.
     #
     # @example Generating and Setting the Key
     #     1. Generate a new secure key in your terminal:
@@ -41,15 +41,26 @@ module Familia
     #        export VERIFIABLE_ID_HMAC_SECRET="<the generated value>"
     #
     # @return [String] the configured secret
-    # @raise [KeyError] if VERIFIABLE_ID_HMAC_SECRET is not set
+    # @raise [KeyError] if VERIFIABLE_ID_HMAC_SECRET is unset or blank
     def self.secret_key
-      @secret_key ||= ENV.fetch('VERIFIABLE_ID_HMAC_SECRET') do
-        raise KeyError, <<~MSG.strip
-          VERIFIABLE_ID_HMAC_SECRET is not set. Familia::VerifiableIdentifier
-          refuses to fall back to a committed default secret -- a known key would
-          let anyone forge valid identifiers. Generate one with `openssl rand -hex
-          32` and export it before generating or verifying identifiers.
-        MSG
+      # Treat a present-but-empty value the same as absent. ENV.fetch only fires
+      # its default block when the key is missing, so a blank
+      # VERIFIABLE_ID_HMAC_SECRET="" would otherwise sail through and HMAC every
+      # identifier under an empty key -- silently reintroducing the forgeable-key
+      # weakness #310 S1 closed. This bites container setups that inject
+      # `VERIFIABLE_ID_HMAC_SECRET=${VERIFIABLE_ID_HMAC_SECRET:-}`, which supplies
+      # an empty string whenever the outer variable is unset. Fail closed on both.
+      @secret_key ||= begin
+        value = ENV.fetch('VERIFIABLE_ID_HMAC_SECRET', nil)
+        if value.nil? || value.empty?
+          raise KeyError, <<~MSG.strip
+            VERIFIABLE_ID_HMAC_SECRET is not set (or is blank). Familia::VerifiableIdentifier
+            refuses to fall back to a committed default or empty secret -- a known or empty
+            key would let anyone forge valid identifiers. Generate one with `openssl rand -hex
+            32` and export it before generating or verifying identifiers.
+          MSG
+        end
+        value
       end
     end
 

--- a/try/integration/verifiable_identifier_try.rb
+++ b/try/integration/verifiable_identifier_try.rb
@@ -2,8 +2,6 @@
 #
 # frozen_string_literal: true
 
-# try/core/verifiable_identifier_try.rb
-
 require_relative '../support/helpers/test_helpers'
 
 # A dedicated HMAC secret is REQUIRED: the library intentionally has no
@@ -206,7 +204,13 @@ begin
 rescue KeyError
   :raised_key_error
 ensure
-  ENV['VERIFIABLE_ID_HMAC_SECRET'] = @orig_hmac_secret
+  # Restore with delete-on-nil: ENV[key] = nil raises TypeError, which would mask
+  # the KeyError assertion above and leave a stale memoized secret behind.
+  if @orig_hmac_secret.nil?
+    ENV.delete('VERIFIABLE_ID_HMAC_SECRET')
+  else
+    ENV['VERIFIABLE_ID_HMAC_SECRET'] = @orig_hmac_secret
+  end
   Familia::VerifiableIdentifier.reset_secret_key!
 end
 #=> :raised_key_error
@@ -223,7 +227,34 @@ begin
 rescue KeyError
   :raised_key_error
 ensure
-  ENV['VERIFIABLE_ID_HMAC_SECRET'] = @orig_hmac_secret
+  # Restore with delete-on-nil: ENV[key] = nil raises TypeError, which would mask
+  # the KeyError assertion above and leave a stale memoized secret behind.
+  if @orig_hmac_secret.nil?
+    ENV.delete('VERIFIABLE_ID_HMAC_SECRET')
+  else
+    ENV['VERIFIABLE_ID_HMAC_SECRET'] = @orig_hmac_secret
+  end
+  Familia::VerifiableIdentifier.reset_secret_key!
+end
+#=> :raised_key_error
+
+## A whitespace-only secret is blank too (issue #335): value.strip.empty? rejects
+## "   " so a secret mangled by a YAML parser or templating tool can't slip
+## through as an effectively-empty HMAC key.
+@orig_hmac_secret = ENV['VERIFIABLE_ID_HMAC_SECRET']
+Familia::VerifiableIdentifier.reset_secret_key!
+ENV['VERIFIABLE_ID_HMAC_SECRET'] = '   '
+begin
+  Familia::VerifiableIdentifier.secret_key
+  :did_not_raise
+rescue KeyError
+  :raised_key_error
+ensure
+  if @orig_hmac_secret.nil?
+    ENV.delete('VERIFIABLE_ID_HMAC_SECRET')
+  else
+    ENV['VERIFIABLE_ID_HMAC_SECRET'] = @orig_hmac_secret
+  end
   Familia::VerifiableIdentifier.reset_secret_key!
 end
 #=> :raised_key_error

--- a/try/integration/verifiable_identifier_try.rb
+++ b/try/integration/verifiable_identifier_try.rb
@@ -194,3 +194,36 @@ ENV['VERIFIABLE_ID_HMAC_SECRET'] = @orig_hmac_secret
 Familia::VerifiableIdentifier.reset_secret_key!
 @after_reset
 #=> 'rotated-secret-for-reset-test-0123456789abcdef'
+
+## An unset secret raises KeyError lazily (issue #310 S1). Uses a fresh key so a
+## restore-on-failure is unnecessary: the case never mutates the configured value.
+@orig_hmac_secret = ENV['VERIFIABLE_ID_HMAC_SECRET']
+Familia::VerifiableIdentifier.reset_secret_key!
+ENV.delete('VERIFIABLE_ID_HMAC_SECRET')
+begin
+  Familia::VerifiableIdentifier.secret_key
+  :did_not_raise
+rescue KeyError
+  :raised_key_error
+ensure
+  ENV['VERIFIABLE_ID_HMAC_SECRET'] = @orig_hmac_secret
+  Familia::VerifiableIdentifier.reset_secret_key!
+end
+#=> :raised_key_error
+
+## A present-but-empty secret raises KeyError too (issue #335): ENV.fetch treats
+## "" as a hit, so without the blank guard it would HMAC under an empty key --
+## silently reintroducing the forgeable-key weakness S1 closed.
+@orig_hmac_secret = ENV['VERIFIABLE_ID_HMAC_SECRET']
+Familia::VerifiableIdentifier.reset_secret_key!
+ENV['VERIFIABLE_ID_HMAC_SECRET'] = ''
+begin
+  Familia::VerifiableIdentifier.secret_key
+  :did_not_raise
+rescue KeyError
+  :raised_key_error
+ensure
+  ENV['VERIFIABLE_ID_HMAC_SECRET'] = @orig_hmac_secret
+  Familia::VerifiableIdentifier.reset_secret_key!
+end
+#=> :raised_key_error


### PR DESCRIPTION
## Summary

Closes #335. Completes the #310 S1 fix by rejecting a **present-but-empty** `VERIFIABLE_ID_HMAC_SECRET`, not just an absent one.

The 2.11.0 S1 fix removed the committed HMAC fallback so a *missing* secret raises. But `ENV.fetch` treats `VERIFIABLE_ID_HMAC_SECRET=""` as a hit, so the default block never fired and every identifier was HMAC'd under an **empty key** — silently reintroducing the forgeable-key weakness S1 was meant to close. Container setups that inject `VERIFIABLE_ID_HMAC_SECRET=${VERIFIABLE_ID_HMAC_SECRET:-}` hit exactly this: the expansion yields an empty string whenever the outer variable is unset.

## Change

- `VerifiableIdentifier.secret_key` now fails closed on `nil` **or** empty, with an updated message. The lazy read is preserved — requiring the file for introspection still never raises; only minting/verifying an identifier does.

## Verification

- Added tryout coverage for both the unset and blank paths in `try/integration/verifiable_identifier_try.rb`.
- Full `verifiable_identifier` tryout suite: **33 passed**.

## Scope

Small and self-contained; flagged in #335 as a candidate to fold into the **2.11.1** release since it completes S1. Sibling 2.12 follow-ups (#333, #334) are tracked separately and not included here.

Downstream, onetimesecret mitigates the same empty-string path at boot (onetimesecret/onetimesecret#3630); this PR closes it at the library layer.

_Drafted with AI assistance._

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UWrr4PuBGb1by2jF6PLFE5)_