### PR TITLE
Fix DataType#exists? and StringKey size/empty? for deleted keys

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,9 +18,15 @@ Fixed
 - ``Familia::DataType#exists?`` (and its ``StringKey``/``Counter``/``Lock``
   subclasses) no longer returns ``true`` for a deleted or never-created key.
   The check consulted ``!size.zero?`` in addition to the database ``EXISTS``
-  count; ``StringKey#to_s`` falls back to ``Object#to_s`` for a ``nil``
-  value, so ``#size`` was non-zero even when the key was absent. ``exists?``
-  now relies solely on a boolean-coerced ``EXISTS`` count. Issue #331
+  count; ``StringKey#char_count`` derived from ``#to_s.size``, and ``#to_s``
+  deliberately falls back to ``Familia::Base``'s "never nil" inspect-string
+  (per that method's documented contract) when the value is ``nil`` -- so
+  ``#size`` was non-zero even when the key was absent. ``exists?`` now relies
+  solely on a boolean-coerced ``EXISTS`` count, and ``char_count``
+  (``size``/``length``/``empty?``) now reads from ``#value`` directly instead
+  of the display-oriented ``#to_s``. ``to_s`` itself is unchanged -- its
+  never-nil fallback is intentional and shared by every ``Familia::Base``
+  object. Issue #331
 
 Documentation
 -------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,16 @@ The format is based on `Keep a Changelog <https://keepachangelog.com/en/1.1.0/>`
 2.11.1 — 2026-07-04
 ===================
 
+Fixed
+-----
+
+- ``Familia::DataType#exists?`` (and its ``StringKey``/``Counter``/``Lock``
+  subclasses) no longer returns ``true`` for a deleted or never-created key.
+  The check consulted ``!size.zero?`` in addition to the database ``EXISTS``
+  count; ``StringKey#to_s`` falls back to ``Object#to_s`` for a ``nil``
+  value, so ``#size`` was non-zero even when the key was absent. ``exists?``
+  now relies solely on a boolean-coerced ``EXISTS`` count. Issue #331
+
 Documentation
 -------------
 
@@ -30,6 +40,9 @@ AI Assistance
 
 - The encryption upgrade proof, its regression tryouts, and this changelog
   entry were drafted with AI assistance. PR #330
+
+- The ``exists?`` fix and its regression tryouts were drafted with AI
+  assistance. Issue #331
 
 .. _changelog-2.11.0:
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,18 +15,21 @@ The format is based on `Keep a Changelog <https://keepachangelog.com/en/1.1.0/>`
 Fixed
 -----
 
-- ``Familia::DataType#exists?`` (and its ``StringKey``/``Counter``/``Lock``
-  subclasses) no longer returns ``true`` for a deleted or never-created key.
-  The check consulted ``!size.zero?`` in addition to the database ``EXISTS``
-  count; ``StringKey#char_count`` derived from ``#to_s.size``, and ``#to_s``
-  deliberately falls back to ``Familia::Base``'s "never nil" inspect-string
-  (per that method's documented contract) when the value is ``nil`` -- so
-  ``#size`` was non-zero even when the key was absent. ``exists?`` now relies
-  solely on a boolean-coerced ``EXISTS`` count, and ``char_count``
-  (``size``/``length``/``empty?``) now reads from ``#value`` directly instead
-  of the display-oriented ``#to_s``. ``to_s`` itself is unchanged -- its
-  never-nil fallback is intentional and shared by every ``Familia::Base``
-  object. Issue #331
+- ``Familia::DataType#exists?`` no longer returns ``true`` for a deleted or
+  never-created scalar key (``StringKey``, ``Counter``, ``Lock``,
+  ``JsonStringKey``). The check was ``dbclient.exists(dbkey) && !size.zero?``,
+  but ``EXISTS`` returns an Integer count and ``0`` is truthy in Ruby, so the
+  guard never short-circuited on a missing key -- existence was decided
+  entirely by the size check. ``exists?`` now uses a boolean-coerced ``EXISTS``
+  count directly. Issue #331
+
+- Relatedly, ``StringKey#size``/``#length``/``#empty?`` (and ``Lock``'s) no
+  longer reflect the never-nil ``#to_s`` fallback. ``#char_count`` derived from
+  ``#to_s.size``, and ``#to_s`` intentionally returns ``Familia::Base``'s
+  documented "never nil" inspect-string when the value is absent -- so
+  ``#size`` was non-zero (and ``#empty?`` false) for a missing key.
+  ``#char_count`` now reads ``#value`` directly; ``#to_s`` is left unchanged.
+  Issue #331
 
 Documentation
 -------------

--- a/lib/familia/data_type/database_commands.rb
+++ b/lib/familia/data_type/database_commands.rb
@@ -35,14 +35,13 @@ module Familia
       end
       alias clear delete!
 
-      # dbclient.exists returns an Integer (the match count), and 0 is truthy in
-      # Ruby, so a bare `dbclient.exists(dbkey) && ...` never short-circuits on a
-      # missing key -- the result ends up governed entirely by the second
-      # operand. That's harmless for container types (Redis deletes them once
-      # empty, so size and existence always agree) but StringKey#to_s falls back
-      # to Object#to_s for a nil value, making #size non-zero even when the key
-      # is gone. Familia.positive? coerces the count to a real boolean (and
-      # passes a Redis::Future through untouched inside a pipeline/transaction).
+      # EXISTS returns an Integer match count (0 for a missing key). The prior
+      # `dbclient.exists(dbkey) && !size.zero?` never short-circuited, since 0
+      # is truthy in Ruby -- so existence was actually decided by the size
+      # check, which some scalar types (see StringKey#char_count) computed from
+      # a never-nil display string and so got wrong for a missing key.
+      # Familia.positive? coerces the count to a real boolean, and passes a
+      # Redis::Future through untouched inside a pipeline/transaction.
       def exists?
         Familia.positive?(dbclient.exists(dbkey))
       end

--- a/lib/familia/data_type/database_commands.rb
+++ b/lib/familia/data_type/database_commands.rb
@@ -35,8 +35,16 @@ module Familia
       end
       alias clear delete!
 
+      # dbclient.exists returns an Integer (the match count), and 0 is truthy in
+      # Ruby, so a bare `dbclient.exists(dbkey) && ...` never short-circuits on a
+      # missing key -- the result ends up governed entirely by the second
+      # operand. That's harmless for container types (Redis deletes them once
+      # empty, so size and existence always agree) but StringKey#to_s falls back
+      # to Object#to_s for a nil value, making #size non-zero even when the key
+      # is gone. Familia.positive? coerces the count to a real boolean (and
+      # passes a Redis::Future through untouched inside a pipeline/transaction).
       def exists?
-        dbclient.exists(dbkey) && !size.zero?
+        Familia.positive?(dbclient.exists(dbkey))
       end
 
       def current_expiration

--- a/lib/familia/data_type/types/stringkey.rb
+++ b/lib/familia/data_type/types/stringkey.rb
@@ -30,10 +30,17 @@ module Familia
       val
     end
 
-    # Returns the number of elements in the list
-    # @return [Integer] number of elements
+    # Returns the number of characters in the stored value.
+    #
+    # Reads from #value rather than #to_s: #to_s follows Familia::Base's
+    # "never nil" contract and falls back to an inspect-style string
+    # (e.g. "#<Familia::StringKey:0x...>") when there's no value, which
+    # made #char_count/#size/#empty? report a nonsense non-zero count for
+    # a deleted/never-created key.
+    #
+    # @return [Integer] number of characters
     def char_count
-      to_s.size
+      value.to_s.size
     end
     alias size char_count
     alias length char_count

--- a/try/bug_fixes/stringkey_exists_try.rb
+++ b/try/bug_fixes/stringkey_exists_try.rb
@@ -14,7 +14,10 @@
 #
 # Fixed on two fronts:
 #   - #exists? now relies solely on a boolean-coerced EXISTS count
-#     (Familia.positive?), not on #size at all.
+#     (Familia.positive?), not on #size at all. This also cures a separate
+#     false-negative for JsonStringKey holding an empty string (old size-0
+#     guard said "absent"), and correctly passes a Redis::Future through
+#     inside a transaction/pipeline.
 #   - #char_count now reads from #value directly instead of #to_s, so it
 #     reflects the actual stored content rather than the display fallback.
 #     #to_s itself is intentionally untouched -- its never-nil contract is
@@ -25,10 +28,12 @@ require_relative '../support/helpers/test_helpers'
 @str = Familia::StringKey.new 'test:bugfix:stringkey_exists'
 @counter = Familia::Counter.new 'test:bugfix:counter_exists'
 @lock = Familia::Lock.new 'test:bugfix:lock_exists'
+@json = Familia::JsonStringKey.new 'test:bugfix:json_exists'
 
 @str.delete!
 @counter.delete!
 @lock.delete!
+@json.delete!
 
 ## StringKey#exists? is false for a key that has never existed
 @str.exists?
@@ -115,7 +120,34 @@ require_relative '../support/helpers/test_helpers'
 @lock.exists?
 #=> false
 
+## JsonStringKey#exists? is false for a key that has never existed
+@json.exists?
+#=> false
+
+## JsonStringKey#exists? is true for a key holding an empty string
+# The old `!size.zero?` guard reported false here (size 0 for ""), a
+# false-negative even though the key is genuinely present. The EXISTS-only
+# check now reports its actual presence.
+@json.value = ''
+@json.exists?
+#=> true
+
+## JsonStringKey#exists? is false again after delete!
+@json.delete!
+@json.exists?
+#=> false
+
+## exists? inside a transaction passes a Redis::Future through without raising
+# Familia.positive? must NOT call Integer#positive? on a Future (that raises);
+# it returns the Future untouched. The Future resolves to the raw EXISTS count.
+@str.value = 'txn'
+@captured = nil
+@str.transaction { |_conn| @captured = @str.exists? }
+[@captured.is_a?(Redis::Future), @captured.value]
+#=> [true, 1]
+
 ## Teardown
 @str.delete!
 @counter.delete!
 @lock.delete!
+@json.delete!

--- a/try/bug_fixes/stringkey_exists_try.rb
+++ b/try/bug_fixes/stringkey_exists_try.rb
@@ -6,11 +6,19 @@
 # `dbclient.exists(dbkey) && !size.zero?`. EXISTS returns an Integer (0 for a
 # missing key), and 0 is truthy in Ruby, so the left operand never
 # short-circuited -- the result was governed entirely by `!size.zero?`. For
-# StringKey (and its Counter/Lock subclasses), #to_s falls back to
-# Object#to_s when the value is nil, making #size non-zero even for a
-# deleted/never-created key. Net effect: #exists? returned true regardless of
-# whether the key was actually present. Fixed to rely solely on a
-# boolean-coerced EXISTS count (Familia.positive?).
+# StringKey (and its Counter/Lock subclasses), #char_count derived from
+# #to_s.size, and #to_s deliberately falls back to Familia::Base's "never
+# nil" inspect-string (e.g. "#<Familia::StringKey:0x...>") when the value is
+# nil, per that method's documented contract. That made #size/#char_count
+# non-zero -- and #empty? false -- even for a deleted/never-created key.
+#
+# Fixed on two fronts:
+#   - #exists? now relies solely on a boolean-coerced EXISTS count
+#     (Familia.positive?), not on #size at all.
+#   - #char_count now reads from #value directly instead of #to_s, so it
+#     reflects the actual stored content rather than the display fallback.
+#     #to_s itself is intentionally untouched -- its never-nil contract is
+#     shared by every Familia::Base object.
 
 require_relative '../support/helpers/test_helpers'
 
@@ -39,6 +47,45 @@ require_relative '../support/helpers/test_helpers'
 @str.delete!
 @str.exists?
 #=> false
+
+## StringKey#size is 0 for a key that has never existed
+@str.size
+#=> 0
+
+## StringKey#empty? is true for a key that has never existed
+@str.empty?
+#=> true
+
+## StringKey#to_s still honors Familia::Base's never-nil contract when unset
+[@str.to_s.nil?, @str.to_s.start_with?('#<Familia::StringKey')]
+#=> [false, true]
+
+## StringKey#size matches the real value length once set
+@str.value = 'hello'
+@str.size
+#=> 5
+
+## StringKey#empty? is false once a value is set
+@str.empty?
+#=> false
+
+## StringKey#to_s returns the real value once set (not the inspect fallback)
+@str.to_s
+#=> 'hello'
+
+## StringKey#size is 0 again after delete!
+@str.delete!
+@str.size
+#=> 0
+
+## StringKey#empty? is true again after delete!
+@str.empty?
+#=> true
+
+## An explicitly-set empty string is also correctly empty (distinct from nil)
+@str.value = ''
+[@str.size, @str.empty?]
+#=> [0, true]
 
 ## Counter#exists? is false for a counter that has never existed
 @counter.exists?

--- a/try/bug_fixes/stringkey_exists_try.rb
+++ b/try/bug_fixes/stringkey_exists_try.rb
@@ -1,0 +1,74 @@
+# try/bug_fixes/stringkey_exists_try.rb
+#
+# frozen_string_literal: true
+
+# Regression (#331): Familia::DataType#exists? checked
+# `dbclient.exists(dbkey) && !size.zero?`. EXISTS returns an Integer (0 for a
+# missing key), and 0 is truthy in Ruby, so the left operand never
+# short-circuited -- the result was governed entirely by `!size.zero?`. For
+# StringKey (and its Counter/Lock subclasses), #to_s falls back to
+# Object#to_s when the value is nil, making #size non-zero even for a
+# deleted/never-created key. Net effect: #exists? returned true regardless of
+# whether the key was actually present. Fixed to rely solely on a
+# boolean-coerced EXISTS count (Familia.positive?).
+
+require_relative '../support/helpers/test_helpers'
+
+@str = Familia::StringKey.new 'test:bugfix:stringkey_exists'
+@counter = Familia::Counter.new 'test:bugfix:counter_exists'
+@lock = Familia::Lock.new 'test:bugfix:lock_exists'
+
+@str.delete!
+@counter.delete!
+@lock.delete!
+
+## StringKey#exists? is false for a key that has never existed
+@str.exists?
+#=> false
+
+## StringKey#exists? returns a real boolean, not a Future/Integer leak
+@str.exists?.class
+#=> FalseClass
+
+## StringKey#exists? is true once a value is set
+@str.value = 'hello'
+@str.exists?
+#=> true
+
+## StringKey#exists? is false again after delete!
+@str.delete!
+@str.exists?
+#=> false
+
+## Counter#exists? is false for a counter that has never existed
+@counter.exists?
+#=> false
+
+## Counter#exists? is true once incremented
+@counter.increment
+@counter.exists?
+#=> true
+
+## Counter#exists? is false again after delete!
+@counter.delete!
+@counter.exists?
+#=> false
+
+## Lock#exists? is false for a lock that was never acquired
+@lock.exists?
+#=> false
+
+## Lock#exists? is true once acquired
+@lock.acquire('token1', ttl: 10)
+@lock.exists?
+#=> true
+
+## Lock#exists? is false again after release
+@lock.release('token1')
+@lock.exists?
+#=> false
+
+## Teardown
+@str.delete!
+@counter.delete!
+@lock.delete!


### PR DESCRIPTION
## Summary

Stacked on `claude/prepare-2-11-release-dq9ci3` (#332) — addresses #331 before that release ships, since it's a real correctness bug with no code changes otherwise in this release.

Same root cause, two effects: `Familia::DataType`'s scalar types misreport their own presence/content for a deleted or never-created key.

## Commit 1 — `exists?` returned `true` for a deleted key

`exists?` checked `dbclient.exists(dbkey) && !size.zero?`. `EXISTS` returns an Integer (`0` for a missing key), and `0` is truthy in Ruby, so the left operand never short-circuited — the result was governed entirely by `!size.zero?`, which was wrong for `StringKey` (see below). Fixed:

```ruby
def exists?
  Familia.positive?(dbclient.exists(dbkey))
end
```

Matches the pattern already used by `StringKey#del`. Applies to all scalar subclasses (`StringKey`/`Counter`/`Lock`/`JsonStringKey`). Behaviorally identical for `HashKey`/`SortedSet`/`UnsortedSet`/`ListKey` (Redis deletes container types once empty, so `EXISTS` and size-based checks always agreed there already), and it's now one round trip instead of two. Also cures a separate `JsonStringKey` false-negative: a key holding `''` used to report `exists? == false` even though it's genuinely present.

## Commit 2 — `size`/`length`/`empty?` still reported nonsense

Initially scoped this PR to just `exists?`, matching the issue's own suggested fix. On reflection (and after empirically checking), that left the identical defect reachable through `size`/`empty?`:

```ruby
sk = Familia::StringKey.new('k'); sk.delete!
sk.empty?  # => false  (should be true)
sk.size    # => 27     (should be 0 -- length of an inspect string, not the value)
```

Root cause: `char_count` (and its `size`/`length` aliases) derived from `to_s.size`. `Familia::Base#to_s` has an explicit, documented contract — *"Never nil... Using this as a default via super is recommended"* — and `StringKey#to_s` correctly follows it, falling back to an inspect-style string when the value is `nil`. That's the right behavior for `to_s` (every `Familia::Base` object shares it), but `char_count` was using that *display* string to answer a *content-length* question. Fix, leaving `to_s` untouched:

```ruby
def char_count
  value.to_s.size   # was: to_s.size
end
```

This corrects `size`/`length`/`empty?` for `StringKey` and `Lock`. (`Counter` reports `size 1` for a missing key regardless — its default of `0` materializes on read — so it's unaffected by this change; only its `exists?` is fixed, by commit 1.)

## Commit 3 — review response

An independent review pass surfaced three refinements (no change to the fix itself): `JsonStringKey` + transaction test coverage, scoping the `size`/`empty?` changelog claim to `StringKey`/`Lock` (not `Counter`), and trimming the `StringKey`-specific narrative out of the generic `DatabaseCommands#exists?` comment.

## Changelog

Folded directly into the still-unreleased `2.11.1` section of `CHANGELOG.rst` (`Fixed` category) rather than adding a new scriv fragment, since 2.11.1 hasn't been tagged/published yet and this stacks on the branch that prepares it.

## Testing

`try/bug_fixes/stringkey_exists_try.rb` (23 tests): `exists?`/`size`/`empty?`/`to_s` across `StringKey`/`Counter`/`Lock`/`JsonStringKey` × never-existed/set/deleted/explicitly-empty-string states; an explicit check that `to_s`'s never-nil fallback still fires post-fix; and a transaction case proving `Familia.positive?` passes a `Redis::Future` through untouched (rather than raising on `Integer#positive?`).

- Verified the tests actually bite: reverting both fixes to their pre-fix state fails **14 of 23** cases (including the new `JsonStringKey` empty-string and transaction cases); the "value present" and "`to_s` never-nil" cases correctly stay green either way.
- Full tryouts suite: **298/298 files pass**.

https://claude.ai/code/session_016ZF9pUtYEENskgfRhbPog4

---
_Generated by [Claude Code](https://claude.ai/code/session_016ZF9pUtYEENskgfRhbPog4)_