### PR TITLE
Memory audit: diagnose #309 O(N) permission query + hunt per-process leaks

### DIFF
--- a/docs/investigation/memory-audit.md
+++ b/docs/investigation/memory-audit.md
@@ -8,9 +8,11 @@ Ruby RSS climbs over weeks. Is the cause in Familia?**
 This document diagnoses #309 precisely and audits the rest of `lib/` for memory
 problems. It is a *diagnosis*, not a set of fixes; each finding carries a fix
 sketch and the remediation section prioritises them, but no behaviour is changed
-by this branch. The one code artifact here is an executable proof
-(`try/investigation/process_memory_leak_proof.rb`) that reproduces the four
-latent per-process leaks in pure Ruby.
+by this branch. The code artifacts here are two executable proofs in
+`try/investigation/`: `process_memory_leak_proof.rb` reproduces the four latent
+per-process leaks (Category A) in pure Ruby, and `memory_leak_proof.rb`
+reproduces the Redis-side orphan and O(N) high-water-mark findings (Categories
+B/C) against a live Redis.
 
 ## Method
 
@@ -19,9 +21,11 @@ Eight focused audits ran in parallel over `lib/`, each owning one vector
 method/module generation; encryption & transient fields; relationships/indexing
 Redis-side orphans; whole-collection materialization; logging/instrumentation).
 Every candidate was then classified adversarially against a two-axis rubric and
-only reported if it survived a refutation attempt. Prior art from the unmerged
-`fix/memory-leak` branch (findings F1–F4 + `try/investigation/memory_leak_proof.rb`)
-was confirmed/updated against current 2.11.1 code rather than restated.
+only reported if it survived a refutation attempt. Prior art from the
+`fix/memory-leak` investigation branch (findings F1–F4 and its Redis-side proof)
+was confirmed against current 2.11.1 code rather than restated, and that proof —
+`try/investigation/memory_leak_proof.rb` — is consolidated onto this branch
+alongside this write-up so the evidence and the diagnosis no longer live apart.
 
 ## TL;DR
 
@@ -300,6 +304,16 @@ values, replicated across every integer timestamp. No single range expresses it
 in fact semantically broken for this reason). The full fetch is by design; the
 issue is bounding how much is pulled.
 
+**Provenance.** This code entered on commit `ed69e69e` ("Fix dead/incorrect
+participation permission query", already merged into 2.11.1), which replaced a
+dead `zrangebyscore` call — a nonexistent method whose fallback also raised, so
+the query raised unconditionally — with today's fetch-all-then-filter. The
+author's own commit message reaches the same root cause independently: *"A
+score-range query also cannot filter by permission: bits live in the fractional
+part of the score and are not a contiguous range."* The O(N) fetch was therefore
+a deliberate correctness fix, and #309 is the follow-on ask to bound it; its
+regression tryout lives at `try/bug_fixes/permission_query_try.rb`.
+
 **Fix design (bounded, backward-compatible).**
 
 1. **Keep the default return an `Array`.** Callers rely on `.length`, indexing,
@@ -383,10 +397,11 @@ weeks-long RSS climb; each is small and low-risk.
 
 ## How to confirm empirically
 
-**In-gem (this branch):** `bundle exec ruby try/investigation/process_memory_leak_proof.rb`
-reproduces A1–A4 (pure Ruby, no Redis). For Category C, the `fix/memory-leak`
-branch's `try/investigation/memory_leak_proof.rb` proves F1/F3 and the O(N)
-materialization high-water mark against a live Redis.
+**In-gem (this branch, both proofs in `try/investigation/`):**
+`bundle exec ruby try/investigation/process_memory_leak_proof.rb` reproduces
+A1–A4 (pure Ruby, no Redis). `FAMILIA_TEST_URI=redis://127.0.0.1:6379 ruby
+try/investigation/memory_leak_proof.rb` proves the Category C orphans (F1/F3) and
+the Category B O(N) materialization high-water mark against a live Redis.
 
 **In a running OTS process — determine which (if any) A-candidate is active:**
 

--- a/docs/investigation/memory-audit.md
+++ b/docs/investigation/memory-audit.md
@@ -1,0 +1,448 @@
+# Familia memory audit (v2.11.1)
+
+Investigation of [#309 — Participation permission query (`<collection>_with_permission`)
+is O(N) memory](https://github.com/delano/familia/issues/309), broadened to the
+question that motivated it: **OneTimeSecret shows a slow per-process memory hole —
+Ruby RSS climbs over weeks. Is the cause in Familia?**
+
+This document diagnoses #309 precisely and audits the rest of `lib/` for memory
+problems. It is a *diagnosis*, not a set of fixes; each finding carries a fix
+sketch and the remediation section prioritises them, but no behaviour is changed
+by this branch. The one code artifact here is an executable proof
+(`try/investigation/process_memory_leak_proof.rb`) that reproduces the four
+latent per-process leaks in pure Ruby.
+
+## Method
+
+Eight focused audits ran in parallel over `lib/`, each owning one vector
+(#309; class-level/global state; connection & fiber-local lifecycle; runtime
+method/module generation; encryption & transient fields; relationships/indexing
+Redis-side orphans; whole-collection materialization; logging/instrumentation).
+Every candidate was then classified adversarially against a two-axis rubric and
+only reported if it survived a refutation attempt. Prior art from the unmerged
+`fix/memory-leak` branch (findings F1–F4 + `try/investigation/memory_leak_proof.rb`)
+was confirmed/updated against current 2.11.1 code rather than restated.
+
+## TL;DR
+
+**Familia has no unconditional, default-configuration per-process memory leak.**
+Its Ruby-heap discipline is strong: there are no `@@` class variables anywhere;
+every class-level structure is keyed on a load-time-finite set (class / field /
+feature / algorithm / section names), is per-instance and GC-reclaimable, is
+fiber-local and cleared in an `ensure`, or lives Redis-side.
+
+The OTS symptom — **per-process RSS growth over weeks** — can only be explained by
+a structure that is *Ruby-process* **and** *permanently, unboundedly retained*.
+Exactly four such structures exist, and **all four are latent**: each is an
+append-only registry with no eviction path that Familia itself never grows —
+each is armed only by a specific *application* call pattern. In descending order
+of likelihood for OTS:
+
+| # | Latent leak | Fires when the app… | Evidence |
+|---|-------------|---------------------|----------|
+| A1 | Encryption request-key cache keyed on `record.identifier` (`encryption/manager.rb:146-167`) | enables key caching at a scope broader than one request | proof A1 |
+| A2 | `reconnect!` re-registers Redis middleware (`connection/middleware.rb:91-94`) | enables DB logging/counter **and** calls `reconnect!` repeatedly | proof A2 |
+| A3 | `Instrumentation.@hooks` append-only arrays (`instrumentation.rb:56-112`) | registers instrumentation hooks per-request / on reload | proof A3 |
+| A4 | `Familia.members` strong-ref subclass registry (`horreum.rb:173`) | defines `Horreum` subclasses at runtime (per request/tenant) | proof A4 |
+
+Everything else the audit surfaced is either a **transient O(N) spike** (#309 and
+its siblings — Ruby-side but GC-reclaimable) or **Redis-side orphan accumulation**
+(real dataset-growth debt, but the wrong locus for a process-RSS climb).
+
+**Most probable Familia-side cause for OTS: A1.** OTS is a secrets application that
+derives a per-record key for every encrypted field; if it has opted into key
+caching anywhere other than a strictly per-request `with_request_cache` block,
+the cache retains one derived key per distinct secret, forever — precisely a
+slow, weeks-long RSS climb of key material. If none of A1–A4 matches OTS's actual
+usage, the leak is most likely in OTS's own code (out of scope for this audit),
+with transient-spike high-water-mark ratcheting (Category B) as the runner-up
+in-gem explanation.
+
+## Classification framework
+
+Two axes decide whether a finding can be the OTS cause:
+
+- **Locus** — *Redis-side* (grows the Redis dataset/keyspace, not the Ruby
+  process) vs *Ruby-process* (grows Ruby heap / RSS).
+- **Persistence** — *transient* (a per-call spike GC reclaims after return) vs
+  *permanent-unbounded* (retained for the process lifetime, growing without
+  bound) vs *bounded* (capped, or keyed on a finite set).
+
+`matches_ots_symptom` is true **only** for Ruby-process **and** permanent-unbounded
+**and** keyed on values that grow with distinct runtime data over the process
+lifetime. A transient O(N) spike does not qualify (GC frees it). A Redis-side
+orphan does not qualify (it grows the server dataset, not the client process).
+This is why a large fraction of "scary-looking" findings are correctly *not* the
+OTS cause — and why the honest answer is a short list of latent registries rather
+than a single smoking gun.
+
+One important caveat sits between Category A and B: a **transient** O(N) spike over
+a collection whose size **grows over time**, hit on a hot or periodic path, keeps
+raising the RSS high-water mark; with glibc/Ruby heap fragmentation the process
+may never return those pages to the OS. That *masquerades* as a slow leak. It is
+bounded-per-call retention, not unbounded retention — but operationally it can
+look identical to A1–A4. Category B calls out which sites have that growing-N,
+hot-path shape.
+
+---
+
+## Category A — latent per-process leaks (the OTS suspects)
+
+All four are `ruby-process` + `permanent-unbounded`, append-only, with no eviction
+API — but Familia never drives the trigger. Reproduced in
+`try/investigation/process_memory_leak_proof.rb` (pure Ruby, no Redis).
+
+### A1 — Encryption request-key cache is unbounded in cache-key cardinality
+
+- **Where:** `lib/familia/encryption/manager.rb:146-167`; lifecycle in
+  `lib/familia/encryption/request_cache.rb:36-55`; context shape in
+  `lib/familia/features/encrypted_fields/encrypted_field_type.rb:183-189`.
+- **Mechanism:** when `Fiber[:familia_request_cache_enabled]` is set,
+  `derive_key_without_increment` stores the derived key at
+  `cache_key = "#{algorithm}:#{version}:#{effective_salt}:#{context}"` where
+  `context = "#{record.class.name}:#{@name}:#{record.identifier}"` (+ optional
+  per-record entropy). Cardinality is therefore `algorithm(≈2) × version(few) ×
+  salt(few) × field(finite) × record.identifier(UNBOUNDED)`. The value is 32 bytes
+  of key material plus the key string; roughly 100–300 B retained per
+  distinct (record, field).
+- **Locus/Persistence:** ruby-process; permanent-unbounded **only** if enabled
+  outside a per-request boundary. Also a **security** locus (retained key
+  material).
+- **Default is safe:** the flag defaults `nil`; the cache Hash is never even
+  allocated, and the gem never enables it internally.
+- **Opt-in is safe:** `with_request_cache` wipes on entry **and** in an `ensure`
+  on exit, so a pooled fiber begins and ends each request empty (this is the
+  #310-S6 defence documented at `request_cache.rb:8-13`).
+- **The leak:** an app that sets `Fiber[:familia_request_cache_enabled] = true`
+  once on a long-lived pooled server fiber, or wraps a worker loop rather than a
+  single request, never clears the Hash. Proof A1 shows it growing to exactly one
+  entry per distinct record and staying (vs. `nil` after `with_request_cache`).
+- **Why this is the top OTS suspect:** OTS derives a per-secret key for every
+  encrypted field; `record.identifier` is per-secret and unbounded over time; the
+  retained object is key material; the growth profile is a slow weeks-long climb.
+- **Fix sketch:** (1) drop the unbounded `record.identifier` dimension from the
+  cache key, or cap the cache (small LRU); (2) refuse to populate unless an active
+  `with_request_cache` frame exists (a depth counter), so directly setting the
+  Fiber flag can't create an unmanaged cache; (3) document that `Fiber[...]`
+  storage is inherited by child fibers.
+
+### A2 — `reconnect!` re-registers Redis middleware on every call
+
+- **Where:** `lib/familia/connection/middleware.rb:87-107` (reset+recall),
+  `:113-136` (`register_middleware_once`), `RedisClient.register` at `:121`/`:129`;
+  guard flags initialised in `lib/familia/connection.rb:20-22`.
+- **Mechanism:** `register_middleware_once` is normally idempotent (guarded by
+  `@logger_registered`/`@counter_registered`, once at boot). `reconnect!` sets
+  those flags back to `false` and calls it again, so both
+  `RedisClient.register(DatabaseLogger)` and `RedisClient.register(DatabaseCommandCounter)`
+  re-run. `RedisClient.register` appends to a **process-global** middleware list
+  with no dedup and no unregister API; the module is included into every
+  subsequently built client's middleware chain and invoked on every command.
+- **Locus/Persistence:** ruby-process (the growth is in `RedisClient`'s registry,
+  outside `lib/`); permanent-unbounded **only** if DB middleware is enabled **and**
+  `reconnect!` runs repeatedly (failover, timers, per-error reconnection).
+- **Proof A2:** 5 `reconnect!` calls → 10 `RedisClient.register` invocations.
+- **Fix sketch:** do not clear the registration flags in `reconnect!`
+  (`middleware.rb:92-93`); its legitimate job is to bump `middleware_version` and
+  drop `@connection_chain` so new connections pick up already-registered
+  middleware. Or track "already ever registered" module-side and check
+  `RedisClient` membership before appending.
+
+### A3 — `Instrumentation.@hooks` arrays are append-only with no unregister
+
+- **Where:** `lib/familia/instrumentation.rb:32-37` (four `Concurrent::Array`s),
+  appends at `:56` (`on_command`), `:73` (`on_pipeline`), `:94` (`on_lifecycle`),
+  `:112` (`on_error`).
+- **Mechanism:** each `on_*` does `@hooks[type] << block` with no dedup, no cap,
+  and **no `off_*`/`clear` method anywhere in `lib/`**. Every registered block is
+  retained forever, invoked on every matching command — and each is a closure that
+  can pin whatever its defining scope captured (request-scoped objects included).
+- **Locus/Persistence:** ruby-process; permanent-unbounded **only** if hooks are
+  registered repeatedly (per-request, per-connection, on class reload). Bounded if
+  registered once at boot.
+- **Familia never grows it:** the gem only ever calls the `notify_*` side
+  (`horreum.rb:260`, `persistence.rb:140/597`, the middleware, `serialization.rb:232`),
+  which *iterates* hooks and never appends. Growth requires consumer misuse.
+- **Proof A3:** 2000 `on_command` registrations all retained; no removal API.
+- **Fix sketch:** add `off_*`/`clear_hooks!`, or key hooks by a caller-supplied
+  name so re-registration replaces rather than appends; document boot-time-only
+  registration.
+
+### A4 — `Familia.members` pins every `Horreum` subclass forever
+
+- **Where:** append at `lib/familia/horreum.rb:173` (`Familia.members << member`);
+  array at `lib/familia.rb:43`; the only removers (`unload_member`,
+  `clear_anonymous_members`) at `lib/familia.rb:116-130`, documented as
+  test-cleanup helpers.
+- **Mechanism:** the `inherited` hook strong-references every subclass, so the
+  class and its generated singleton methods (`:instances` sorted set, etc.) can
+  never be GC'd. Bounded for a static model set defined once at boot; a permanent
+  unbounded leak iff the app mints `Horreum` subclasses at runtime.
+- **Locus/Persistence:** ruby-process; permanent-unbounded **only** under runtime
+  subclassing. The gem contains **zero** `Class.new`/`Struct.new`, so it never
+  self-triggers this.
+- **Proof A4:** 50 anonymous subclasses appended, all survive a full GC; only the
+  manual `clear_anonymous_members` helper evicts them.
+- **Fix sketch:** store members in an `ObjectSpace::WeakMap`/set-of-weakrefs, or
+  skip registering anonymous (`member.name.nil?`) classes the way
+  `Migration::Base.inherited` already does (`migration/base.rb:81`).
+
+---
+
+## Category B — transient O(N) materialization spikes (incl. #309)
+
+Ruby-process but GC-reclaimable: each site assigns to a method-local that is
+returned/consumed then dropped. **None writes its result into a class-level or
+process-lifetime structure** (verified). So `matches_ots_symptom = FALSE` for all
+— but the hot-path, growing-N ones can ratchet the RSS high-water mark (see the
+framework caveat). Ranked by OTS relevance:
+
+- **`find_all_by_<field>` (multi-index)** — `multi_index_generators.rb:170` and
+  `:433-434`. `index_set.members` (SMEMBERS whole bucket) + instantiate every
+  match; **no `limit:`/pagination**; the instance-level branch also does an N+1
+  load. Hot web path, N grows with the bucket. *The closest structural twin to
+  #309, and the highest-severity Category-B site.*
+- **`<collection>_with_permission`** — **issue #309**, `target_methods.rb:241`.
+  See the focused section below.
+- **`run_chores!`** — `housekeeping.rb:128`: `instances.to_a` (whole ZSET) then
+  slice; the `limit:` is applied *after* materialization. Periodic/background;
+  N = full instance count, grows over weeks.
+- **Rebuild strategies (confirms F2)** — `rebuild_strategies.rb:108,226`;
+  `multi_index_generators.rb:232,468`. `.members.each_slice(n)` fully materializes
+  the identifier array *before* slicing, so `batch_size` bounds only the per-batch
+  load, not the up-front fetch; the multi-index rebuilds additionally hold
+  `cached_objects` = every hydrated object at once. Admin/rare path, so it cannot
+  accumulate in a web worker; still a large transient spike.
+- **Audit/health-check** — `management/audit.rb:286-287` etc.:
+  `load_multi(scan_identifiers.to_a)` materializes *every deserialized instance of
+  a class simultaneously* — the largest transient magnitude in the gem, but an
+  admin/ops path.
+- **List position scans** — `participant_methods.rb:325`, `participation.rb:724`:
+  `collection.to_a.index(id)` (LRANGE 0 -1) to find one element; fix with `LPOS`.
+- Reverse-index `participations.members` scans (`participation.rb:625,658,675`):
+  small N (collections one object participates in); low severity.
+
+The correct streaming primitives already exist and are the basis of the fixes:
+`SortedSet#each`/`#scan` (ZSCAN, `sorted_set.rb:263-301,675`), `UnsortedSet#each`
+(SSCAN), `HashKey#each`/`#hscan` (HSCAN), `ListKey#each` (LRANGE pagination),
+`CollectionBase#each_record` (batched `load_multi`, `collection_base.rb:74-143`).
+
+---
+
+## Category C — Redis-side orphan accumulation
+
+Real dataset-growth debt (OTS's expiring session/secret/token models will grow
+these unboundedly in **Redis**), but `matches_ots_symptom = FALSE` for all — this
+is server memory, not client process RSS. The structural root:
+
+> **There is no keyspace-notification / expiry listener anywhere in `lib/`.** When
+> Redis silently drops an object's hash at TTL, no Familia code runs. Every
+> collection/index populated at `save` keeps the dead identifier. Removal happens
+> **only** via explicit `destroy!` or the manual `repair_*`/`audit_*` tooling.
+
+- **`{prefix}:instances` ZSET (confirms F1a)** — `horreum.rb:176`,
+  `persistence.rb:708-741`. One permanent orphan per TTL-expired object; every
+  model carries this set; `remove_from_instances!` is reachable only from
+  `destroy!` (`persistence.rb:588`). The set is excluded from the TTL cascade
+  because it is a `class_sorted_set` and the cascade iterates only instance-level
+  `related_fields` (`expiration.rb:272-288` vs `related_fields.rb:208-216`). **High.**
+- **class `unique_index` HASH + `objid_lookup` + `extid_lookup` (confirms F1b)** —
+  `unique_index_generators.rb:93-99,428-484`; `object_identifier.rb:105`;
+  `external_identifier.rb:24`. HSET on save vs HDEL only via `destroy!`; one orphan
+  per expired object. OTS almost certainly uses `object_identifier`. **High.**
+- **`multi_index` per-value SETs** — `multi_index_generators.rb:121-134`. Minted
+  dynamically, never declared as related fields → never TTL'd, not deleted on
+  scope `destroy!`, and **add-only on field-value change** (changing `role`
+  admin→user leaves the id in *both* buckets). Four independent orphan vectors.
+  **Medium-High.**
+- **`atomic_swap` temp key (confirms F3)** — `atomic_operations.rb:32-35,54-84`.
+  `build_temp_key` uses a **second-granularity** timestamp, so two rebuilds of the
+  same index in the same second collide; on swap failure the temp key (a full
+  index-sized HASH) is preserved with **no TTL** and never reaped. **Medium.**
+- Instance-scoped unique index (whole-key TTL refreshed on every scope save while
+  members orphan inside) and participation reverse-index orphans. **Medium / Low-Med.**
+
+Related note: `run_chores!` iterates the same orphan-laden `instances` ZSET, so
+chores waste work on phantom ids (`load_multi` returns nil) — a performance drag,
+not a leak.
+
+**Fix direction (all of Category C):** a reaper is the clean fix — either subscribe
+to Redis keyspace `expired` notifications and prune the identifier from
+`instances` + all indexes, or document `repair_*` as a required scheduled job for
+expiring models and add a `*:rebuild:*` sweep + a TTL on temp keys.
+
+---
+
+## Issue #309 — focused diagnosis and fix design
+
+**What it is.** The generated `<collection>_with_permission(min_permission)`
+(`target_methods.rb:230-248`) issues one `ZRANGEBYSCORE key -inf +inf WITHSCORES`,
+materializing the **entire** sorted set as a Ruby array of `[member, score]` pairs
+(`raw_pairs`, `:241`), then filters per member in Ruby (`each_with_object`,
+`:242-246`), deserializing survivors.
+
+**Memory behaviour.** A per-call **transient O(N) spike**, not a retained leak. Peak
+live memory ≈ O(N) for `raw_pairs` (outer array + N pair arrays + N member strings
++ N float scores) + O(M) for the kept survivors, plus O(N) short-lived churn from
+`ScoreEncoding.permission?` → `decode_score` allocating a fresh Hash + Array per
+member (`score_encoding.rb:140-151`). Nothing in Familia retains `raw_pairs` or the
+result; both are GC-reclaimable at/after return. **So #309 does not itself match
+the OTS symptom** — but it is a hot-path, growing-N site (Category B), so on a
+large participation set it raises the RSS high-water mark.
+
+**Why server-side filtering is impossible.** `encode_score` stores
+`timestamp.to_i + permission_bits/1000.0` (`score_encoding.rb:129`); the permission
+test is `permission_bits.anybits?(flag)` (`:168`) — a bitwise-AND membership test.
+`ZRANGEBYSCORE` selects a single contiguous `[min,max]` interval, but "has the read
+bit" ⇔ bits ∈ {1,3,5,…,255} (all odd) — 128 discrete, non-adjacent fractional
+values, replicated across every integer timestamp. No single range expresses it
+(the existing `permission_range`/`score_range` helpers, `:221-232`/`:255-279`, are
+in fact semantically broken for this reason). The full fetch is by design; the
+issue is bounding how much is pulled.
+
+**Fix design (bounded, backward-compatible).**
+
+1. **Keep the default return an `Array`.** Callers rely on `.length`, indexing,
+   `is_a?(Array)`, mutation, serialization. Switching the default to a lazy
+   `Enumerator` is a breaking contract change.
+2. **Add additive keyword args** `limit:`, `offset:`, `batch_size:` and stream
+   internally via `ZRANGEBYSCORE … LIMIT offset count`, so peak intermediate memory
+   is O(batch) and the result is O(limit):
+
+   ```ruby
+   target_class.define_method("#{collection_name}_with_permission") do
+     |min_permission = :read, limit: nil, offset: 0, batch_size: 500|
+     collection = send(collection_name)
+     out = []; skipped = 0; page = 0
+     loop do
+       batch = collection.rangebyscoreraw('-inf', '+inf',
+                 limit: [page * batch_size, batch_size], with_scores: true)
+       break if batch.empty?
+       batch.each do |raw_member, score|
+         next unless ScoreEncoding.permission?(score, min_permission)
+         if skipped < offset then skipped += 1; next end
+         out << collection.deserialize_value(raw_member)
+         return out if limit && out.size >= limit
+       end
+       break if batch.size < batch_size
+       page += 1
+     end
+     out
+   end
+   ```
+
+3. **Add an opt-in lazy sibling** `each_<collection>_with_permission(min_permission,
+   batch_size:)` that yields survivors and `return to_enum(...) unless block_given?`,
+   mirroring the repo's existing idiom (`SortedSet#each` `sorted_set.rb:263-267`;
+   `CollectionBase#each_record` `collection_base.rb:74-75`). This gives O(1)-retained
+   iteration with no full materialization.
+
+**Trap to avoid — do NOT use score-cursor pagination here.** `encode_score` uses
+`timestamp.to_i` (integer seconds, `score_encoding.rb:115`), so two members added in
+the same second with the same permission bits have **identical** scores; an
+exclusive `"(#{score}"` cursor bound would silently drop same-score members
+straddling a page boundary. Use offset-based `LIMIT` (order-preserving, O(N²/batch)
+CPU — acceptable for a memory fix) or ZSCAN (`collection.scan`, O(N) CPU but
+unordered and may yield rare duplicates — document as the alternative, not the
+default).
+
+**Apply the same treatment to the twin** `find_all_by_<field>`
+(`multi_index_generators.rb:170,433`): add `limit:`/pagination + a lazy `each_*`
+variant, and drop the N+1 in the instance-level branch in favour of `load_multi`.
+
+---
+
+## Prioritised remediation
+
+**Group 1 — fixes for the per-process (OTS) symptom.** Do these to close the
+weeks-long RSS climb; each is small and low-risk.
+
+1. **A1 encryption cache** *(highest expected impact for OTS; low effort)* — cap or
+   re-key the request cache and gate population on an active `with_request_cache`
+   frame. Risk: low (default path already unaffected). *This is the one most likely
+   to actually stop the OTS climb.*
+2. **A2 `reconnect!`** *(low effort)* — stop clearing the registration flags in
+   `reconnect!`. Risk: low.
+3. **A3 `@hooks`** *(low effort)* — add `off_*`/`clear_hooks!` and document
+   boot-time registration. Risk: low.
+4. **A4 `Familia.members`** *(low-med effort)* — `WeakMap` or skip anonymous
+   classes. Risk: low; only relevant if OTS subclasses at runtime.
+
+**Group 2 — scalability / Redis-footprint (not the process leak, but real).**
+
+5. **#309 + `find_all_by_*`** *(med effort)* — bounded streaming + pagination as
+   designed above. Impact: bounds hot-path spikes and result size.
+6. **Category C reaper** *(med-high effort)* — keyspace-notification pruning or a
+   scheduled `repair_*` + temp-key TTL + entropy in `build_temp_key`. Impact: stops
+   unbounded **Redis** growth for expiring models. This is the biggest *Redis*
+   sustainability win, independent of the process leak.
+7. **`run_chores!` / rebuild `.members.each_slice`** *(low-med effort)* — switch to
+   `each_record`/streaming so periodic/admin jobs don't materialise whole ZSETs.
+
+---
+
+## How to confirm empirically
+
+**In-gem (this branch):** `bundle exec ruby try/investigation/process_memory_leak_proof.rb`
+reproduces A1–A4 (pure Ruby, no Redis). For Category C, the `fix/memory-leak`
+branch's `try/investigation/memory_leak_proof.rb` proves F1/F3 and the O(N)
+materialization high-water mark against a live Redis.
+
+**In a running OTS process — determine which (if any) A-candidate is active:**
+
+- **A1:** grep OTS for `with_request_cache` and for any direct assignment to
+  `Fiber[:familia_request_cache_enabled]`. If caching is enabled outside a
+  strictly per-request block (middleware `ensure`), that is the leak. Confirm by
+  sampling `Fiber[:familia_request_cache]&.size` on a worker over time, or
+  `ObjectSpace.each_object(String).count` trend after GC.
+- **A2:** count OTS calls to `Familia.reconnect!` (startup only vs. failover/timer)
+  with `enable_database_logging`/`enable_database_counter` on. Growing
+  `RedisClient` middleware registrations confirm it.
+- **A3:** grep for `Familia::Instrumentation.on_command`/`on_lifecycle`/`on_error`
+  inside request or reload paths.
+- **A4:** grep for `Class.new(Familia::Horreum)` / dynamic model definition; watch
+  `Familia.members.size` over process life.
+
+**General RSS-over-time signal (distinguishes leak from high-water plateau):**
+sample per-worker `GC.stat(:heap_live_slots)`, `ObjectSpace.count_objects`, and RSS
+on a fixed interval. A true Category-A leak shows `heap_live_slots` climbing
+monotonically after `GC.start`; a Category-B high-water-mark plateau shows RSS
+stepping up to a ceiling while live slots stay flat (fragmentation/arena
+retention, not live-object growth). If neither climbs in-process while RSS does,
+suspect native allocations outside Familia.
+
+---
+
+## Appendix — considered and dismissed (the discipline evidence)
+
+The audit checked and cleared a large surface; the highlights that make the
+"no default leak" conclusion credible:
+
+- **No `@@` class variables in `lib/` at all.**
+- **Class registries are bounded** — `@features_available`/`@feature_definitions`
+  (`base.rb`), `@features_enabled` (`features.rb`), encryption `Registry.@providers`
+  and `@managers` (keyed on ≤3 algorithms), `@registered_types` (`data_type.rb`),
+  `SchemaRegistry.@schemas` (load-once), `Migration.migrations` (skips anonymous),
+  `@min_length_for_bits_cache` (finite tiers), and every per-class definition map
+  (`@fields`, `@field_types`, `@indexing_relationships`, …) — all keyed on
+  load-time-finite sets.
+- **Connection layer is clean** — `@connection_chain` is memoized (built once,
+  rebuilt only on `reconnect!`/`connection_provider=`); the Fiber-local connection/
+  transaction/pipeline slots are single-slot overwrite (one value per fiber,
+  bounded by pool size) and cleared in `ensure`; the one uncleared slot
+  (`Fiber[:familia_connection_handler_class]`, `handlers.rb:31`) holds a single
+  already-permanent `Class` reference. No uri/thread-keyed client or pool cache
+  exists.
+- **All metaprogramming is one-time** — every `define_method`/`class_eval`/
+  `const_set` fires at class-definition/load time behind the DSL or an `included`/
+  `inherited` hook; there are zero `Class.new`/`Struct.new` in `lib/`.
+- **Encryption is hardened** — `ObjectSpace` finalizers on ConcealedString/
+  RedactedString use class-method procs (no `self` capture, so they do not pin);
+  `derivation_count` is a single atomic, not a per-key hash; the record↔concealed
+  cycle and `@dirty_fields` are per-instance/bounded and cleared on save.
+- **`ThreadSafety::Monitor`** is disabled by default and, when on, keyed on
+  fixed-literal section names with a `reset_metrics`; its `Thread.current.object_id`
+  read is dead code.
+- **`DatabaseLogger.@commands`** is a bounded ring buffer (10k), though
+  `capture_enabled` defaults on and it retains command *values* — a footprint /
+  data-retention note, not a leak (consider defaulting it off in production).

--- a/try/investigation/memory_leak_proof.rb
+++ b/try/investigation/memory_leak_proof.rb
@@ -1,0 +1,408 @@
+# try/investigation/memory_leak_proof.rb
+#
+# frozen_string_literal: true
+#
+# Standalone proof for the Redis-side / high-water-mark memory findings (F1-F4)
+# documented in docs/investigation/memory-audit.md: the Category C Redis-side
+# orphans (Findings 1 & 3), the Category B O(N) materialization high-water mark
+# (Finding 2), and connection_provider churn (Finding 4, a non-leak contrast).
+#
+# Companion: try/investigation/process_memory_leak_proof.rb covers the Category A
+# Ruby-process registries (A1-A4) and needs no Redis. Together the two proofs
+# cover every candidate in the audit.
+#
+# Provenance: originally written on the fix/memory-leak investigation branch
+# (commit cb3a9a82) against a memory-audit-findings.md that was never committed;
+# consolidated here so the proof and the write-up live together. Verified
+# API-compatible with this release (the rebuild_strategies.rb:108 `.members`
+# reference below is still accurate).
+#
+# NOT a tryout (no _try.rb suffix) so the suite never runs it. Requires a live
+# Redis -- run it directly:
+#
+#   FAMILIA_TEST_URI=redis://127.0.0.1:6379 ruby try/investigation/memory_leak_proof.rb
+#
+# Tunables (generous defaults sized for a 32GB box):
+#   PROOF_BATCH   objects created+expired per round in Proof A   (default 20_000)
+#   PROOF_ROUNDS  number of expiry rounds in Proof A             (default 5)
+#   PROOF_GHOSTS  ghost ids seeded into the instances ZSET in B  (default 3_000_000)
+#   PROOF_TTL     default_expiration seconds for Proof A model   (default 2)
+#
+# Each proof prints measured numbers and a PASS/FAIL line. Exit code is non-zero
+# if any assertion fails.
+
+require 'delegate'
+require 'connection_pool'
+require 'redis'
+
+require_relative '../../lib/familia'
+
+Familia.uri = ENV.fetch('FAMILIA_TEST_URI', 'redis://127.0.0.1:6379')
+
+BATCH  = Integer(ENV.fetch('PROOF_BATCH',  '20000'))
+ROUNDS = Integer(ENV.fetch('PROOF_ROUNDS', '5'))
+GHOSTS = Integer(ENV.fetch('PROOF_GHOSTS', '3000000'))
+TTL    = Integer(ENV.fetch('PROOF_TTL',    '2'))
+
+# --------------------------------------------------------------------------
+# Measurement helpers
+# --------------------------------------------------------------------------
+
+def rss_kb
+  if File.exist?('/proc/self/status')
+    File.read('/proc/self/status')[/VmRSS:\s+(\d+)/, 1].to_i
+  else
+    `ps -o rss= -p #{Process.pid}`.to_i
+  end
+end
+
+def used_memory
+  Familia.dbclient.info('memory').fetch('used_memory').to_i
+rescue StandardError
+  Familia.dbclient.call('INFO', 'memory')[/used_memory:(\d+)/, 1].to_i
+end
+
+def connected_clients
+  Familia.dbclient.info('clients').fetch('connected_clients').to_i
+rescue StandardError
+  -1
+end
+
+def mb(kb) = (kb / 1024.0).round(1)
+def mbb(bytes) = (bytes / 1024.0 / 1024.0).round(1)
+
+$failures = 0
+def check(label, ok)
+  status = ok ? 'PASS' : 'FAIL'
+  $failures += 1 unless ok
+  puts "  [#{status}] #{label}"
+  ok
+end
+
+def section(title)
+  puts "\n#{'=' * 78}\n#{title}\n#{'=' * 78}"
+end
+
+# Sample peak RSS across a block. Best-effort (GVL-limited), used only as
+# corroboration; the primary RSS evidence in Proof B is deterministic.
+def with_peak_rss
+  peak = rss_kb
+  stop = false
+  sampler = Thread.new do
+    until stop
+      cur = rss_kb
+      peak = cur if cur > peak
+      sleep 0.01
+    end
+  end
+  result = yield
+  stop = true
+  sampler.join
+  [peak, result]
+end
+
+# --------------------------------------------------------------------------
+# Models
+# --------------------------------------------------------------------------
+
+# Expiring model with a class-level unique index. Mirrors a session/token model.
+class ProofSession < Familia::Horreum
+  feature :expiration
+  feature :relationships
+
+  default_expiration TTL
+
+  identifier_field :sessid
+  field :sessid
+  field :email
+
+  unique_index :email, :email_lookup
+end
+
+# Non-expiring model used only to seed a ghost-laden instances ZSET for the
+# RSS contrast in Proof B.
+class GhostModel < Familia::Horreum
+  feature :relationships
+
+  identifier_field :gid
+  field :gid
+  field :email
+
+  unique_index :email, :email_lookup
+end
+
+RebuildStrategies = Familia::Features::Relationships::Indexing::RebuildStrategies
+AtomicOps = Familia::AtomicOperations
+
+# --------------------------------------------------------------------------
+puts "Familia memory-leak proof"
+puts "uri=#{Familia.uri}  BATCH=#{BATCH} ROUNDS=#{ROUNDS} GHOSTS=#{GHOSTS} TTL=#{TTL}s"
+begin
+  Familia.dbclient.ping
+rescue StandardError => e
+  abort "Cannot reach Redis at #{Familia.uri}: #{e.class}: #{e.message}"
+end
+
+# ==========================================================================
+# PROOF A - Finding 1: instances ZSET + unique_index HASH orphan on TTL expiry
+# ==========================================================================
+# Each round: create BATCH objects with a short TTL, confirm the TTL was set,
+# wait for Redis to expire the main hashes, then confirm the main hashes are
+# gone while the instances ZSET and the email_lookup HASH retain every entry.
+# Primary evidence is cardinality (ZCARD / HLEN); used_memory corroborates.
+
+section 'PROOF A - orphaned instances/index entries under continuous writes (Finding 1)'
+
+# Mechanism (verified): the instances ZSET and the unique_index HASH inherit the
+# model default_expiration as a WHOLE-KEY ttl, and that ttl is refreshed on every
+# save (touch_instances! / auto_update_class_indexes). So normal app traffic keeps
+# the collection keys alive indefinitely, while members belonging to objects whose
+# own hash already expired are never pruned (no per-member/per-field ttl, and TTL
+# expiry never calls destroy!). The orphans accumulate without bound.
+#
+# Each round: create BATCH objects, then run keepalive saves (simulating traffic)
+# for longer than TTL so the batch's main hashes expire while the collection keys
+# stay alive. Then show the batch members are gone-as-objects but still present as
+# ZSET members / HASH fields, and that ZCARD grows every round.
+
+inst_key  = ProofSession.instances.dbkey
+index_key = ProofSession.email_lookup.dbkey
+Familia.dbclient.del(inst_key, index_key)
+
+baseline_used = used_memory
+puts "  model default_expiration=#{TTL}s (whole-key ttl, refreshed on every save)"
+puts "  baseline used_memory: #{mbb(baseline_used)} MB"
+printf "  %-7s %12s %12s %12s %10s %12s\n",
+       'round', 'live(s25)', 'orphan(s25)', 'ZCARD', 'ttl(inst)', 'used_MB'
+
+ttl_seen = false
+zcards = []
+ka = 0
+last_live = nil
+last_orphan = nil
+last_n = nil
+
+ROUNDS.times do |r|
+  sample = []
+  BATCH.times do |i|
+    o = ProofSession.new(sessid: "s-#{r}-#{i}-#{Process.pid}",
+                         email: "u-#{r}-#{i}-#{Process.pid}@proof.test")
+    o.save
+    sample << o if i < 25
+  end
+  ttl_seen ||= sample.first&.ttl&.positive?
+
+  # Keepalive traffic: refresh the collection whole-key ttl while the batch ages
+  # past its own TTL. This is exactly what a live, continuously-writing app does.
+  deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + TTL + 2
+  while Process.clock_gettime(Process::CLOCK_MONOTONIC) < deadline
+    ProofSession.new(sessid: "ka-#{ka}-#{Process.pid}",
+                     email: "ka-#{ka}-#{Process.pid}@proof.test").save
+    ka += 1
+    sleep 0.1
+  end
+
+  last_live   = sample.count { |o| Familia.dbclient.exists?(o.dbkey) }
+  last_orphan = sample.count { |o| !Familia.dbclient.zscore(inst_key, o.identifier).nil? }
+  last_n      = sample.size
+  zc = Familia.dbclient.zcard(inst_key)
+  zcards << zc
+  printf "  %-7d %12d %12d %12d %10d %12s\n",
+         r + 1, last_live, last_orphan, zc, Familia.dbclient.ttl(inst_key), mbb(used_memory)
+end
+
+final_zc   = Familia.dbclient.zcard(inst_key)
+final_hl   = Familia.dbclient.hlen(index_key)
+final_used = used_memory
+
+puts
+check("save() set a TTL on the main hash (precondition)", ttl_seen)
+check("collection key stayed ALIVE under continuous writes (ttl>0)",
+      Familia.dbclient.ttl(inst_key) > 0)
+check("final-round sampled main hashes expired (live=#{last_live}/#{last_n})",
+      last_live.zero?)
+check("those expired objects still present in instances ZSET (orphans=#{last_orphan}/#{last_n})",
+      last_orphan == last_n)
+check("index HASH also retained orphans (HLEN=#{final_hl})", final_hl.positive?)
+check("ZCARD grew every round - monotonic, unbounded (#{zcards.inspect})",
+      zcards.each_cons(2).all? { |a, b| b > a })
+puts "  corroborating: used_memory #{mbb(baseline_used)} -> #{mbb(final_used)} MB"
+puts "  Interpretation: the collection keys never expire while traffic flows, yet"
+puts "  every expired object leaves its ZSET member + HASH field behind. ZCARD/HLEN"
+puts "  climb monotonically. destroy! prunes them; TTL expiry never calls destroy!."
+
+# ==========================================================================
+# PROOF B - Finding 2: rebuild materializes the whole collection (Ruby RSS)
+# ==========================================================================
+# Seed GHOSTS ids into GhostModel.instances directly (raw ZADD, no objects).
+# rebuild_via_instances calls `instances.members` (the exact line 108) which
+# pulls the ENTIRE ZSET into one Ruby array. rebuild_via_scan streams instead.
+
+section 'PROOF B - full materialization vs streaming on rebuild (Finding 2)'
+
+ghost_inst = GhostModel.instances.dbkey
+Familia.dbclient.del(ghost_inst, GhostModel.email_lookup.dbkey)
+
+print "  seeding #{GHOSTS} ghost ids into #{ghost_inst} ..."
+seeded = 0
+(0...GHOSTS).each_slice(50_000) do |slice|
+  pairs = slice.flat_map { |i| [i.to_f, "ghost_#{i}"] }
+  Familia.dbclient.zadd(ghost_inst, pairs)
+  seeded += slice.size
+end
+puts " done (ZCARD=#{Familia.dbclient.zcard(ghost_inst)})"
+
+# B1 (deterministic, primary): hold the materialized array, measure RSS delta.
+GC.start
+b0 = rss_kb
+members = GhostModel.instances.members        # <-- rebuild_strategies.rb:108
+b1 = rss_kb
+materialize_delta = b1 - b0
+puts "  members.length=#{members.length}  RSS delta from .members: #{mb(materialize_delta)} MB"
+members = nil
+GC.start
+
+# B2 (contrast): stream the same ZSET, measure RSS delta (should be ~flat).
+s0 = rss_kb
+streamed = 0
+Familia.dbclient.zscan_each(ghost_inst) { |_m, _s| streamed += 1 }
+s1 = rss_kb
+stream_delta = s1 - s0
+puts "  zscan_each streamed=#{streamed}  RSS delta from streaming: #{mb(stream_delta)} MB"
+
+# B3 (corroboration): run the real strategy methods, sample peak RSS of each.
+GC.start
+idx = GhostModel.email_lookup
+peak_scan = nil
+begin
+  base = rss_kb
+  peak_scan, = with_peak_rss do
+    RebuildStrategies.rebuild_via_scan(
+      GhostModel, :email, :add_to_class_email_lookup, idx, batch_size: 1000
+    )
+  end
+  puts "  rebuild_via_scan      peak RSS delta: #{mb(peak_scan - base)} MB"
+rescue StandardError => e
+  puts "  rebuild_via_scan skipped: #{e.class}: #{e.message}"
+end
+
+GC.start
+base = rss_kb
+peak_inst, = with_peak_rss do
+  RebuildStrategies.rebuild_via_instances(
+    GhostModel, :email, :add_to_class_email_lookup, idx, batch_size: 1000
+  )
+end
+puts "  rebuild_via_instances peak RSS delta: #{mb(peak_inst - base)} MB"
+
+puts
+check("`.members` materialization RSS scales with N (#{mb(materialize_delta)} MB for #{GHOSTS} ids)",
+      materialize_delta > GHOSTS / 200) # KB; ~>5 bytes resident/id, trivially true if it materializes
+check("streaming the same ZSET cost materially less than materializing " \
+      "(stream #{mb(stream_delta)} MB << members #{mb(materialize_delta)} MB)",
+      stream_delta < materialize_delta)
+puts "  Interpretation: via_instances loads the whole (ghost-bloated) ZSET into"
+puts "  Ruby before batching; via_scan streams. O(N) high-watermark over the"
+puts "  unbounded base from Finding 1."
+
+# ==========================================================================
+# PROOF C - Finding 3: failed rebuild leaves an orphaned temp key (no TTL)
+# ==========================================================================
+# Exercise the real atomic_swap rescue branch (atomic_operations.rb:80-83):
+# HSET into the temp key so the `exists > 0` guard passes, then force RENAME to
+# raise a non-"no such key" error. The temp key is preserved with no TTL.
+
+section 'PROOF C - orphaned rebuild temp key with no TTL (Finding 3)'
+
+class FailingRename < SimpleDelegator
+  def rename(*)
+    raise Redis::CommandError, 'OOM command not allowed (simulated)'
+  end
+end
+
+final_key = "proof:tempkeyleak:final"
+temp_key  = AtomicOps.build_temp_key(final_key)
+Familia.dbclient.del(final_key, temp_key)
+
+# Populate the temp key the way a rebuild would (full index copy lives here).
+Familia.dbclient.hset(temp_key, 'a@x', '1', 'b@x', '2', 'c@x', '3')
+
+raised = false
+begin
+  AtomicOps.atomic_swap(temp_key, final_key, FailingRename.new(Familia.dbclient))
+rescue Redis::CommandError
+  raised = true
+end
+
+temp_ttl    = Familia.dbclient.ttl(temp_key)
+temp_exists = Familia.dbclient.exists?(temp_key)
+
+# Timestamp-collision footnote: same-second rebuilds reuse the same temp key.
+collide = AtomicOps.build_temp_key(final_key) == AtomicOps.build_temp_key(final_key)
+
+puts "  after forced swap failure: exists=#{temp_exists} ttl=#{temp_ttl}"
+check("atomic_swap re-raised (preserve-and-raise branch taken)", raised)
+check("temp key was preserved (leaked), not cleaned up", temp_exists)
+check("temp key has NO expiration (ttl == -1)", temp_ttl == -1)
+check("build_temp_key collides within the same second", collide)
+Familia.dbclient.del(final_key, temp_key)
+puts "  Interpretation: every failed/interrupted rebuild orphans a full"
+puts "  index-sized HASH with no TTL. Unbounded across failures."
+
+# ==========================================================================
+# PROOF D - Finding 4: README connection_provider recreates the pool per call
+# ==========================================================================
+# Not a permanent leak (pools are GC-reclaimable) - it is connection churn /
+# fd pressure and defeated pooling. Proven by object identity.
+
+section 'PROOF D - connection_provider per-call pool allocation (Finding 4)'
+
+uri = Familia.uri.to_s
+N = 25
+
+# README.md:380-384 - new ConnectionPool on every call.
+readme_provider = lambda do |u|
+  ConnectionPool.new(size: 10, timeout: 5) { Redis.new(url: u) }
+end
+
+# docs/guides/index.md:94 - memoized per-uri.
+memo_pools = {}
+memoized_provider = lambda do |u|
+  memo_pools[u] ||= ConnectionPool.new(size: 10, timeout: 5) { Redis.new(url: u) }
+end
+
+before_clients = connected_clients
+readme_ids = []
+N.times do
+  pool = readme_provider.call(uri)
+  pool.with { |c| c.ping } # force an actual socket open
+  readme_ids << pool.object_id
+end
+after_readme_clients = connected_clients
+
+memo_ids = Array.new(N) { memoized_provider.call(uri).object_id }
+
+puts "  README provider:   #{readme_ids.uniq.size} distinct pool objects over #{N} calls"
+puts "  memoized provider: #{memo_ids.uniq.size} distinct pool object over #{N} calls"
+puts "  connected_clients: #{before_clients} -> #{after_readme_clients} (after #{N} README checkouts)"
+
+check("README provider allocates a NEW pool every call (#{readme_ids.uniq.size}==#{N})",
+      readme_ids.uniq.size == N)
+check("memoized provider reuses ONE pool (#{memo_ids.uniq.size}==1)",
+      memo_ids.uniq.size == 1)
+GC.start
+puts "  Note: orphaned README pools are GC-reclaimable, so this is connection"
+puts "  churn / fd pressure under throughput, not permanent memory growth."
+
+# --------------------------------------------------------------------------
+section 'CLEANUP'
+killed = Familia.dbclient.del(
+  ProofSession.instances.dbkey, ProofSession.email_lookup.dbkey,
+  GhostModel.instances.dbkey, GhostModel.email_lookup.dbkey
+)
+puts "  deleted #{killed} proof collection keys (ProofSession orphans self-expire)"
+
+# --------------------------------------------------------------------------
+section 'SUMMARY'
+puts $failures.zero? ? "ALL CHECKS PASSED" : "#{$failures} CHECK(S) FAILED"
+exit($failures.zero? ? 0 : 1)

--- a/try/investigation/memory_leak_proof.rb
+++ b/try/investigation/memory_leak_proof.rb
@@ -71,6 +71,13 @@ end
 def mb(kb) = (kb / 1024.0).round(1)
 def mbb(bytes) = (bytes / 1024.0 / 1024.0).round(1)
 
+# Print-safe URI: scheme://host:port/path only -- never userinfo -- so a
+# password embedded in FAMILIA_TEST_URI (redis://:pw@host) cannot leak to logs.
+def safe_uri
+  u = Familia.uri
+  "#{u.scheme}://#{u.host}:#{u.port}#{u.path}"
+end
+
 $failures = 0
 def check(label, ok)
   status = ok ? 'PASS' : 'FAIL'
@@ -136,11 +143,11 @@ AtomicOps = Familia::AtomicOperations
 
 # --------------------------------------------------------------------------
 puts "Familia memory-leak proof"
-puts "uri=#{Familia.uri}  BATCH=#{BATCH} ROUNDS=#{ROUNDS} GHOSTS=#{GHOSTS} TTL=#{TTL}s"
+puts "uri=#{safe_uri}  BATCH=#{BATCH} ROUNDS=#{ROUNDS} GHOSTS=#{GHOSTS} TTL=#{TTL}s"
 begin
   Familia.dbclient.ping
 rescue StandardError => e
-  abort "Cannot reach Redis at #{Familia.uri}: #{e.class}: #{e.message}"
+  abort "Cannot reach Redis at #{safe_uri}: #{e.class}: #{e.message}"
 end
 
 # ==========================================================================

--- a/try/investigation/process_memory_leak_proof.rb
+++ b/try/investigation/process_memory_leak_proof.rb
@@ -1,0 +1,199 @@
+# try/investigation/process_memory_leak_proof.rb
+#
+# frozen_string_literal: true
+#
+# Executable proof for the FOUR "Category A" latent per-process (Ruby heap)
+# memory leaks identified in docs/investigation/memory-audit.md.
+#
+# NOT a tryout (no _try.rb suffix) so the suite never runs it. Run it directly;
+# it needs NO Redis server -- every proof is pure Ruby object growth:
+#
+#   bundle exec ruby try/investigation/process_memory_leak_proof.rb
+#
+# Companion proof: try/investigation/memory_leak_proof.rb (on branch
+# fix/memory-leak) covers the Category C *Redis-side* orphan findings and the
+# Category B O(N) materialization high-watermark. This file covers only the
+# Ruby-process, permanent-unbounded, append-only registries -- i.e. the only
+# category whose growth profile matches the OneTimeSecret symptom (per-process
+# RSS climbing over weeks).
+#
+# The load-bearing point of each proof: the structure is unbounded and has no
+# eviction path, BUT Familia itself never drives the trigger. Each leak is armed
+# only by a specific *application* call pattern. So each proof demonstrates both
+# (1) unbounded growth when the trigger fires, and (2) that the guarded/correct
+# usage stays bounded.
+
+require 'base64'
+require 'securerandom'
+
+require_relative '../../lib/familia'
+
+# --------------------------------------------------------------------------
+$failures = 0
+def check(label, ok)
+  $failures += 1 unless ok
+  puts "  [#{ok ? 'PASS' : 'FAIL'}] #{label}"
+  ok
+end
+
+def section(title)
+  puts "\n#{'=' * 78}\n#{title}\n#{'=' * 78}"
+end
+
+puts 'Familia latent per-process (Ruby heap) memory-leak proof'
+puts "ruby #{RUBY_VERSION}  familia #{Familia::VERSION}  (no Redis required)"
+
+# ==========================================================================
+# PROOF A1 - Encryption request-key cache (TOP OTS suspect)
+# ==========================================================================
+# Familia::Encryption::Manager#derive_key_without_increment caches the derived
+# key in Fiber[:familia_request_cache] when Fiber[:familia_request_cache_enabled]
+# is set (manager.rb:146-167). The cache key embeds the PER-RECORD context
+# ("Class:field:identifier", encrypted_field_type.rb:184), so cardinality is
+# UNBOUNDED in distinct records touched.
+#
+# Default: caching is OFF (flag nil) -> the Hash is never allocated -> no leak.
+# Correct opt-in: with_request_cache wipes on entry AND in an ensure on exit, so
+# a pooled fiber starts and ends every request empty (request_cache.rb:36-55).
+# The leak: an app that enables the flag at a scope BROADER than one request
+# (e.g. sets it once on a long-lived pooled server fiber, or wraps a worker
+# loop) never clears the Hash; it grows one retained 32-byte key per distinct
+# record, forever.
+
+section 'PROOF A1 - encryption request-key cache: unbounded when mis-scoped, bounded under with_request_cache'
+
+Familia.config.encryption_keys = { v1: Base64.strict_encode64(SecureRandom.bytes(32)) }
+Familia.config.current_key_version = :v1
+mgr = Familia::Encryption::Manager.new
+N = 300
+
+# (1) Mis-scoped: enable the flag the way a pooled fiber that opts in ONCE would,
+# without the per-request clear. This is the leak condition.
+Fiber[:familia_request_cache_enabled] = true
+Fiber[:familia_request_cache] = {}
+N.times { |i| mgr.send(:derive_key_without_increment, "Secret:value:secret_#{i}") }
+mis_scoped_size = Fiber[:familia_request_cache].size
+
+# (2) Correct opt-in: with_request_cache clears on exit even on exception.
+Fiber[:familia_request_cache_enabled] = false
+Fiber[:familia_request_cache] = nil
+Familia::Encryption.with_request_cache do
+  N.times { |i| mgr.send(:derive_key_without_increment, "Secret:value:secret_#{i}") }
+end
+after_block = Fiber[:familia_request_cache]
+
+# (3) Default: flag never set -> cache never even allocated.
+Fiber[:familia_request_cache_enabled] = nil
+Fiber[:familia_request_cache] = nil
+mgr.send(:derive_key_without_increment, 'Secret:value:default_path')
+default_cache = Fiber[:familia_request_cache]
+
+puts "  mis-scoped cache size after #{N} distinct-record derivations: #{mis_scoped_size}"
+puts "  cache after with_request_cache block exits:                   #{after_block.inspect}"
+puts "  cache on the default (flag-off) path:                         #{default_cache.inspect}"
+check("mis-scoped cache grows one entry per distinct record (#{mis_scoped_size} == #{N})", mis_scoped_size == N)
+check('with_request_cache wipes the cache on exit (nil)', after_block.nil?)
+check('default path never allocates the cache (nil)', default_cache.nil?)
+puts '  Interpretation: retained *key material* grows with distinct records over'
+puts '  the fiber lifetime iff caching is enabled outside a per-request boundary.'
+puts '  OTS relevance: a secrets app deriving per-record keys is the exact shape.'
+
+# ==========================================================================
+# PROOF A2 - reconnect! re-registers Redis middleware every call
+# ==========================================================================
+# register_middleware_once is guarded by @logger_registered/@counter_registered
+# so it fires once at boot. reconnect! resets those flags to false and calls it
+# again (middleware.rb:91-94), so every reconnect! re-runs RedisClient.register,
+# which appends to a process-global middleware list with no dedup and no
+# unregister API. Repeated reconnect! (failover, timers, per-error) stacks
+# permanent duplicate registrations.
+
+section 'PROOF A2 - reconnect! re-registers middleware (append-only global list)'
+
+reg_count = 0
+orig_register = RedisClient.method(:register)
+RedisClient.singleton_class.send(:define_method, :register) do |*a, **k, &b|
+  reg_count += 1
+  orig_register.call(*a, **k, &b)
+end
+Familia.enable_database_logging = true if Familia.respond_to?(:enable_database_logging=)
+Familia.enable_database_counter = true if Familia.respond_to?(:enable_database_counter=)
+
+reg_count = 0
+rounds = 5
+rounds.times { Familia.reconnect! }
+puts "  RedisClient.register invocations across #{rounds} reconnect! calls: #{reg_count}"
+check("reconnect! re-registers on every call (#{reg_count} >= #{rounds})", reg_count >= rounds)
+puts '  Interpretation: RedisClient has no unregister; each reconnect! leaves one'
+puts '  more DatabaseLogger/DatabaseCommandCounter reference on the global list,'
+puts '  invoked on every command thereafter. Bounded only if reconnect! is rare.'
+
+# restore
+RedisClient.singleton_class.send(:define_method, :register, orig_register)
+
+# ==========================================================================
+# PROOF A3 - Instrumentation hook arrays are append-only, no unregister
+# ==========================================================================
+# on_command/on_pipeline/on_lifecycle/on_error do @hooks[type] << block
+# (instrumentation.rb:56-112). There is no off_*/clear API anywhere in lib/.
+# Each retained block is a closure that can pin whatever its defining scope
+# captured. Familia's own code only ever calls the notify_* side (iterate), so
+# the gem never grows @hooks itself -- growth requires repeated app registration
+# (per-request, per-connection, or on every code reload).
+
+section 'PROOF A3 - Instrumentation @hooks: append-only, no removal API'
+
+hooks = Familia::Instrumentation.instance_variable_get(:@hooks)
+before = hooks[:command].size
+2_000.times { Familia::Instrumentation.on_command { |*| } }
+after = hooks[:command].size
+has_removal = Familia::Instrumentation.respond_to?(:off_command) ||
+              Familia::Instrumentation.respond_to?(:clear_hooks) ||
+              Familia::Instrumentation.respond_to?(:reset_hooks)
+puts "  @hooks[:command] grew #{before} -> #{after} over 2000 registrations"
+puts "  removal/unregister API present: #{has_removal}"
+check('every on_command registration is retained (grew by 2000)', after - before == 2_000)
+check('no unregister/clear API exists to shed them', !has_removal)
+hooks[:command].clear # local cleanup so this proof does not perturb others
+
+# ==========================================================================
+# PROOF A4 - Familia.members pins every Horreum subclass forever (strong ref)
+# ==========================================================================
+# Horreum.inherited does `Familia.members << member` (horreum.rb:173) with a
+# STRONG reference; the only removers (unload_member/clear_anonymous_members,
+# familia.rb:116-130) are documented test-cleanup helpers, never called in
+# production. Bounded for a static model set defined once at boot; a permanent
+# unbounded leak iff the app mints Horreum subclasses at runtime (per request /
+# per tenant / Class.new in a hot path). The subclass, its generated singleton
+# methods, and everything it references can never be GC'd.
+
+section 'PROOF A4 - Familia.members: append-only strong-ref registry of subclasses'
+
+before_m = Familia.members.size
+50.times { Class.new(Familia::Horreum) { identifier_field :id; field :id } }
+after_create = Familia.members.size
+GC.start(full_mark: true, immediate_sweep: true)
+after_gc = Familia.members.size
+puts "  Familia.members: #{before_m} -> #{after_create} (after 50 anon subclasses) -> #{after_gc} (after full GC)"
+check('each runtime subclass is appended to the registry (+50)', after_create - before_m == 50)
+check('strong reference survives a full GC (not reclaimed)', after_gc == after_create)
+
+# Demonstrate the ONLY escape hatch is the manual test-cleanup helper.
+if Familia.respond_to?(:clear_anonymous_members)
+  Familia.clear_anonymous_members
+  after_manual = Familia.members.size
+  puts "  after manual Familia.clear_anonymous_members: #{after_manual}"
+  check('only a manual/test helper (clear_anonymous_members) evicts them', after_manual < after_create)
+end
+puts '  Interpretation: in-gem this is bounded (models defined once at boot). It'
+puts '  becomes the classic ORM registry leak only under runtime subclassing --'
+puts '  something to confirm against the consuming app, not a default-config leak.'
+
+# --------------------------------------------------------------------------
+section 'SUMMARY'
+puts 'All four are ruby-process + permanent-unbounded, but each is armed only by a'
+puts 'specific application call pattern; Familia never drives the trigger itself.'
+puts 'See docs/investigation/memory-audit.md for classification, remediation, and'
+puts 'the OTS-side checks that determine which (if any) is the active cause.'
+puts($failures.zero? ? "\nALL CHECKS PASSED" : "\n#{$failures} CHECK(S) FAILED")
+exit($failures.zero? ? 0 : 1)

--- a/try/investigation/process_memory_leak_proof.rb
+++ b/try/investigation/process_memory_leak_proof.rb
@@ -116,20 +116,24 @@ RedisClient.singleton_class.send(:define_method, :register) do |*a, **k, &b|
   reg_count += 1
   orig_register.call(*a, **k, &b)
 end
-Familia.enable_database_logging = true if Familia.respond_to?(:enable_database_logging=)
-Familia.enable_database_counter = true if Familia.respond_to?(:enable_database_counter=)
+begin
+  Familia.enable_database_logging = true if Familia.respond_to?(:enable_database_logging=)
+  Familia.enable_database_counter = true if Familia.respond_to?(:enable_database_counter=)
 
-reg_count = 0
-rounds = 5
-rounds.times { Familia.reconnect! }
-puts "  RedisClient.register invocations across #{rounds} reconnect! calls: #{reg_count}"
-check("reconnect! re-registers on every call (#{reg_count} >= #{rounds})", reg_count >= rounds)
-puts '  Interpretation: RedisClient has no unregister; each reconnect! leaves one'
-puts '  more DatabaseLogger/DatabaseCommandCounter reference on the global list,'
-puts '  invoked on every command thereafter. Bounded only if reconnect! is rare.'
-
-# restore
-RedisClient.singleton_class.send(:define_method, :register, orig_register)
+  reg_count = 0
+  rounds = 5
+  rounds.times { Familia.reconnect! }
+  puts "  RedisClient.register invocations across #{rounds} reconnect! calls: #{reg_count}"
+  check("reconnect! re-registers on every call (#{reg_count} >= #{rounds})", reg_count >= rounds)
+  puts '  Interpretation: RedisClient has no unregister; each reconnect! leaves one'
+  puts '  more DatabaseLogger/DatabaseCommandCounter reference on the global list,'
+  puts '  invoked on every command thereafter. Bounded only if reconnect! is rare.'
+ensure
+  # Guaranteed restore: if reconnect!/registration raises mid-loop, the global
+  # RedisClient.register must not stay patched -- it would corrupt A3/A4 below
+  # and leak the instrumented method into the host process.
+  RedisClient.singleton_class.send(:define_method, :register, orig_register)
+end
 
 # ==========================================================================
 # PROOF A3 - Instrumentation hook arrays are append-only, no unregister
@@ -154,7 +158,9 @@ puts "  @hooks[:command] grew #{before} -> #{after} over 2000 registrations"
 puts "  removal/unregister API present: #{has_removal}"
 check('every on_command registration is retained (grew by 2000)', after - before == 2_000)
 check('no unregister/clear API exists to shed them', !has_removal)
-hooks[:command].clear # local cleanup so this proof does not perturb others
+# Remove only the hooks THIS proof appended (LIFO); non-destructive to any
+# instrumentation a host process registered before this script ran.
+(after - before).times { hooks[:command].pop }
 
 # ==========================================================================
 # PROOF A4 - Familia.members pins every Horreum subclass forever (strong ref)


### PR DESCRIPTION
## What this is

Investigates **#309** (O(N) memory in `_with_permission`) and broadens it to the motivating question: **is OneTimeSecret's slow per-process RSS growth (climbing over weeks) caused by Familia?**

This is **diagnosis only — no behaviour changes.** It adds a written audit and two executable proofs. Fixes are sketched and prioritised but intentionally left for follow-up PRs.

Three files:
- `docs/investigation/memory-audit.md` — the full diagnosis
- `try/investigation/process_memory_leak_proof.rb` — pure-Ruby, no-Redis proof of the four latent per-process leaks (all checks pass)
- `try/investigation/memory_leak_proof.rb` — Redis-backed proof of the Redis-side orphan (F1/F3) and O(N) materialization high-water-mark findings, consolidated here from the prior `fix/memory-leak` investigation so the evidence and the write-up live together

## Method

Eight focused audits ran in parallel over `lib/` (one per vector: #309; class/global state; connection & fiber-local lifecycle; runtime method generation; encryption & transient fields; relationships/indexing Redis-side orphans; whole-collection materialization; logging/instrumentation). Every candidate was classified adversarially on two axes — **locus** (Redis-side dataset vs Ruby-process heap) × **persistence** (transient/GC-reclaimable vs permanent-unbounded) — and only reported if it survived a refutation attempt. Prior art from the `fix/memory-leak` branch (F1–F4) was confirmed against current 2.11.1 code and its proof consolidated onto this branch.

## Headline conclusion

**Familia has no unconditional/default per-process memory leak.** No `@@` class variables anywhere; every class-level structure is keyed on a load-time-finite set, is per-instance and GC-reclaimable, is fiber-local and cleared in an `ensure`, or lives Redis-side.

The per-process-over-weeks symptom can only be one of **four latent append-only registries** — each with no eviction path, each armed *solely* by an application call pattern the gem never triggers itself:

| # | Latent leak | Fires when the app… |
|---|-------------|---------------------|
| **A1** | Encryption request-key cache keyed on `record.identifier` (`encryption/manager.rb:146-167`) | enables key caching outside a per-request `with_request_cache` boundary |
| **A2** | `reconnect!` re-registers Redis middleware (`connection/middleware.rb:91-94`) | enables DB logging/counter **and** calls `reconnect!` repeatedly |
| **A3** | `Instrumentation.@hooks` append-only arrays (`instrumentation.rb:56-112`) | registers instrumentation hooks per-request / on reload |
| **A4** | `Familia.members` strong-ref subclass registry (`horreum.rb:173`) | defines `Horreum` subclasses at runtime |

**A1 is the most probable OTS cause** — a secrets app deriving a per-record key for every encrypted field, if it has caching enabled anywhere broader than one request, retains one derived key per distinct secret forever. The proof reproduces all four and shows each is bounded under correct usage.

## Issue #309

`_with_permission` is a **per-call transient O(N) spike, not a leak** — it `ZRANGEBYSCORE -inf +inf WITHSCORES` (the whole set) and filters in Ruby because permission bits live in the fractional part of the score and can't be a contiguous range. GC reclaims it; nothing is retained. It doesn't match the OTS symptom directly, but it's a hot-path, growing-N site that ratchets the RSS high-water mark on large collections.

The doc includes a **bounded, backward-compatible fix design** (keep the `Array` return; add additive `limit:`/`offset:`/`batch_size:` streaming via `ZRANGEBYSCORE … LIMIT`; plus an opt-in lazy `each_*` sibling) and flags a correctness trap: **score-cursor pagination is unsafe here** because `encode_score` uses `timestamp.to_i` (integer seconds), so same-second same-permission members share identical scores and an exclusive cursor bound would drop them. The same treatment applies to the twin `find_all_by_`.

It also records the provenance of the current #309 code (commit `ed69e69e`, already merged), whose own commit message independently states the fractional-score root cause.

## Redis-side sustainability debt (separate from the process leak)

Confirms prior F1/F3 against current code: because **there is no keyspace-notification/expiry reaper**, TTL expiry runs no Familia code, so `instances` ZSETs, unique/`objid`/`extid` index HASHes, `multi_index` buckets, and failed-`atomic_swap` temp keys all orphan and are pruned only by manual `repair_*`. This grows the **Redis dataset** (real debt for OTS's expiring models) but is the wrong locus for a process-RSS climb.

## Proof

```
$ bundle exec ruby try/investigation/process_memory_leak_proof.rb
… ALL CHECKS PASSED
```

Pure Ruby, no Redis required. The Redis-side counterpart `try/investigation/memory_leak_proof.rb` (Categories B/C) is now consolidated into this PR; run it with `FAMILIA_TEST_URI=redis://…` against a live Redis.

## Notes

- Targets `claude/prepare-2-11-release-dq9ci3` (stacked on the 2.11.1 line) for a clean diff; happy to retarget to `main` since the doc has no dependency on the release changes. (Greptile skips this PR because the base isn't in its allowed-branches list — retargeting to `main` would let it review.)
- No changelog entry added — no behaviour change. Fix PRs that follow should carry their own entries.
- The doc's final section lists the exact OTS-side greps/measurements to determine which (if any) of A1–A4 is the active cause.
- Review follow-ups applied to the proofs (no `lib/` changes): begin/ensure around the `RedisClient.register` monkeypatch, LIFO cleanup of only the hooks the A3 proof adds, and userinfo-stripped URI printing so a password in `FAMILIA_TEST_URI` can't leak into logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016ZF9pUtYEENskgfRhbPog4

---
_Generated by [Claude Code](https://claude.ai/code/session_016ZF9pUtYEENskgfRhbPog4)_