### PR TITLE
Implement per-field algorithm override on encrypted_field (#334)

### DIFF
--- a/changelog.d/20260705_010540_claude_per_field_algorithm_334.rst
+++ b/changelog.d/20260705_010540_claude_per_field_algorithm_334.rst
@@ -1,0 +1,29 @@
+Added
+-----
+
+- ``encrypted_field`` now honors a per-field ``algorithm:`` option, pinning that
+  field's write algorithm to a specific registered provider (``'aes-256-gcm'`` or
+  ``'xchacha20poly1305'``) independent of the registry's default-provider
+  priority. The option was previously documented but silently ignored, so writes
+  always used the default provider. Decryption stays envelope-driven, so a pin can
+  be added, changed, or removed without breaking ciphertext already at rest, and
+  ``re_encrypt_fields!`` re-encrypts under the pin rather than the default. This is
+  the supported lever for a reader-before-writer format migration: deploy
+  ``rbnacl`` fleet-wide so every node can *read* XChaCha20-Poly1305 while keeping
+  *writes* pinned to AES-256-GCM until all readers are confirmed capable, then drop
+  the pin. Issue #334
+
+Documentation
+-------------
+
+- The encrypted-fields guide previously showed a ``provider: :aes_gcm`` field
+  option that was never implemented; those examples now use the real
+  ``algorithm: 'aes-256-gcm'`` form, and the ``Familia::Encryption`` facade
+  docstring documents the shipped behavior instead of a hypothetical
+  implementation sketch. Issue #334
+
+AI Assistance
+-------------
+
+- The per-field algorithm implementation, its regression tryouts, the guide
+  corrections, and this changelog entry were drafted with AI assistance. Issue #334

--- a/changelog.d/20260705_010540_claude_per_field_algorithm_334.rst
+++ b/changelog.d/20260705_010540_claude_per_field_algorithm_334.rst
@@ -13,6 +13,18 @@ Added
   *writes* pinned to AES-256-GCM until all readers are confirmed capable, then drop
   the pin. Issue #334
 
+Fixed
+-----
+
+- ``encrypted_fields_status`` now reports each field's real algorithm for a live
+  encrypted value (e.g. ``{ encrypted: true, algorithm: "aes-256-gcm", cleared:
+  false }``), honoring any per-field pin. Previously it returned ``{ encrypted:
+  false, value: "[CONCEALED]" }`` for every encrypted field, because
+  ``ConcealedString`` had no ``concealed?`` predicate for the status check to
+  match -- so the algorithm shown in the method's docstring and the guides was
+  never actually produced. ``ConcealedString`` gains ``#concealed?`` and
+  ``#algorithm`` readers (the latter reads the stored envelope). Issue #334
+
 Documentation
 -------------
 
@@ -20,10 +32,13 @@ Documentation
   option that was never implemented; those examples now use the real
   ``algorithm: 'aes-256-gcm'`` form, and the ``Familia::Encryption`` facade
   docstring documents the shipped behavior instead of a hypothetical
-  implementation sketch. Issue #334
+  implementation sketch. The ``encrypted_fields_status`` output examples across
+  the guides and the overview were corrected to match what the method now
+  returns. Issue #334
 
 AI Assistance
 -------------
 
-- The per-field algorithm implementation, its regression tryouts, the guide
-  corrections, and this changelog entry were drafted with AI assistance. Issue #334
+- The per-field algorithm implementation, the ``encrypted_fields_status`` fix,
+  their regression tryouts, the guide corrections, and this changelog entry were
+  drafted with AI assistance. Issue #334

--- a/docs/guides/feature-encrypted-fields.md
+++ b/docs/guides/feature-encrypted-fields.md
@@ -189,8 +189,8 @@ Standard AES encryption using OpenSSL (always available):
 class StandardVault < Familia::Horreum
   feature :encrypted_fields
 
-  # Explicitly specify AES-GCM
-  encrypted_field :secret_data, provider: :aes_gcm
+  # Pin this field's writes to AES-256-GCM
+  encrypted_field :secret_data, algorithm: 'aes-256-gcm'
 end
 ```
 
@@ -211,11 +211,11 @@ providers = Familia::Encryption.available_providers
 #   { name: :aes_gcm, priority: 50, available: true }
 # ]
 
-# Force specific provider for testing
+# Pin a specific write algorithm (e.g. for testing or compliance)
 class TestVault < Familia::Horreum
   feature :encrypted_fields
 
-  encrypted_field :test_data, provider: :aes_gcm  # Force AES-GCM
+  encrypted_field :test_data, algorithm: 'aes-256-gcm'  # Force AES-256-GCM
 end
 ```
 
@@ -258,24 +258,54 @@ doc.save
 >
 > Do not mutate any `aad_fields` value between `load` and `re_encrypt_fields!`. The old ciphertext's AAD is bound to the values present at encryption time; changing an AAD field first causes `reveal` inside the rotation loop to fail with `Familia::EncryptionError`, leaving the in-memory object partially rotated (some encrypted fields re-encrypted, others still under the old key). Either re-encrypt before mutating AAD fields, or mutate AAD fields, `save`, re-load, and re-encrypt.
 
-### Per-Field Provider Selection
+### Per-Field Algorithm Selection
+
+By default every field writes with the registry's default provider — the
+highest-priority algorithm available, i.e. XChaCha20-Poly1305 whenever `rbnacl`
+is loaded, otherwise AES-256-GCM. Pass `algorithm:` to pin a field's **write**
+algorithm to a specific registered identifier instead:
 
 ```ruby
 class MultiAlgorithmVault < Familia::Horreum
   feature :encrypted_fields
 
-  # Use best available algorithm (XChaCha20-Poly1305 preferred)
+  # Use the best available algorithm (XChaCha20-Poly1305 when rbnacl is loaded)
   encrypted_field :general_secret
 
-  # Force AES-GCM for compliance requirements
-  encrypted_field :compliance_data, provider: :aes_gcm
+  # Pin writes to AES-256-GCM for compliance requirements
+  encrypted_field :compliance_data, algorithm: 'aes-256-gcm'
 
-  # High-security field with AAD
+  # Pin writes to XChaCha20-Poly1305, combined with AAD
   encrypted_field :ultra_secure,
-                  provider: :xchacha20_poly1305,
+                  algorithm: 'xchacha20poly1305',
                   aad_fields: [:vault_id, :owner_id]
 end
 ```
+
+Valid identifiers are `'aes-256-gcm'` and `'xchacha20poly1305'` (the values a
+provider reports as its `algorithm`). An unregistered value — for example
+`'xchacha20poly1305'` when `rbnacl` is not installed — raises
+`Familia::EncryptionError` on the **first write** to that field, not at class
+declaration.
+
+Only the write side is affected. Decryption always resolves the provider from
+the stored envelope's own `algorithm` field, so a pin can be added, changed, or
+removed at any time without breaking ciphertext already at rest. `re_encrypt_fields!`
+honors the current pin, re-encrypting under the pinned algorithm rather than the
+default.
+
+> **🔄 Reader-before-writer migrations**
+>
+> This is the supported lever for a one-way format migration on a multi-node
+> fleet. To move from AES-256-GCM to XChaCha20-Poly1305 without a mixed-fleet
+> window where new pods write envelopes old pods cannot read:
+>
+> 1. Pin the field to `algorithm: 'aes-256-gcm'` and deploy `rbnacl` fleet-wide,
+>    so every node can *read* XChaCha20 while all *writes* stay AES-256-GCM.
+> 2. Once every node is confirmed capable of reading XChaCha20, remove the pin
+>    (or set it to `'xchacha20poly1305'`) and deploy. New writes flip to XChaCha20;
+>    existing AES-256-GCM envelopes keep decrypting.
+> 3. Optionally run `re_encrypt_fields!` to migrate data at rest to the new format.
 
 ## ConcealedString Security
 
@@ -546,7 +576,7 @@ vault.save
 
 field_status = vault.encrypted_fields_status
 puts "Field status: #{field_status}"
-# => {debug_data: {encrypted: true, key_version: :v2, provider: :xchacha20_poly1305}}
+# => {debug_data: {encrypted: true, algorithm: "xchacha20poly1305", cleared: false}}
 ```
 
 ### Performance Debugging

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -826,7 +826,7 @@ Familia::Encryption.validate_configuration!
 
 # Check encryption status for specific fields
 user.encrypted_fields_status
-# => {ssn: {encrypted: true, key_version: :v2}, credit_card: {encrypted: false}}
+# => {ssn: {encrypted: true, algorithm: "xchacha20poly1305", cleared: false}, credit_card: {encrypted: false, value: nil}}
 
 # Re-encrypt all fields with current key
 user.re_encrypt_fields!

--- a/lib/familia/encryption.rb
+++ b/lib/familia/encryption.rb
@@ -19,48 +19,30 @@ module Familia
   class EncryptionError < StandardError; end
 
   module Encryption
-    # Smart facade with provider selection and field-specific encryption
+    # Smart facade over the provider registry: default-provider selection,
+    # explicit per-call algorithm selection, and envelope-driven decryption.
     #
-    # Usage in EncryptedFieldType can now be more flexible:
+    # Three entry points:
     #
-    #   module Familia
-    #     class EncryptedFieldType < FieldType
-    #       attr_reader :algorithm  # Optional algorithm override
+    #   # Encrypt with the registry's default provider (highest priority
+    #   # available -- XChaCha20-Poly1305 when rbnacl is loaded, else AES-256-GCM).
+    #   Familia::Encryption.encrypt(plaintext, context:, additional_data:)
     #
-    #       def initialize(name, aad_fields: [], algorithm: nil, **options)
-    #         super(name, **options.merge(on_conflict: :raise))
-    #         @aad_fields = Array(aad_fields).freeze
-    #         @algorithm = algorithm  # Use specific algorithm for this field
-    #       end
+    #   # Encrypt with a specific registered algorithm, independent of the
+    #   # default's priority ('aes-256-gcm' or 'xchacha20poly1305').
+    #   Familia::Encryption.encrypt_with(algorithm, plaintext, context:, additional_data:)
     #
-    #       def encrypt_value(record, value)
-    #         context = build_context(record)
-    #         additional_data = build_aad(record)
+    #   # Decrypt: the provider is resolved from the envelope's own algorithm
+    #   # field, so ciphertext written under any registered algorithm (or a
+    #   # retired key version) decrypts without the caller specifying anything.
+    #   Familia::Encryption.decrypt(encrypted, context:, additional_data:)
     #
-    #         if @algorithm
-    #           # Use specific algorithm for this field
-    #           Familia::Encryption.encrypt_with(@algorithm, value,
-    #             context: context,
-    #             additional_data: additional_data)
-    #         else
-    #           # Use default best algorithm
-    #           Familia::Encryption.encrypt(value,
-    #             context: context,
-    #             additional_data: additional_data)
-    #         end
-    #       end
-    #
-    #       # Decrypt auto-detects algorithm from data, so no change needed
-    #       def decrypt_value(record, encrypted)
-    #         context = build_context(record)
-    #         additional_data = build_aad(record)
-    #
-    #         Familia::Encryption.decrypt(encrypted,
-    #           context: context,
-    #           additional_data: additional_data)
-    #       end
-    #     end
-    #   end
+    # EncryptedFieldType builds on this: `encrypted_field :name` uses #encrypt
+    # (the default provider), while `encrypted_field :name, algorithm: '...'`
+    # pins that field's writes to #encrypt_with. Because reads are always
+    # envelope-driven, a field's algorithm pin can be added, changed, or removed
+    # without breaking any ciphertext already at rest -- the lever behind the
+    # reader-before-writer rollout for a one-way format migration.
     class << self
       # Get or create a manager with specific algorithm
       #

--- a/lib/familia/features/encrypted_fields.rb
+++ b/lib/familia/features/encrypted_fields.rb
@@ -291,6 +291,18 @@ module Familia
         #   wrong material yields a derivation mismatch (garbage/failed decrypt), not
         #   an auth-tag error. The value is not persisted, so it must be reproducible
         #   at decrypt time.
+        # @param algorithm [String, nil] Optional per-field write-algorithm pin. When
+        #   nil (default), writes use the registry's default provider -- the highest
+        #   priority available, i.e. XChaCha20-Poly1305 whenever rbnacl is loaded, else
+        #   AES-256-GCM. When set to a registered algorithm identifier
+        #   ('aes-256-gcm' or 'xchacha20poly1305'), every write from this field is
+        #   encrypted with that algorithm regardless of the default. Reads are always
+        #   driven by the stored envelope's own algorithm, so pinning is safe to add,
+        #   change, or remove without breaking ciphertext already at rest. This is the
+        #   supported lever for a reader-before-writer format migration: deploy rbnacl
+        #   fleet-wide so every node can read XChaCha20, while keeping writes pinned to
+        #   'aes-256-gcm' until all readers are confirmed capable, then remove the pin.
+        #   An unregistered algorithm raises Familia::EncryptionError on first write.
         # @param kwargs [Hash] Additional field options
         #
         # @example Basic encrypted field
@@ -312,7 +324,15 @@ module Familia
         #     encrypted_field :payload, key_material: ->(rec) { rec.passphrase }
         #   end
         #
-        def encrypted_field(name, aad_fields: [], **)
+        # @example Field pinned to a specific write algorithm
+        #   class Ledger < Familia::Horreum
+        #     feature :encrypted_fields
+        #     # Keep writing AES-256-GCM even after rbnacl makes XChaCha20 the
+        #     # default, so older nodes can still decrypt during a fleet rollout.
+        #     encrypted_field :entry, algorithm: 'aes-256-gcm'
+        #   end
+        #
+        def encrypted_field(name, aad_fields: [], algorithm: nil, **)
           @encrypted_fields ||= []
           @encrypted_fields << name unless @encrypted_fields.include?(name)
 
@@ -321,7 +341,7 @@ module Familia
             field_groups[:encrypted_fields] << name
           end
 
-          field_type = EncryptedFieldType.new(name, aad_fields: aad_fields, **)
+          field_type = EncryptedFieldType.new(name, aad_fields: aad_fields, algorithm: algorithm, **)
           register_field_type(field_type)
         end
 

--- a/lib/familia/features/encrypted_fields.rb
+++ b/lib/familia/features/encrypted_fields.rb
@@ -465,7 +465,7 @@ module Familia
       #   vault.encrypted_fields_status
       #   # => {
       #   #   secret_key: { encrypted: true, algorithm: "xchacha20poly1305", cleared: false },
-      #   #   api_token: { encrypted: true, algorithm: "aes-256-gcm", cleared: true }
+      #   #   api_token: { encrypted: true, cleared: true }
       #   # }
       #
       def encrypted_fields_status
@@ -477,7 +477,10 @@ module Familia
                                elsif field_value.respond_to?(:cleared?) && field_value.cleared?
                                  { encrypted: true, cleared: true }
                                elsif field_value.respond_to?(:concealed?) && field_value.concealed?
-                                 { encrypted: true, algorithm: 'unknown', cleared: false }
+                                 # ConcealedString#algorithm reads the stored envelope, so this
+                                 # reflects the field's real write algorithm (including a
+                                 # per-field pin), not the current default provider.
+                                 { encrypted: true, algorithm: field_value.algorithm, cleared: false }
                                else
                                  { encrypted: false, value: '[CONCEALED]' }
                                end

--- a/lib/familia/features/encrypted_fields/concealed_string.rb
+++ b/lib/familia/features/encrypted_fields/concealed_string.rb
@@ -149,6 +149,33 @@ class ConcealedString
     @cleared
   end
 
+  # Check if this wrapper is currently concealing encrypted data.
+  #
+  # True for a live encrypted value; false once #clear! has wiped it. Used by
+  # Horreum#encrypted_fields_status to tell an active encrypted field apart from
+  # a cleared one.
+  #
+  # @return [Boolean]
+  #
+  def concealed?
+    !@cleared && !@encrypted_data.nil?
+  end
+
+  # Algorithm identifier recorded in the encrypted envelope (e.g.
+  # 'aes-256-gcm', 'xchacha20poly1305').
+  #
+  # Read from the stored envelope, so it reflects the algorithm the value was
+  # actually written with -- including a per-field pin -- not the current
+  # default provider. Returns nil once the data has been cleared.
+  #
+  # @return [String, nil]
+  #
+  def algorithm
+    return nil if @cleared
+
+    @encrypted_data_obj&.algorithm
+  end
+
   def empty?
     @encrypted_data.to_s.empty?
   end

--- a/lib/familia/features/encrypted_fields/encrypted_field_type.rb
+++ b/lib/familia/features/encrypted_fields/encrypted_field_type.rb
@@ -9,13 +9,23 @@ require_relative 'concealed_string'
 
 module Familia
   class EncryptedFieldType < FieldType
-    attr_reader :aad_fields, :key_material
+    attr_reader :aad_fields, :key_material, :algorithm
 
-    def initialize(name, aad_fields: [], key_material: nil, **options)
+    def initialize(name, aad_fields: [], key_material: nil, algorithm: nil, **options)
       # Encrypted fields are not loggable by default for security
       super(name, **options.merge(on_conflict: :raise, loggable: false))
       @aad_fields = Array(aad_fields).freeze
       @key_material = key_material # Proc returning entropy string
+      # Optional per-field write-algorithm pin. When nil, writes use the
+      # registry's default provider (highest priority available). When set to a
+      # registered algorithm identifier (e.g. 'aes-256-gcm', 'xchacha20poly1305')
+      # every write from this field is encrypted with that algorithm regardless
+      # of the default. Reads are unaffected -- the provider is always resolved
+      # from the stored envelope's own algorithm field -- so pinning changes
+      # only the write side and never breaks ciphertext already at rest.
+      # Validated lazily: an unregistered algorithm raises Familia::EncryptionError
+      # on the first write, not at field declaration.
+      @algorithm = algorithm
     end
 
     def define_setter(klass)
@@ -132,7 +142,15 @@ module Familia
       entropy = build_key_material(record)
       context = context_with_entropy(context, entropy)
 
-      result = Familia::Encryption.encrypt(value, context: context, additional_data: additional_data)
+      # A per-field @algorithm pins the write algorithm via encrypt_with;
+      # otherwise the default provider (registry priority) is used. Either path
+      # records the chosen algorithm in the envelope, so the read path stays
+      # self-describing and unpinning/repinning never affects existing data.
+      result = if @algorithm
+        Familia::Encryption.encrypt_with(@algorithm, value, context: context, additional_data: additional_data)
+      else
+        Familia::Encryption.encrypt(value, context: context, additional_data: additional_data)
+      end
 
       Familia::Encryption::EncryptedData.from_json(result).with_metadata(
         envelope_version: 2,

--- a/try/features/encrypted_fields/encrypted_fields_integration_try.rb
+++ b/try/features/encrypted_fields/encrypted_fields_integration_try.rb
@@ -160,24 +160,15 @@ concealed_data = @xchacha_model.secret_data
 #=> [true, "[CONCEALED]", "xchacha20poly1305 integration test"]
 
 
-# ALGORITHM PARAMETER FIX NEEDED:
-#
-# Problem: encrypted_field :secret_data, algorithm: 'aes-256-gcm'
-# is ignored - always uses default XChaCha20Poly1305
-#
-# Root cause: EncryptedFieldType.encrypt_value always calls
-# Familia::Encryption.encrypt() (default) instead of
-# Familia::Encryption.encrypt_with(@algorithm, ...) when algorithm specified
-#
-# Fix required in lib/familia/features/encrypted_fields/encrypted_field_type.rb:
-# 1. Add attr_reader :algorithm
-# 2. Add algorithm: nil parameter to initialize()
-# 3. Store @algorithm = algorithm
-# 4. Update encrypt_value() to use encrypt_with(@algorithm, ...) when @algorithm present
-#
-# This enables per-field algorithm selection while maintaining backward compatibility
+# Per-field algorithm pin (issue #334): encrypted_field :name, algorithm: '...'
+# selects the write algorithm for that field via Familia::Encryption.encrypt_with,
+# independent of the registry's default provider. Reads stay envelope-driven, so
+# pinning never affects ciphertext already at rest. See per_field_algorithm_try.rb
+# for the full behavioral contract; the two checks below pin it end-to-end through
+# the model field path.
 
-## TEST 8: AES-GCM algorithm specification test (shows default provider takes precedence)
+## TEST 8: a field pinned to AES-256-GCM writes AES-256-GCM even though the
+## registry default is XChaCha20-Poly1305 (rbnacl loaded)
 test_keys = { v1: Base64.strict_encode64('a' * 32) }
 Familia.config.encryption_keys = test_keys
 Familia.config.current_key_version = :v1
@@ -187,20 +178,20 @@ class AESIntegrationModel < Familia::Horreum
   identifier_field :model_id
 
   field :model_id
-  encrypted_field :secret_data, algorithm: 'aes-256-gcm' # Specify the algorithm
+  encrypted_field :secret_data, algorithm: 'aes-256-gcm' # Pin the write algorithm
 end
 
 @aes_model = AESIntegrationModel.new(model_id: 'aes-test')
 @aes_model.secret_data = 'aes-gcm integration test'
 
-# Test shows that algorithm parameter is currently ignored - XChaCha20Poly1305 is used by default
+# The pin is honored: the envelope records aes-256-gcm, not the default xchacha.
 concealed_data = @aes_model.secret_data
 encrypted_json = concealed_data.encrypted_value
 parsed_data = Familia::JsonSerializer.parse(encrypted_json, symbolize_names: true)
 [parsed_data[:algorithm], @aes_model.secret_data.reveal { |data| data }]
-#=> ["xchacha20poly1305", "aes-gcm integration test"]
+#=> ["aes-256-gcm", "aes-gcm integration test"]
 
-## TEST 9: Provider-specific integration: AES-GCM with forced algorithm
+## TEST 9: Provider-specific integration: AES-GCM with pinned algorithm
 test_keys = { v1: Base64.strict_encode64('a' * 32) }
 Familia.config.encryption_keys = test_keys
 Familia.config.current_key_version = :v1
@@ -209,7 +200,7 @@ class AESIntegrationModel2 < Familia::Horreum
   feature :encrypted_fields
   identifier_field :model_id
   field :model_id
-  encrypted_field :secret_data, algorithm: 'aes-256-gcm' # Specify the algorithm
+  encrypted_field :secret_data, algorithm: 'aes-256-gcm' # Pin the write algorithm
 end
 
 @aes_model2 = AESIntegrationModel2.new(model_id: 'aes-test')
@@ -220,4 +211,4 @@ concealed_data = @aes_model2.secret_data
 encrypted_json = concealed_data.encrypted_value
 parsed_data = Familia::JsonSerializer.parse(encrypted_json, symbolize_names: true)
 [parsed_data[:algorithm], @aes_model2.secret_data.reveal { |data| data }]
-#=> ["xchacha20poly1305", "aes-gcm integration test"]
+#=> ["aes-256-gcm", "aes-gcm integration test"]

--- a/try/features/encrypted_fields/per_field_algorithm_try.rb
+++ b/try/features/encrypted_fields/per_field_algorithm_try.rb
@@ -134,3 +134,31 @@ rescue Familia::EncryptionError => e
   e.message.include?('nonexistent-cipher') ? 'raised-with-algorithm' : 'raised-generic'
 end
 #=> 'raised-with-algorithm'
+
+## encrypted_fields_status surfaces each field's real algorithm for a live value
+## (issue #334): a live encrypted field now reports {encrypted: true, algorithm:
+## <real>, cleared: false} instead of falling through to the {encrypted: false}
+## fallback branch, and the algorithm honors the per-field pin.
+@status_rec = PerFieldAlgoModel.new(objid: 'rec_status')
+@status_rec.default_field = 'd'
+@status_rec.aes_field = 'a'
+@status_rec.xchacha_field = 'x'
+status = @status_rec.encrypted_fields_status
+[status[:default_field], status[:aes_field], status[:xchacha_field]]
+#=> [{ encrypted: true, algorithm: 'xchacha20poly1305', cleared: false }, { encrypted: true, algorithm: 'aes-256-gcm', cleared: false }, { encrypted: true, algorithm: 'xchacha20poly1305', cleared: false }]
+
+## A nil encrypted field reports encrypted: false with no algorithm
+PerFieldAlgoModel.new(objid: 'rec_nilstatus').encrypted_fields_status[:aes_field]
+#=> { encrypted: false, value: nil }
+
+## ConcealedString exposes #concealed? and #algorithm for a live value
+[@status_rec.aes_field.concealed?, @status_rec.aes_field.algorithm]
+#=> [true, 'aes-256-gcm']
+
+## A cleared field reports cleared (no algorithm) and the wrapper stops concealing
+@clear_rec = PerFieldAlgoModel.new(objid: 'rec_clear')
+@clear_rec.aes_field = 'to be cleared'
+cs = @clear_rec.aes_field
+cs.clear!
+[@clear_rec.encrypted_fields_status[:aes_field], cs.concealed?, cs.algorithm]
+#=> [{ encrypted: true, cleared: true }, false, nil]

--- a/try/features/encrypted_fields/per_field_algorithm_try.rb
+++ b/try/features/encrypted_fields/per_field_algorithm_try.rb
@@ -1,0 +1,136 @@
+# try/features/encrypted_fields/per_field_algorithm_try.rb
+#
+# frozen_string_literal: true
+#
+# Per-field algorithm pin (issue #334).
+#
+# `encrypted_field :name, algorithm: '...'` pins that field's WRITE algorithm to
+# a specific registered provider via Familia::Encryption.encrypt_with, decoupling
+# it from the registry's default-provider priority. The READ path is unchanged --
+# the provider is always resolved from the stored envelope's own `algorithm`
+# field -- so a pin can be added, changed, or removed without breaking ciphertext
+# already at rest. That decoupling is the supported lever for a reader-before-
+# writer format migration: install rbnacl fleet-wide so every node can READ
+# XChaCha20, while keeping WRITES pinned to AES-256-GCM until every reader is
+# confirmed capable, then drop the pin.
+#
+# AES-256-GCM (OpenSSL) is always available. The XChaCha assertions assume rbnacl
+# is loaded -- the same environment assumption as algorithm_upgrade_try.rb, whose
+# first check would already fail without it. No database writes: everything here
+# exercises the in-memory field path.
+
+require_relative '../../support/helpers/test_helpers'
+require 'base64'
+
+Familia.config.encryption_keys = { v1: Base64.strict_encode64('a' * 32) }
+Familia.config.current_key_version = :v1
+Familia::Encryption::Registry.setup!
+
+class PerFieldAlgoModel < Familia::Horreum
+  feature :encrypted_fields
+  identifier_field :objid
+  field :objid
+  encrypted_field :default_field                                  # no pin -> default provider
+  encrypted_field :aes_field, algorithm: 'aes-256-gcm'            # pinned AES-256-GCM
+  encrypted_field :xchacha_field, algorithm: 'xchacha20poly1305'  # pinned XChaCha20
+end
+
+@record = PerFieldAlgoModel.new(objid: 'rec_1')
+@record.default_field = 'default plaintext'
+@record.aes_field = 'aes plaintext'
+@record.xchacha_field = 'xchacha plaintext'
+
+## Precondition: the registry default is XChaCha20-Poly1305 (rbnacl loaded)
+Familia::Encryption::Registry.default_provider.algorithm
+#=> 'xchacha20poly1305'
+
+## An unpinned field writes with the default provider
+Familia::JsonSerializer.parse(@record.default_field.encrypted_value)['algorithm']
+#=> 'xchacha20poly1305'
+
+## A field pinned to aes-256-gcm writes AES-256-GCM despite the XChaCha default
+Familia::JsonSerializer.parse(@record.aes_field.encrypted_value)['algorithm']
+#=> 'aes-256-gcm'
+
+## A field pinned to xchacha20poly1305 writes XChaCha20-Poly1305
+Familia::JsonSerializer.parse(@record.xchacha_field.encrypted_value)['algorithm']
+#=> 'xchacha20poly1305'
+
+## Per-field granularity: two fields on the SAME record select different algorithms
+[
+  Familia::JsonSerializer.parse(@record.aes_field.encrypted_value)['algorithm'],
+  Familia::JsonSerializer.parse(@record.xchacha_field.encrypted_value)['algorithm'],
+]
+#=> ['aes-256-gcm', 'xchacha20poly1305']
+
+## Reads are envelope-driven: the aes_field envelope decrypts even though the
+## default provider is XChaCha, proving the read path uses the stored algorithm,
+## not the field pin or the default. All three fields round-trip.
+[
+  @record.default_field.reveal { |p| p },
+  @record.aes_field.reveal { |p| p },
+  @record.xchacha_field.reveal { |p| p },
+]
+#=> ['default plaintext', 'aes plaintext', 'xchacha plaintext']
+
+## The pin is introspectable via the field type's #algorithm reader; unpinned is nil
+[
+  PerFieldAlgoModel.field_types[:default_field].algorithm,
+  PerFieldAlgoModel.field_types[:aes_field].algorithm,
+  PerFieldAlgoModel.field_types[:xchacha_field].algorithm,
+]
+#=> [nil, 'aes-256-gcm', 'xchacha20poly1305']
+
+## re_encrypt_fields! preserves each field's pinned algorithm (it does NOT drift to
+## the default provider) -- the guarantee the reader-before-writer rollout relies on
+@record.re_encrypt_fields!
+[
+  Familia::JsonSerializer.parse(@record.aes_field.encrypted_value)['algorithm'],
+  Familia::JsonSerializer.parse(@record.xchacha_field.encrypted_value)['algorithm'],
+  Familia::JsonSerializer.parse(@record.default_field.encrypted_value)['algorithm'],
+]
+#=> ['aes-256-gcm', 'xchacha20poly1305', 'xchacha20poly1305']
+
+## ...and plaintext survives the re-encryption
+[
+  @record.aes_field.reveal { |p| p },
+  @record.xchacha_field.reveal { |p| p },
+]
+#=> ['aes plaintext', 'xchacha plaintext']
+
+## A pin composes with aad_fields
+class PerFieldAlgoAadModel < Familia::Horreum
+  feature :encrypted_fields
+  identifier_field :objid
+  field :objid
+  field :owner
+  encrypted_field :secret, algorithm: 'aes-256-gcm', aad_fields: [:owner]
+end
+@aad_rec = PerFieldAlgoAadModel.new(objid: 'rec_2', owner: 'alice')
+@aad_rec.secret = 'bound secret'
+Familia::JsonSerializer.parse(@aad_rec.secret.encrypted_value)['algorithm']
+#=> 'aes-256-gcm'
+
+## ...and still reveals with the AAD binding intact
+@aad_rec.secret.reveal { |p| p }
+#=> 'bound secret'
+
+## An unregistered algorithm is NOT validated at field declaration...
+class BadAlgoModel < Familia::Horreum
+  feature :encrypted_fields
+  identifier_field :objid
+  field :objid
+  encrypted_field :secret, algorithm: 'nonexistent-cipher'
+end
+BadAlgoModel.field_types[:secret].algorithm
+#=> 'nonexistent-cipher'
+
+## ...but raises Familia::EncryptionError naming the algorithm on the first write
+@bad = BadAlgoModel.new(objid: 'rec_3')
+begin
+  @bad.secret = 'oops'
+  'no-error'
+rescue Familia::EncryptionError => e
+  e.message.include?('nonexistent-cipher') ? 'raised-with-algorithm' : 'raised-generic'
+end
+#=> 'raised-with-algorithm'


### PR DESCRIPTION
## Summary

Fixes #334. The `encrypted_field :name, algorithm: '...'` option was advertised on the `Familia::Encryption` facade docstring — and was already *used* in an integration tryout — but `EncryptedFieldType` never read it. The option fell through `**options` into the base `FieldType`'s option hash and was silently swallowed, so every write used the registry's default provider regardless of the pin. This implements the option (the issue's recommended **Option 1**).

Stacked on `claude/prepare-2-11-release-dq9ci3` for the 2.11 release.

## What changed

**Core** (`encrypted_field_type.rb`, `encrypted_fields.rb`)
- `EncryptedFieldType` now accepts `algorithm:`, exposes it via `attr_reader :algorithm`, and `#encrypt_value` routes to `Familia::Encryption.encrypt_with(@algorithm, …)` when a field is pinned, falling back to `.encrypt` (default provider) when it isn't.
- `encrypted_field` surfaces `algorithm:` explicitly in its signature and YARD.

## Behavioral guarantees (all covered by tests)

- **Reads stay envelope-driven.** The decrypt provider is resolved from the stored envelope's own `algorithm`, so a pin can be added, changed, or removed without breaking ciphertext already at rest.
- **`re_encrypt_fields!` honors the pin.** It re-encrypts under the pinned algorithm, not the default — this is the exact guarantee the reader-before-writer fleet migration relies on.
- **Lazy validation.** An unregistered algorithm raises `Familia::EncryptionError` (naming the algorithm) on the first write, consistent with `Manager.new(algorithm:)` everywhere else — not at field declaration.

## Why it matters

This is the supported lever for a one-way encrypted-format migration across a multi-node fleet: deploy `rbnacl` everywhere so every node can *read* XChaCha20-Poly1305, while keeping *writes* pinned to `aes-256-gcm` until all readers are confirmed capable — then drop the pin. Relates to #330, #333, #335.

## Tests

- **New** `try/features/encrypted_fields/per_field_algorithm_try.rb` (13 checks): per-field granularity on one record, envelope-driven cross-algorithm reads, `re_encrypt` preservation, `aad_fields` composition, `#algorithm` introspection, and the invalid-algorithm error path.
- **Flipped** the integration tryout's **TEST 8 / TEST 9** — they previously *pinned the bug* (asserting `"xchacha20poly1305"` while `algorithm: 'aes-256-gcm'` was set); they now assert the pin is honored (`"aes-256-gcm"`).

## Docs

The guide also showed a `provider: :aes_gcm` field option that was *likewise* never implemented (and didn't match the registry identifiers). Those examples are corrected to the real `algorithm: 'aes-256-gcm'` form, with a reader-before-writer migration callout. The "here's how you could implement it" sketch in `encryption.rb` is replaced with documentation of the shipped facade. Scriv changelog fragment added.

## Verification

- New tryout **13/13**, integration **9/9**, full encrypted-fields + encryption suite **503/503** green.
- **Zero net-new RuboCop offenses** (verified base-vs-working per file).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016ZF9pUtYEENskgfRhbPog4

---
_Generated by [Claude Code](https://claude.ai/code/session_016ZF9pUtYEENskgfRhbPog4)_