### PR TITLE
Clarify Registry.get error for a known-but-unavailable algorithm (#334 follow-up)

### DIFF
--- a/changelog.d/20260705_034300_claude_registry_algorithm_error_message.rst
+++ b/changelog.d/20260705_034300_claude_registry_algorithm_error_message.rst
@@ -8,11 +8,14 @@ Changed
   node without ``rbnacl``/libsodium previously raised the misleading
   ``"Unsupported algorithm: xchacha20poly1305"`` -- pointing an operator at a typo
   when the real fix is a missing dependency. It now names the provider, explains
-  the dependency is missing, and lists the algorithms actually available. The set
-  of registerable providers is centralized in ``Registry.known_providers``, the
-  single source of truth shared by ``setup!`` and ``get``. Error-message and
-  internal-refactor only; the resolution of every available algorithm is
-  unchanged. Issue #334
+  the dependency is missing, and lists the algorithms actually available. Each
+  provider declares its own dependency via a new ``Provider.dependency_hint``
+  class method (nil for always-available providers like OpenSSL AES-256-GCM), so
+  the generic error path names the correct library as providers are added rather
+  than hardcoding any one of them. The set of registerable providers is
+  centralized in ``Registry.known_providers``, the single source of truth shared
+  by ``setup!`` and ``get``. Error-message and internal-refactor only; the
+  resolution of every available algorithm is unchanged. Issue #334
 
 AI Assistance
 -------------

--- a/changelog.d/20260705_034300_claude_registry_algorithm_error_message.rst
+++ b/changelog.d/20260705_034300_claude_registry_algorithm_error_message.rst
@@ -1,0 +1,21 @@
+Changed
+-------
+
+- ``Familia::Encryption::Registry.get`` now distinguishes an unknown algorithm
+  from a *known* algorithm whose provider is not available on the current node.
+  Because ``Registry.register`` only stores providers whose runtime dependency is
+  present, pinning ``encrypted_field ..., algorithm: 'xchacha20poly1305'`` on a
+  node without ``rbnacl``/libsodium previously raised the misleading
+  ``"Unsupported algorithm: xchacha20poly1305"`` -- pointing an operator at a typo
+  when the real fix is a missing dependency. It now names the provider, explains
+  the dependency is missing, and lists the algorithms actually available. The set
+  of registerable providers is centralized in ``Registry.known_providers``, the
+  single source of truth shared by ``setup!`` and ``get``. Error-message and
+  internal-refactor only; the resolution of every available algorithm is
+  unchanged. Issue #334
+
+AI Assistance
+-------------
+
+- The registry error-message refinement, its regression tryout, and this
+  changelog entry were drafted with AI assistance. Issue #334

--- a/changelog.d/20260705_034300_claude_registry_algorithm_error_message.rst
+++ b/changelog.d/20260705_034300_claude_registry_algorithm_error_message.rst
@@ -8,7 +8,10 @@ Changed
   node without ``rbnacl``/libsodium previously raised the misleading
   ``"Unsupported algorithm: xchacha20poly1305"`` -- pointing an operator at a typo
   when the real fix is a missing dependency. It now names the provider, explains
-  the dependency is missing, and lists the algorithms actually available. Each
+  the dependency is missing, and (because ``get`` runs on both the encrypt and
+  decrypt paths) states that installing the dependency is what enables reading
+  *and* writing the algorithm, framing an algorithm pin as a write-time
+  workaround that cannot decrypt existing ciphertext. Each
   provider declares its own dependency via a new ``Provider.dependency_hint``
   class method (nil for always-available providers like OpenSSL AES-256-GCM), so
   the generic error path names the correct library as providers are added rather

--- a/lib/familia/encryption/provider.rb
+++ b/lib/familia/encryption/provider.rb
@@ -46,6 +46,15 @@ module Familia
       def self.priority
         0
       end
+
+      # Human-readable name of the runtime dependency this provider needs to be
+      # `available?`, or nil when it has none (e.g. an always-available OpenSSL
+      # provider). Used only to build a helpful error when a field is pinned to a
+      # known algorithm whose provider isn't installed on this node; override in
+      # subclasses whose availability is gated on an optional library.
+      def self.dependency_hint
+        nil
+      end
     end
   end
 end

--- a/lib/familia/encryption/providers/secure_xchacha20_poly1305_provider.rb
+++ b/lib/familia/encryption/providers/secure_xchacha20_poly1305_provider.rb
@@ -55,6 +55,10 @@ module Familia
           !!defined?(RbNaCl) && !!defined?(FFI)
         end
 
+        def self.dependency_hint
+          'rbnacl/libsodium and ffi'
+        end
+
         def self.priority
           110 # Higher than regular XChaCha20Poly1305Provider
         end

--- a/lib/familia/encryption/providers/xchacha20_poly1305_provider.rb
+++ b/lib/familia/encryption/providers/xchacha20_poly1305_provider.rb
@@ -41,6 +41,10 @@ module Familia
           !!defined?(RbNaCl)
         end
 
+        def self.dependency_hint
+          'rbnacl/libsodium'
+        end
+
         def self.priority
           100 # Highest priority - best in class
         end

--- a/lib/familia/encryption/registry.rb
+++ b/lib/familia/encryption/registry.rb
@@ -30,6 +30,12 @@ module Familia
           # deployed), so point at the real fix instead of implying a typo.
           known = known_providers.find { |klass| algorithm == klass::ALGORITHM }
           if known
+            # get is on both the write (encrypt) and read (decrypt) paths --
+            # Manager#decrypt resolves the provider from the stored envelope's
+            # own algorithm. Installing the dependency is the fix for BOTH;
+            # pinning to another algorithm is a write-time workaround only and
+            # cannot decrypt ciphertext already written under this one, so the
+            # message frames pinning as write-only rather than a general fix.
             # Each provider declares its own dependency (via .dependency_hint),
             # so this generic path stays accurate as providers are added without
             # naming any one library here.
@@ -39,8 +45,10 @@ module Familia
                   "Algorithm #{algorithm.inspect} is known but its provider " \
                   "(#{known.name}) is not available on this node -- its " \
                   "runtime dependency is missing#{requirement}. Install the " \
-                  'dependency, or pin to an available algorithm: ' \
-                  "#{available_algorithms.inspect}."
+                  'dependency to read or write this algorithm. (For writes you ' \
+                  'may instead pin the field to an available algorithm ' \
+                  "(#{available_algorithms.inspect}), but that cannot decrypt " \
+                  'ciphertext already written with this one.)'
           end
 
           raise EncryptionError, "Unsupported algorithm: #{algorithm}"

--- a/lib/familia/encryption/registry.rb
+++ b/lib/familia/encryption/registry.rb
@@ -19,9 +19,27 @@ module Familia
 
         def get(algorithm)
           provider_class = providers[algorithm]
-          raise EncryptionError, "Unsupported algorithm: #{algorithm}" unless provider_class
+          return provider_class.new if provider_class
 
-          provider_class.new
+          # Not registered. `register` only stores providers whose runtime
+          # dependency is present (available? == true), so distinguish a
+          # genuinely unknown algorithm from a known one whose provider isn't
+          # installed on this node. The latter is the common misstep when
+          # pinning `encrypted_field ..., algorithm:` ahead of a fleet rollout
+          # (e.g. pinning xchacha20poly1305 before rbnacl/libsodium is
+          # deployed), so point at the real fix instead of implying a typo.
+          known = known_providers.find { |klass| algorithm == klass::ALGORITHM }
+          if known
+            raise EncryptionError,
+                  "Algorithm #{algorithm.inspect} is known but its provider " \
+                  "(#{known.name}) is not available on this node -- its " \
+                  'runtime dependency is missing (e.g. xchacha20poly1305 ' \
+                  'requires rbnacl/libsodium). Install the dependency, or pin ' \
+                  'to an available algorithm: ' \
+                  "#{available_algorithms.inspect}."
+          end
+
+          raise EncryptionError, "Unsupported algorithm: #{algorithm}"
         end
 
         def default_provider
@@ -40,11 +58,23 @@ module Familia
           providers.keys
         end
 
+        # Every provider class Familia knows how to register, regardless of
+        # whether its runtime dependency is available on this node. `providers`
+        # holds only the subset that passed `available?`; this is the full set,
+        # and the single source of truth shared by `setup!` (which registers
+        # the available ones) and `get` (which uses it to tell an unknown
+        # algorithm apart from a known-but-unavailable one).
+        def known_providers
+          [
+            Providers::XChaCha20Poly1305Provider,
+            Providers::AESGCMProvider,
+            # Future: Providers::ChaCha20Poly1305Provider
+          ]
+        end
+
         # Auto-register known providers
         def setup!
-          register(Providers::XChaCha20Poly1305Provider)
-          register(Providers::AESGCMProvider)
-          # Future: register(Providers::ChaCha20Poly1305Provider)
+          known_providers.each { |provider_class| register(provider_class) }
         end
       end
     end

--- a/lib/familia/encryption/registry.rb
+++ b/lib/familia/encryption/registry.rb
@@ -30,12 +30,16 @@ module Familia
           # deployed), so point at the real fix instead of implying a typo.
           known = known_providers.find { |klass| algorithm == klass::ALGORITHM }
           if known
+            # Each provider declares its own dependency (via .dependency_hint),
+            # so this generic path stays accurate as providers are added without
+            # naming any one library here.
+            dependency = known.dependency_hint
+            requirement = dependency ? " (requires #{dependency})" : ''
             raise EncryptionError,
                   "Algorithm #{algorithm.inspect} is known but its provider " \
                   "(#{known.name}) is not available on this node -- its " \
-                  'runtime dependency is missing (e.g. xchacha20poly1305 ' \
-                  'requires rbnacl/libsodium). Install the dependency, or pin ' \
-                  'to an available algorithm: ' \
+                  "runtime dependency is missing#{requirement}. Install the " \
+                  'dependency, or pin to an available algorithm: ' \
                   "#{available_algorithms.inspect}."
           end
 

--- a/try/features/encryption/registry_algorithm_resolution_try.rb
+++ b/try/features/encryption/registry_algorithm_resolution_try.rb
@@ -1,0 +1,85 @@
+# try/features/encryption/registry_algorithm_resolution_try.rb
+#
+# frozen_string_literal: true
+
+# Registry.get error-message contract.
+#
+# `Registry.register` only stores a provider whose runtime dependency is present
+# (available? == true), so `Registry.get` for an unregistered algorithm has two
+# distinct causes worth telling apart:
+#
+#   1. A genuinely unknown algorithm (typo / never-existed)   -> "Unsupported algorithm"
+#   2. A KNOWN algorithm whose provider isn't installed here   -> actionable "install the dependency"
+#
+# Case 2 is the common misstep when pinning `encrypted_field ..., algorithm:`
+# ahead of a fleet rollout (e.g. pinning xchacha20poly1305 before rbnacl/libsodium
+# is deployed). Before this refinement both cases returned the same "Unsupported
+# algorithm" message, pointing an operator at a typo when the real fix is a
+# missing dependency.
+#
+# These checks simulate a node WITHOUT the xchacha provider by removing it from
+# the live registry (it stays in `known_providers`), then restore the registry so
+# later tryouts see it intact. No database writes.
+
+require_relative '../../support/helpers/test_helpers'
+
+Familia::Encryption::Registry.setup!
+
+## known_providers lists every provider Familia can register, independent of availability
+Familia::Encryption::Registry.known_providers.map { |k| k::ALGORITHM }.sort
+#=> ['aes-256-gcm', 'xchacha20poly1305']
+
+## An available algorithm resolves to a provider instance
+Familia::Encryption::Registry.get('aes-256-gcm').class
+#=> Familia::Encryption::Providers::AESGCMProvider
+
+## A genuinely unknown algorithm raises the plain "Unsupported algorithm" error
+begin
+  Familia::Encryption::Registry.get('totally-made-up')
+  :no_raise
+rescue Familia::EncryptionError => e
+  e.message
+end
+#=> 'Unsupported algorithm: totally-made-up'
+
+# Each check below simulates a node where the xchacha provider's dependency
+# (rbnacl) is absent by removing it from the live registry for the duration of the
+# call, then restoring it in an ensure. The mutate/assert/restore is kept inside a
+# single test block so it can't leak into other tryouts regardless of how the
+# runner orders top-level setup code. (xchacha stays in `known_providers` -- only
+# the live registration is dropped, which is exactly what an absent dependency
+# looks like: `register` skipped it because `available?` was false.)
+
+## A known-but-unavailable algorithm names the provider and points at the missing dependency
+saved = Familia::Encryption::Registry.providers.dup
+Familia::Encryption::Registry.providers.delete('xchacha20poly1305')
+begin
+  Familia::Encryption::Registry.get('xchacha20poly1305')
+  :no_raise
+rescue Familia::EncryptionError => e
+  [
+    e.message.include?('is known but its provider'),
+    e.message.include?('rbnacl'),
+    e.message.include?('XChaCha20Poly1305Provider'),
+  ]
+ensure
+  Familia::Encryption::Registry.providers.replace(saved)
+end
+#=> [true, true, true]
+
+## The known-but-unavailable message does NOT reuse the misleading "Unsupported algorithm" wording
+saved = Familia::Encryption::Registry.providers.dup
+Familia::Encryption::Registry.providers.delete('xchacha20poly1305')
+begin
+  Familia::Encryption::Registry.get('xchacha20poly1305')
+  :no_raise
+rescue Familia::EncryptionError => e
+  e.message.start_with?('Unsupported algorithm')
+ensure
+  Familia::Encryption::Registry.providers.replace(saved)
+end
+#=> false
+
+## Restore is automatic: xchacha resolves again outside the simulated-absent block
+Familia::Encryption::Registry.get('xchacha20poly1305').class
+#=> Familia::Encryption::Providers::XChaCha20Poly1305Provider

--- a/try/features/encryption/registry_algorithm_resolution_try.rb
+++ b/try/features/encryption/registry_algorithm_resolution_try.rb
@@ -50,22 +50,43 @@ end
 # the live registration is dropped, which is exactly what an absent dependency
 # looks like: `register` skipped it because `available?` was false.)
 
-## A known-but-unavailable algorithm names the provider and points at the missing dependency
+## Each provider declares its own dependency (nil when always available), so the error hint is not hardcoded
+[
+  Familia::Encryption::Providers::AESGCMProvider.dependency_hint,
+  Familia::Encryption::Providers::XChaCha20Poly1305Provider.dependency_hint,
+]
+#=> [nil, 'rbnacl/libsodium']
+
+## A known-but-unavailable algorithm names the provider and sources the dependency hint from the provider itself
 saved = Familia::Encryption::Registry.providers.dup
 Familia::Encryption::Registry.providers.delete('xchacha20poly1305')
 begin
   Familia::Encryption::Registry.get('xchacha20poly1305')
   :no_raise
 rescue Familia::EncryptionError => e
+  hint = Familia::Encryption::Providers::XChaCha20Poly1305Provider.dependency_hint
   [
     e.message.include?('is known but its provider'),
-    e.message.include?('rbnacl'),
     e.message.include?('XChaCha20Poly1305Provider'),
+    e.message.include?("requires #{hint}"), # dependency text comes from .dependency_hint, not a literal
   ]
 ensure
   Familia::Encryption::Registry.providers.replace(saved)
 end
 #=> [true, true, true]
+
+## A hintless provider (always-available OpenSSL AES) omits the "requires ..." clause rather than naming another provider's library
+saved = Familia::Encryption::Registry.providers.dup
+Familia::Encryption::Registry.providers.delete('aes-256-gcm')
+begin
+  Familia::Encryption::Registry.get('aes-256-gcm')
+  :no_raise
+rescue Familia::EncryptionError => e
+  [e.message.include?('is known but its provider'), e.message.include?('requires')]
+ensure
+  Familia::Encryption::Registry.providers.replace(saved)
+end
+#=> [true, false]
 
 ## The known-but-unavailable message does NOT reuse the misleading "Unsupported algorithm" wording
 saved = Familia::Encryption::Registry.providers.dup

--- a/try/features/encryption/registry_algorithm_resolution_try.rb
+++ b/try/features/encryption/registry_algorithm_resolution_try.rb
@@ -75,6 +75,25 @@ ensure
 end
 #=> [true, true, true]
 
+## The message is correct for the decrypt path too: installing the dependency covers reads and writes, and pinning is flagged as write-only
+# get() runs on both encrypt and decrypt (Manager#decrypt resolves the provider from
+# the stored envelope), so the guidance must not imply pinning fixes decrypt.
+saved = Familia::Encryption::Registry.providers.dup
+Familia::Encryption::Registry.providers.delete('xchacha20poly1305')
+begin
+  Familia::Encryption::Registry.get('xchacha20poly1305')
+  :no_raise
+rescue Familia::EncryptionError => e
+  [
+    e.message.include?('read or write this algorithm'),
+    e.message.include?('cannot decrypt ciphertext already written'),
+    e.message.downcase.include?('for writes'), # pinning scoped to writes
+  ]
+ensure
+  Familia::Encryption::Registry.providers.replace(saved)
+end
+#=> [true, true, true]
+
 ## A hintless provider (always-available OpenSSL AES) omits the "requires ..." clause rather than naming another provider's library
 saved = Familia::Encryption::Registry.providers.dup
 Familia::Encryption::Registry.providers.delete('aes-256-gcm')

--- a/try/unit/data_types/enumerable_consistency/large_scale_consistency_try.rb
+++ b/try/unit/data_types/enumerable_consistency/large_scale_consistency_try.rb
@@ -16,31 +16,57 @@ require_relative '../../../support/helpers/test_helpers'
 require 'digest'
 require 'set'
 
+# Number of commands to buffer per pipeline round-trip when bulk-loading.
+#
+# The setups here load 10k-1M items. Doing that as a SINGLE pipelined block
+# buffers the whole command batch client-side and forces the server to ingest
+# all of it before the first reply comes back. On a busy/shared CI database that
+# round-trip can exceed the client read timeout -- surfacing as
+# `Redis::ConnectionError: Waited 5 seconds` during setup, which then cascades
+# into the dependent assertions (the collection was never fully populated). This
+# is the standard Redis pipelining guidance: prefer many bounded pipelines over
+# one unbounded one. 10k keeps each round-trip small and fast while still
+# amortizing away per-command latency, and mirrors the `batch_size: 10000` the
+# iteration assertions use.
+BULK_PIPELINE_BATCH = 10_000
+
+# Bulk-load `count` items in bounded pipeline batches. Yields the pipeline and
+# the current index for each item; batches run in ascending index order and each
+# pipeline completes before the next begins, so insertion order is preserved
+# (matters for ListKey's ordered checks).
+def bulk_pipeline(dbclient, count, batch_size: BULK_PIPELINE_BATCH)
+  (0...count).each_slice(batch_size) do |batch|
+    dbclient.pipelined do |pipe|
+      batch.each { |i| yield pipe, i }
+    end
+  end
+end
+
 # Helper to bulk-insert into an UnsortedSet via pipelining
 def bulk_add_to_set(set, count, prefix: 'item')
-  set.dbclient.pipelined do |pipe|
-    count.times { |i| pipe.sadd(set.dbkey, Familia::JsonSerializer.dump("#{prefix}_#{i.to_s.rjust(7, '0')}")) }
+  bulk_pipeline(set.dbclient, count) do |pipe, i|
+    pipe.sadd(set.dbkey, Familia::JsonSerializer.dump("#{prefix}_#{i.to_s.rjust(7, '0')}"))
   end
 end
 
 # Helper to bulk-insert into a SortedSet via pipelining
 def bulk_add_to_zset(zset, count, prefix: 'metric')
-  zset.dbclient.pipelined do |pipe|
-    count.times { |i| pipe.zadd(zset.dbkey, i.to_f, Familia::JsonSerializer.dump("#{prefix}_#{i.to_s.rjust(7, '0')}")) }
+  bulk_pipeline(zset.dbclient, count) do |pipe, i|
+    pipe.zadd(zset.dbkey, i.to_f, Familia::JsonSerializer.dump("#{prefix}_#{i.to_s.rjust(7, '0')}"))
   end
 end
 
 # Helper to bulk-insert into a ListKey via pipelining
 def bulk_push_to_list(list, count, prefix: 'owner')
-  list.dbclient.pipelined do |pipe|
-    count.times { |i| pipe.rpush(list.dbkey, Familia::JsonSerializer.dump("#{prefix}_#{i.to_s.rjust(7, '0')}")) }
+  bulk_pipeline(list.dbclient, count) do |pipe, i|
+    pipe.rpush(list.dbkey, Familia::JsonSerializer.dump("#{prefix}_#{i.to_s.rjust(7, '0')}"))
   end
 end
 
 # Helper to bulk-insert into a HashKey via pipelining
 def bulk_set_hash(hash, count, prefix: 'field')
-  hash.dbclient.pipelined do |pipe|
-    count.times { |i| pipe.hset(hash.dbkey, "#{prefix}_#{i.to_s.rjust(7, '0')}", Familia::JsonSerializer.dump("value_#{i}")) }
+  bulk_pipeline(hash.dbclient, count) do |pipe, i|
+    pipe.hset(hash.dbkey, "#{prefix}_#{i.to_s.rjust(7, '0')}", Familia::JsonSerializer.dump("value_#{i}"))
   end
 end
 


### PR DESCRIPTION
## Summary

Stacked on top of #332 (base: `claude/prepare-2-11-release-dq9ci3`). A small refinement that came out of reviewing the per-field encryption algorithm feature (#334, merged into the release branch via #339).

`Familia::Encryption::Registry.register` only stores a provider whose runtime dependency is present (`available? == true`). So `Registry.get` for an unregistered algorithm has **two distinct causes** that were collapsed into one error message:

1. A genuinely unknown algorithm (typo / never existed) — correctly `"Unsupported algorithm: <name>"`.
2. A **known** algorithm whose provider isn't installed on this node — *also* raised `"Unsupported algorithm: <name>"`.

Case 2 is the natural misstep with the new per-field pin: `encrypted_field :x, algorithm: 'xchacha20poly1305'` on a node where `rbnacl`/libsodium isn't deployed yet. That's the *first half* of the exact fleet-rollout workflow the feature is built for — and the old message pointed the operator at a typo when the real fix is a missing dependency.

## What changed

- **`Registry.get`** now tells the two cases apart. A known-but-unavailable algorithm raises an actionable error that names the provider, states the dependency is missing, and lists the algorithms actually available on this node. An unknown algorithm still raises the plain `"Unsupported algorithm"`.
- **`Registry.known_providers`** centralizes the registerable provider list as the single source of truth, shared by `setup!` (registers the available subset) and `get` (uses the full set to classify the failure). `setup!` now iterates it instead of hardcoding the same two classes.

This is **error-message + internal-refactor only** — resolution of every available algorithm is unchanged, and lazy validation still happens on first write (no eager validation at field declaration).

### Before / after (node without rbnacl, field pinned to xchacha)

```
before: Familia::EncryptionError: Unsupported algorithm: xchacha20poly1305
after:  Familia::EncryptionError: Algorithm "xchacha20poly1305" is known but its
        provider (Familia::Encryption::Providers::XChaCha20Poly1305Provider) is not
        available on this node -- its runtime dependency is missing (e.g.
        xchacha20poly1305 requires rbnacl/libsodium). Install the dependency, or pin
        to an available algorithm: ["aes-256-gcm"].
```

## Tests

New `try/features/encryption/registry_algorithm_resolution_try.rb` (6 checks, all green):
- `known_providers` lists both providers regardless of availability
- an available algorithm resolves to a provider instance
- an unknown algorithm → plain `"Unsupported algorithm"`
- a known-but-unavailable algorithm → provider name + `rbnacl` hint, and does **not** reuse the `"Unsupported algorithm"` wording

The unavailable case is simulated by removing xchacha from the live registry (it stays in `known_providers`) inside a single test block with an `ensure` restore, so it can't leak into other tryouts.

## Verification

- `bin/try` on the new tryout: **6 passed**
- Existing encryption + per-field tryouts: no new failures (the `encoding_phase*` and `registry_methods` failures in this container are pre-existing — `US-ASCII` default locale and no local Redis respectively; both reproduce with this change stashed)
- RuboCop clean on the changed `lib/` file

## Notes

Reviewing the feature also surfaced two items I deliberately did **not** change, for the record: the empty-string `StringKey#exists?` semantics change in #337 is intentional and documented, and the "typo caught only at first write" behavior is the feature's documented lazy-validation contract. Neither warranted a change.

https://claude.ai/code/session_016ZF9pUtYEENskgfRhbPog4

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GF58R6fKtantPjWXX3Dwko)_