### PR TITLE
Fix nil field persistence: omit from storage instead of storing "null"

### DIFF
--- a/changelog.d/20260705_184821_claude_familia-field-persistence.rst
+++ b/changelog.d/20260705_184821_claude_familia-field-persistence.rst
@@ -28,6 +28,15 @@ Changed
   non-empty. ``to_h`` is unchanged and still returns every declared field
   (including nils) for API stability.
 
+- ``save`` and ``commit_fields`` remain a *full-overwrite* of scalar state: after
+  a save the stored hash matches the in-memory object exactly, so a field that is
+  nil in memory is removed from storage. A consequence worth noting for the claim
+  pattern: a field claimed out of band via ``HSETNX`` while an in-memory copy
+  still holds nil for it is cleared by a full ``save``/``commit_fields`` of that
+  (stale) copy. To claim a field and update the record without disturbing it, use
+  the targeted writers (``save_fields``, ``multi_field_update``,
+  ``multi_field_fast_write``), or ``refresh!`` before saving.
+
 AI Assistance
 -------------
 

--- a/changelog.d/20260705_184821_claude_familia-field-persistence.rst
+++ b/changelog.d/20260705_184821_claude_familia-field-persistence.rst
@@ -25,8 +25,11 @@ Changed
   ``multi_field_fast_write``) delete a named field passed as nil. ``HMSET`` on an
   object with no non-nil fields is treated as a successful no-op instead of
   raising, since a normal object's always-present identifier field keeps its hash
-  non-empty. ``to_h`` is unchanged and still returns every declared field
-  (including nils) for API stability.
+  non-empty. In that degenerate "nothing persisted" case (only reachable with a
+  Proc-derived identifier and all-nil fields) the write paths also skip touching
+  the class ``instances`` timeline, so the identifier is not registered pointing
+  at a hash key that was never created. ``to_h`` is unchanged and still returns
+  every declared field (including nils) for API stability.
 
 - ``save`` and ``commit_fields`` remain a *full-overwrite* of scalar state: after
   a save the stored hash matches the in-memory object exactly, so a field that is

--- a/changelog.d/20260705_184821_claude_familia-field-persistence.rst
+++ b/changelog.d/20260705_184821_claude_familia-field-persistence.rst
@@ -1,0 +1,37 @@
+Fixed
+-----
+
+- Nil-valued fields are no longer persisted to Valkey/Redis as the JSON string
+  ``"null"``. A hash has no native NULL, so storing ``"null"`` for every declared
+  field left declared fields perpetually *present*, which defeated
+  ``HSETNX``/``HEXISTS``-based atomic claim ("first writer wins") patterns and
+  wasted memory. Nil fields are now omitted so that field *absence* represents
+  "no value" -- realigning with the behavior ``to_h_for_storage``'s own
+  documentation had described all along (v1.x excluded nils; the v2.0
+  type-preserving serialization rewrite started writing ``"null"`` without
+  updating the docs). A field cleared to nil is now actively removed from storage
+  on save (``HDEL``), so ``"unset"`` and ``nil`` are again the same observable
+  state after a round trip. Hashes that still contain ``"null"`` values are
+  cleaned up automatically the next time the object is saved; reads already decode
+  ``"null"`` back to ``nil``, so no migration is required.
+
+Changed
+-------
+
+- ``Horreum#to_h_for_storage`` now omits nil-valued fields, and every write path
+  removes a field that has become nil rather than storing ``"null"``: the
+  full-object paths (``save``, ``commit_fields``) delete now-nil declared fields,
+  and the partial paths (``save_fields``, ``multi_field_update``,
+  ``multi_field_fast_write``) delete a named field passed as nil. ``HMSET`` on an
+  object with no non-nil fields is treated as a successful no-op instead of
+  raising, since a normal object's always-present identifier field keeps its hash
+  non-empty. ``to_h`` is unchanged and still returns every declared field
+  (including nils) for API stability.
+
+AI Assistance
+-------------
+
+- Investigation of the serialization/persistence code paths, the implementation,
+  and new tryouts coverage (proving ``HSETNX``-based claims now succeed on a
+  nil-declared field and that a field cleared to nil is removed from storage) were
+  produced with assistance from Claude Code.

--- a/lib/familia/horreum/database_commands.rb
+++ b/lib/familia/horreum/database_commands.rb
@@ -157,8 +157,14 @@ module Familia
       #
       # @param hsh [Hash] Hash of field-value pairs to set
       # @return [String] 'OK' on success
-      def hmset(hsh = {})
+      def hmset(hsh = nil)
         hsh ||= to_h_for_storage
+        # An empty hash means there is nothing to persist -- e.g. an object whose
+        # only non-nil field would be a Proc-derived identifier, so no declared
+        # field is written. HMSET with zero field/value pairs is a Redis error,
+        # so treat it as a successful no-op rather than crashing the save.
+        return 'OK' if hsh.empty?
+
         Familia.trace :HMSET, nil, hsh if Familia.debug?
         dbclient.hmset dbkey(suffix), hsh
       end

--- a/lib/familia/horreum/persistence.rb
+++ b/lib/familia/horreum/persistence.rb
@@ -88,6 +88,15 @@ module Familia
       # @example Single-expression short-circuit
       #   user.save && AuditLog.record(:user_updated, user.identifier)
       #
+      # @note This is a FULL-OVERWRITE of the object's scalar state: afterwards
+      #   the stored hash matches the in-memory object exactly. Non-nil fields are
+      #   written and fields that are nil in memory are removed from storage. A
+      #   field managed out of band -- e.g. one claimed by another actor via
+      #   HSETNX while this (possibly stale) copy still holds nil for it -- is
+      #   therefore cleared by a full save. To update an object without disturbing
+      #   such fields, use the targeted writers ({#save_fields},
+      #   {#multi_field_update}, {#multi_field_fast_write}) or {#refresh!} first.
+      #
       # @see #save_if_not_exists! For conditional saves
       # @see #transaction For atomic operations after save
       #
@@ -1004,6 +1013,12 @@ module Familia
       # cleared to nil does not leave a stale entry behind. This is what keeps
       # "absent" and "nil" the same observable state after a round trip, and
       # what makes HSETNX/HEXISTS on a nil'd field behave correctly.
+      #
+      # Because it removes every field that is nil in memory, save/commit_fields
+      # are a full-overwrite of scalar state (see {#save}). A field managed out of
+      # band (e.g. an HSETNX claim) that is still nil on this in-memory copy is
+      # cleared by a full save; use the targeted writers or {#refresh!} to avoid
+      # that.
       #
       # Intended to run inside the save/commit transaction. HDEL of an absent
       # field is a harmless no-op, so it is safe on both the create and update

--- a/lib/familia/horreum/persistence.rb
+++ b/lib/familia/horreum/persistence.rb
@@ -329,20 +329,23 @@ module Familia
 
         result = transaction do |_conn|
           # Set all non-nil fields atomically
-          result = hmset(prepared_value)
+          hmset_result = hmset(prepared_value)
 
           # Remove any fields cleared to nil so their prior stored value is not
           # left stale (HMSET never deletes omitted fields).
           remove_stale_nil_fields
 
           # Update expiration in same transaction to ensure atomicity
-          self.update_expiration if result && update_expiration
+          self.update_expiration if hmset_result && update_expiration
 
-          # Touch instances timeline so the object is visible
-          # to list-based enumeration (instances.to_a, count, etc.)
-          touch_instances! if result
+          # Touch instances timeline so the object is visible to list-based
+          # enumeration (instances.to_a, count, etc.). Skip it when nothing was
+          # persisted and no hash key exists -- otherwise the identifier is
+          # registered in `instances` pointing at a missing hash (see
+          # {#persist_to_storage}).
+          touch_instances! if hmset_result && !prepared_value.empty?
 
-          result
+          hmset_result
         end
 
         # Clear dirty tracking after successful commit
@@ -1067,8 +1070,18 @@ module Familia
         # 3. Update class-level indexes
         auto_update_class_indexes
 
-        # 4. Touch instances timeline (delegates to touch_instances!)
-        touch_instances!
+        # 4. Touch instances timeline (delegates to touch_instances!).
+        #
+        # Skip it when there is genuinely nothing stored and no hash key exists.
+        # prepared_h is empty only when every declared persistent field is nil
+        # AND the identifier is not itself a stored field (a Proc-derived
+        # identifier) -- hmset no-op'd and no key was created. Registering the
+        # identifier in `instances` in that case would leave a dangling
+        # reference: the identifier would list in instances.to_a while exists?
+        # (check_size: true) returns false and any load follows a dead pointer.
+        # In the ubiquitous `identifier_field :id; field :id` pattern the id
+        # keeps prepared_h non-empty, so this only skips the degenerate case.
+        touch_instances! unless prepared_h.empty?
 
         hmset_result
       end

--- a/lib/familia/horreum/persistence.rb
+++ b/lib/familia/horreum/persistence.rb
@@ -319,8 +319,12 @@ module Familia
         Familia.debug "[commit_fields] Begin #{self.class} #{dbkey} #{prepared_value} (exp: #{update_expiration})"
 
         result = transaction do |_conn|
-          # Set all fields atomically
+          # Set all non-nil fields atomically
           result = hmset(prepared_value)
+
+          # Remove any fields cleared to nil so their prior stored value is not
+          # left stale (HMSET never deletes omitted fields).
+          remove_stale_nil_fields
 
           # Update expiration in same transaction to ensure atomicity
           self.update_expiration if result && update_expiration
@@ -376,10 +380,15 @@ module Familia
         Familia.trace :MULTI_FIELD_UPDATE, nil, fields.keys if Familia.debug?
 
         result = transaction do |_conn|
-          # 1. Update all fields atomically (Redis only, no in-memory mutation)
+          # 1. Update all fields atomically (Redis only, no in-memory mutation).
+          # A nil value deletes the field rather than storing "null", so absence
+          # stays authoritative (see Serialization#to_h_for_storage).
           fields.each do |field, value|
-            prepared_value = serialize_value(value)
-            hset field, prepared_value
+            if value.nil?
+              remove_field(field)
+            else
+              hset field, serialize_value(value)
+            end
           end
 
           # 2. Update expiration in same transaction
@@ -434,14 +443,23 @@ module Familia
 
         Familia.trace :MULTI_FIELD_FAST_WRITE, nil, fields.keys if Familia.debug?
 
-        # Serialize values before the transaction (read-only on instance)
+        # Serialize values before the transaction (read-only on instance).
+        # A nil value deletes the field rather than storing "null" (see
+        # Serialization#to_h_for_storage), so split writes from removals.
         serialized = {}
+        nil_fields = []
         fields.each do |field, value|
-          serialized[field] = serialize_value(value)
+          if value.nil?
+            nil_fields << field.to_s
+          else
+            serialized[field] = serialize_value(value)
+          end
         end
 
         result = transaction do |_conn|
           hmset(serialized)
+
+          dbclient.hdel(dbkey, *nil_fields) unless nil_fields.empty?
 
           update_expiration if update_exp
 
@@ -478,19 +496,28 @@ module Familia
         Familia.trace :SAVE_FIELDS, nil, field_names if Familia.debug?
 
         result = transaction do |_conn|
-          # Build hash of field names to serialized values
+          # Build hash of non-nil field values; collect nil'd fields for removal.
+          # A nil field is deleted rather than stored as "null" so that absence
+          # stays authoritative (see Serialization#to_h_for_storage).
           fields_hash = {}
+          nil_fields = []
           field_names.each do |field|
             field_sym = field.to_sym
             raise ArgumentError, "Unknown field: #{field}" unless respond_to?(field_sym)
 
             value = send(field_sym)
-            prepared_value = serialize_value(value)
-            fields_hash[field] = prepared_value
+            if value.nil?
+              nil_fields << field.to_s
+            else
+              fields_hash[field] = serialize_value(value)
+            end
           end
 
-          # Set all fields at once using hmset
+          # Set all non-nil fields at once (hmset no-ops on an empty hash)
           hmset(fields_hash)
+
+          # Remove any nil'd fields so their prior stored value does not linger
+          dbclient.hdel(dbkey, *nil_fields) unless nil_fields.empty?
 
           # Update expiration in same transaction
           self.update_expiration if update_expiration
@@ -959,6 +986,40 @@ module Familia
       end
       private :prepare_for_save
 
+      # Names (as strings) of declared persistent fields whose current in-memory
+      # value is nil. These are omitted from {Serialization#to_h_for_storage}, so
+      # on an update their previously-stored value must be explicitly deleted.
+      #
+      # @return [Array<String>]
+      #
+      def nil_persistent_field_names
+        self.class.persistent_fields.each_with_object([]) do |field, names|
+          field_type = self.class.field_types[field]
+          names << field.to_s if send(field_type.method_name).nil?
+        end
+      end
+      private :nil_persistent_field_names
+
+      # Deletes any now-nil persistent fields from the object hash so a value
+      # cleared to nil does not leave a stale entry behind. This is what keeps
+      # "absent" and "nil" the same observable state after a round trip, and
+      # what makes HSETNX/HEXISTS on a nil'd field behave correctly.
+      #
+      # Intended to run inside the save/commit transaction. HDEL of an absent
+      # field is a harmless no-op, so it is safe on both the create and update
+      # paths (and queues cleanly inside MULTI/EXEC).
+      #
+      # @return [void]
+      #
+      def remove_stale_nil_fields
+        names = nil_persistent_field_names
+        return if names.empty?
+
+        Familia.trace :HDEL, nil, names if Familia.debug?
+        dbclient.hdel(dbkey, *names)
+      end
+      private :remove_stale_nil_fields
+
       # Persists the object's data to storage within a transaction.
       #
       # This is the primary code path that adds an object to the class-level
@@ -975,9 +1036,15 @@ module Familia
       # @return [Object] The result of the hmset operation
       #
       def persist_to_storage(update_expiration)
-        # 1. Save all fields to hashkey at once
+        # 1. Save all non-nil fields to hashkey at once
         prepared_h = to_h_for_storage
         hmset_result = hmset(prepared_h)
+
+        # 1b. Remove any fields cleared to nil so a nil'd value does not linger
+        # in storage. HMSET only sets the fields it is given; it never deletes
+        # omitted ones, so an update that clears a field to nil would otherwise
+        # leave the prior value behind. Harmless no-op on the create path.
+        remove_stale_nil_fields
 
         # 2. Set expiration in same transaction
         self.update_expiration if update_expiration

--- a/lib/familia/horreum/serialization.rb
+++ b/lib/familia/horreum/serialization.rb
@@ -22,7 +22,9 @@ module Familia
       #   # Note: Returns actual Ruby types, not JSON strings
       #
       # @note Only loggable fields are included. Encrypted fields are excluded.
-      # @note Nil values are excluded from the returned hash (storage optimization)
+      # @note Every persistent field appears, including those whose value is nil.
+      #   This differs from {#to_h_for_storage}, which omits nil fields so that
+      #   absence -- not a stored "null" -- represents "no value" in Valkey/Redis.
       #
       def to_h
         self.class.persistent_fields.each_with_object({}) do |field, hsh|
@@ -55,13 +57,25 @@ module Familia
       #   # Note: Strings are JSON-encoded with quotes
       #
       # @note This is an internal method used by commit_fields and hmset
-      # @note Nil values are excluded to optimize Redis storage
+      # @note Nil-valued fields are omitted so that field *absence* -- not a
+      #   stored "null" -- represents "no value" in the Valkey/Redis hash. This
+      #   is what keeps HSETNX/HEXISTS-based claim patterns usable and avoids
+      #   materializing every declared field. Fields cleared to nil are actively
+      #   removed from storage on save; see {Persistence#remove_stale_nil_fields}.
       #
       def to_h_for_storage
         self.class.persistent_fields.each_with_object({}) do |field, hsh|
           field_type = self.class.field_types[field]
 
           val = send(field_type.method_name)
+
+          # Omit nil fields entirely. A Valkey/Redis hash has no NULL: absence is
+          # the native "no value". Persisting nil as the JSON string "null" would
+          # make declared fields perpetually present, defeating HSETNX/HEXISTS and
+          # wasting memory. Round-trips are unaffected -- deserialize_value already
+          # returns nil for an absent field.
+          next if val.nil?
+
           prepared = serialize_value(val)
 
           if Familia.debug?

--- a/try/features/encrypted_fields/re_encrypt_fields_try.rb
+++ b/try/features/encrypted_fields/re_encrypt_fields_try.rb
@@ -127,13 +127,13 @@ result = @partial_fresh.re_encrypt_fields!
 
 raw_token = Familia.dbclient.hget(@partial_fresh.dbkey, 'token')
 raw_secret = Familia.dbclient.hget(@partial_fresh.dbkey, 'secret')
-# Nil encrypted fields are stored as the JSON literal "null" by Familia's
-# scalar serializer -- not as an encrypted envelope. The contract we care
-# about here is: re_encrypt_fields! must not turn a nil field into
-# ciphertext. Parsing "null" yields nil, so we assert that directly.
-token_parsed = JSON.parse(raw_token) rescue :unparseable
-[result, token_parsed, JSON.parse(raw_secret)['key_version']]
-#=> [true, nil, 'v2']
+# A nil field is not persisted at all -- in a Redis hash, absence *is* the
+# representation of "no value" -- so the token field simply does not exist in
+# storage (hget returns nil). The contract we care about here is: re_encrypt_fields!
+# must not turn a nil field into ciphertext; an absent field trivially satisfies
+# that, and is now directly observable via HEXISTS/hget being nil.
+[result, raw_token.nil?, JSON.parse(raw_secret)['key_version']]
+#=> [true, true, 'v2']
 
 ## is idempotent when current key is unchanged
 # Calling re_encrypt_fields! twice without rotating must succeed both times

--- a/try/integration/database_consistency_try.rb
+++ b/try/integration/database_consistency_try.rb
@@ -67,10 +67,11 @@ key_parts = dbkey.split(':')
 expected_fields = @serial_test.class.persistent_fields.length
 redis_field_count = Familia.dbclient.hlen(@serial_test.dbkey)
 actual_object_fields = @serial_test.to_h.keys.length
-# The JSON Serializer stores all fields (including nil as "null")
-# Expected fields (5) >= redis count (5) >= to_h count (5, even though email is nil)
+# Storage omits nil fields (absence represents "no value"), so only the single
+# non-nil field (id) is written even though the class declares 5 persistent
+# fields. to_h still reports every declared field, including the nil ones.
 [expected_fields, redis_field_count, actual_object_fields]
-#=> [5, 5, 5]
+#=> [5, 1, 5]
 
 ## Memory vs persistence state consistency after save
 @consistency_obj = ConsistencyTestModel.new(id: next_test_id, name: 'Memory Test', email: 'test@example.com')

--- a/try/integration/nil_field_absence_try.rb
+++ b/try/integration/nil_field_absence_try.rb
@@ -1,0 +1,121 @@
+# try/integration/nil_field_absence_try.rb
+#
+# frozen_string_literal: true
+#
+# Nil-valued declared fields are ABSENT from the Valkey/Redis hash rather than
+# stored as the JSON literal "null". Field absence is the native representation
+# of "no value" in a hash, and it is what makes HSETNX/HEXISTS-based claim
+# patterns work and keeps "unset" and "nil" the same observable state after a
+# round trip.
+
+require_relative '../support/helpers/test_helpers'
+
+class NilAbsenceModel < Familia::Horreum
+  identifier_field :id
+  field :id
+  field :name
+  field :claimed_at # nil until atomically claimed via HSETNX
+  field :note
+end
+
+# Clean up any prior test data
+begin
+  existing = Familia.dbclient.keys('nilabsencemodel:*')
+  Familia.dbclient.del(*existing) if existing.any?
+rescue StandardError
+  # ignore cleanup errors
+end
+
+@id_counter = 0
+def next_id
+  @id_counter += 1
+  "nil-absence-#{Familia.now.to_i}-#{@id_counter}"
+end
+
+## A nil declared field is not written to storage (HEXISTS is false)
+@obj = NilAbsenceModel.new(id: next_id, name: 'has name')
+@obj.save
+Familia.dbclient.hexists(@obj.dbkey, 'claimed_at')
+#=> false
+
+## Only the non-nil fields are stored in the hash
+@obj.hgetall.keys.sort
+#=> ["id", "name"]
+
+## to_h still reports every declared field, including the nil ones
+@obj.to_h.keys.sort
+#=> ["claimed_at", "id", "name", "note"]
+
+## The nil field round-trips as nil after refresh (absent == nil)
+@obj.refresh!
+@obj.claimed_at
+#=> nil
+
+## HSETNX succeeds on a nil declared field -- the field is genuinely absent
+@claim = NilAbsenceModel.new(id: next_id, name: 'claimant')
+@claim.save
+@claim.hsetnx('claimed_at', Familia.now.to_i.to_s)
+#=> true
+
+## A second HSETNX fails: the field now holds a value (first-writer-wins)
+@claim.hsetnx('claimed_at', Familia.now.to_i.to_s)
+#=> false
+
+## Clearing a previously-set field to nil and saving REMOVES it from storage
+@edit = NilAbsenceModel.new(id: next_id, name: 'edit me', note: 'temporary')
+@edit.save
+@edit.note = nil
+@edit.save
+Familia.dbclient.hexists(@edit.dbkey, 'note')
+#=> false
+
+## After clearing, HSETNX can claim the freed field again
+@edit.hsetnx('note', 'reclaimed')
+#=> true
+
+## An object whose only non-nil field is its identifier still exists
+@bare = NilAbsenceModel.new(id: next_id)
+@bare.save
+@bare.exists?
+#=> true
+
+## commit_fields also removes a field cleared to nil
+@commit = NilAbsenceModel.new(id: next_id, name: 'keep', note: 'drop me')
+@commit.save
+@commit.note = nil
+@commit.commit_fields
+Familia.dbclient.hexists(@commit.dbkey, 'note')
+#=> false
+
+## multi_field_update with a nil value deletes the field
+@mfu = NilAbsenceModel.new(id: next_id, name: 'mfu', note: 'present')
+@mfu.save
+@mfu.multi_field_update(note: nil)
+Familia.dbclient.hexists(@mfu.dbkey, 'note')
+#=> false
+
+## save_fields with a nil value deletes the named field
+@sf = NilAbsenceModel.new(id: next_id, name: 'sf', note: 'present')
+@sf.save
+@sf.note = nil
+@sf.save_fields(:note)
+Familia.dbclient.hexists(@sf.dbkey, 'note')
+#=> false
+
+## Legacy data: a field stored as the JSON literal "null" is cleaned up on save
+@legacy = NilAbsenceModel.new(id: next_id, name: 'legacy')
+@legacy.save
+# Simulate a hash written by the pre-fix serializer, which stored nil as "null"
+Familia.dbclient.hset(@legacy.dbkey, 'claimed_at', 'null')
+@legacy.refresh! # deserialize_value turns "null" back into nil
+@legacy.save     # the now-nil field is actively removed
+Familia.dbclient.hexists(@legacy.dbkey, 'claimed_at')
+#=> false
+
+# Final cleanup
+begin
+  leftover = Familia.dbclient.keys('nilabsencemodel:*')
+  Familia.dbclient.del(*leftover) if leftover.any?
+rescue StandardError
+  # ignore cleanup errors
+end

--- a/try/integration/nil_field_absence_try.rb
+++ b/try/integration/nil_field_absence_try.rb
@@ -18,6 +18,17 @@ class NilAbsenceModel < Familia::Horreum
   field :note
 end
 
+# Identifier derived from a NON-persistent attribute (a Proc), so every declared
+# persistent field can be nil while the object still has a usable identifier.
+# This exercises the degenerate "nothing to persist" path.
+class ProcIdAbsenceModel < Familia::Horreum
+  identifier_field ->(obj) { obj.probe_id }
+  field :name
+  field :note
+
+  attr_accessor :probe_id
+end
+
 # Clean up any prior test data
 begin
   existing = Familia.dbclient.keys('nilabsencemodel:*')
@@ -102,6 +113,33 @@ Familia.dbclient.hexists(@mfu.dbkey, 'note')
 Familia.dbclient.hexists(@sf.dbkey, 'note')
 #=> false
 
+## multi_field_fast_write with a nil value deletes the named field
+@mffw = NilAbsenceModel.new(id: next_id, name: 'mffw', note: 'present')
+@mffw.save
+@mffw.multi_field_fast_write(note: nil)
+Familia.dbclient.hexists(@mffw.dbkey, 'note')
+#=> false
+
+## multi_field_fast_write also clears the in-memory value
+@mffw.note
+#=> nil
+
+## A Proc-identifier object with all-nil fields does not create a ghost instances entry
+# Nothing is persisted (hmset no-ops), so no hash key is created; the identifier
+# must NOT be registered in the instances timeline, or it would dangle -- listed
+# in instances.to_a while exists? reports false and any load follows a dead ref.
+@ghost = ProcIdAbsenceModel.new
+@ghost.probe_id = "proc-#{Familia.now.to_i}-#{@id_counter += 1}"
+@ghost.save
+[@ghost.exists?, ProcIdAbsenceModel.instances.to_a.include?(@ghost.identifier)]
+#=> [false, false]
+
+## Once a Proc-identifier object has a real field value, it persists and registers normally
+@ghost.name = 'now real'
+@ghost.save
+[@ghost.exists?, ProcIdAbsenceModel.instances.to_a.include?(@ghost.identifier)]
+#=> [true, true]
+
 ## Legacy data: a field stored as the JSON literal "null" is cleaned up on save
 @legacy = NilAbsenceModel.new(id: next_id, name: 'legacy')
 @legacy.save
@@ -115,6 +153,7 @@ Familia.dbclient.hexists(@legacy.dbkey, 'claimed_at')
 # Final cleanup
 begin
   leftover = Familia.dbclient.keys('nilabsencemodel:*')
+  leftover.concat(Familia.dbclient.keys('procidabsencemodel:*'))
   Familia.dbclient.del(*leftover) if leftover.any?
 rescue StandardError
   # ignore cleanup errors

--- a/try/unit/horreum/serialization_try.rb
+++ b/try/unit/horreum/serialization_try.rb
@@ -66,9 +66,12 @@ Familia.dbclient.set('debug:ending_save_if_not_exists_tests', Familia.now.to_s)
 #=> "John Doe"
 
 ## multi_field_update can update multiple fields atomically, to_h
+# email was never set before the initial save, so under nil-omitting storage it
+# was not persisted; this HSET therefore CREATES the field (returns 1) whereas
+# name already exists (returns 0).
 @result = @customer.multi_field_update(name: 'Jane Windows', email: 'jane@example.com')
 @result.to_h
-#=> {:success=>true, :results=>[0, 0, false, true]}
+#=> {:success=>true, :results=>[0, 1, false, true]}
 
 ## multi_field_update returns successful result, successful?
 @result.successful?
@@ -76,11 +79,11 @@ Familia.dbclient.set('debug:ending_save_if_not_exists_tests', Familia.now.to_s)
 
 ## multi_field_update returns successful result, tuple
 @result.tuple
-#=> [true, [0, 0, false, true]]
+#=> [true, [0, 1, false, true]]
 
 ## multi_field_update returns successful result, to_a
 @result.to_a
-#=> [true, [0, 0, false, true]]
+#=> [true, [0, 1, false, true]]
 
 ## multi_field_update updates object fields in memory, confirm fields changed
 [@customer.name, @customer.email]


### PR DESCRIPTION
## Summary

This PR fixes how nil-valued fields are persisted to Valkey/Redis. Previously, nil values were stored as the JSON string `"null"`, which caused declared fields to always be present in the hash. This broke `HSETNX`/`HEXISTS`-based atomic claim patterns and wasted memory. Now nil fields are omitted from storage entirely, so field *absence* represents "no value" — aligning with Redis hash semantics where there is no native NULL type.

## Key Changes

- **Serialization**: `to_h_for_storage` now omits nil-valued fields entirely instead of serializing them as `"null"`. The public `to_h` method remains unchanged and still returns every declared field for API stability.

- **Persistence paths**: All write operations now actively remove fields that are nil:
  - `save` and `commit_fields` (full-overwrite paths) call new `remove_stale_nil_fields` to delete any declared fields that are nil in memory
  - `save_fields`, `multi_field_update`, and `multi_field_fast_write` (targeted paths) delete individual fields passed as nil via `HDEL`

- **New helper method**: `remove_stale_nil_fields` identifies and removes any persistent fields whose in-memory value is nil, ensuring cleared fields don't leave stale values behind in storage.

- **Empty hash handling**: `hmset` now treats an empty hash as a successful no-op instead of raising an error, since objects with only nil declared fields (besides the identifier) would produce empty hashes.

- **Backward compatibility**: Hashes still containing legacy `"null"` values are automatically cleaned up the next time the object is saved. Reads already decode `"null"` back to nil, so no migration is required.

## Notable Implementation Details

- The change makes `save`/`commit_fields` a true full-overwrite of scalar state: the stored hash matches the in-memory object exactly after save. A field claimed out-of-band via `HSETNX` while an in-memory copy still holds nil will be cleared by a full save of that stale copy. Users should use targeted writers or `refresh!` before saving to avoid this.

- Field absence and nil are now the same observable state after a round trip, making `HSETNX`-based claim patterns work correctly on declared fields.

- All write operations run inside transactions, so field removal via `HDEL` is atomic with field updates.

https://claude.ai/code/session_01TKTqBurk6cehrH8drShUJq