### PR TITLE
Prune stale index tracker entries when saving under a reused identifier (#365)

### DIFF
--- a/changelog.d/fragments/20260728_120000_delano_365_stale_tracker_prune.md
+++ b/changelog.d/fragments/20260728_120000_delano_365_stale_tracker_prune.md
@@ -1,7 +1,0 @@
-### Fixed
-
-- **A record saved under a reused identifier no longer inherits the previous record's index tracker**: `delete!` removes only the main object hash, so the instance-scoped index tracker (`_idx_scopes`) survived it — and the next `save` under the same identifier replayed the stale entries, silently joining the new record to every scope the *previous* record had been added to (or raising `Familia::RecordExistsError` when the new value collided with another record's entry). Save now detects the staleness — tracker entries can only outlive the object hash when a previous incarnation was `delete!`'d or expired, since `add_to_*` refuses never-saved records — and prunes them inside the save transaction: `remove_from_*` is replayed with the recorded values, clearing the dead incarnation's index entries (previously orphaned forever) along with the tracker itself. The new record starts with no instance-scoped memberships; `add_to_*` remains the explicit opt-in. `save_if_not_exists!` applies the same reconciliation (replacing its previous behavior of re-syncing stale entries onto the resurrected record), and the detection costs an EXISTS probe only when the tracker actually has entries. (#365)
-
-### AI Assistance
-
-- The staleness-detection design (prune-on-stale rather than a `delete!` override or an epoch marker), the save-path wiring, and the accompanying tests were developed with AI assistance.

--- a/changelog.d/fragments/20260728_120000_delano_365_stale_tracker_prune.md
+++ b/changelog.d/fragments/20260728_120000_delano_365_stale_tracker_prune.md
@@ -1,0 +1,7 @@
+### Fixed
+
+- **A record saved under a reused identifier no longer inherits the previous record's index tracker**: `delete!` removes only the main object hash, so the instance-scoped index tracker (`_idx_scopes`) survived it — and the next `save` under the same identifier replayed the stale entries, silently joining the new record to every scope the *previous* record had been added to (or raising `Familia::RecordExistsError` when the new value collided with another record's entry). Save now detects the staleness — tracker entries can only outlive the object hash when a previous incarnation was `delete!`'d or expired, since `add_to_*` refuses never-saved records — and prunes them inside the save transaction: `remove_from_*` is replayed with the recorded values, clearing the dead incarnation's index entries (previously orphaned forever) along with the tracker itself. The new record starts with no instance-scoped memberships; `add_to_*` remains the explicit opt-in. `save_if_not_exists!` applies the same reconciliation (replacing its previous behavior of re-syncing stale entries onto the resurrected record), and the detection costs an EXISTS probe only when the tracker actually has entries. (#365)
+
+### AI Assistance
+
+- The staleness-detection design (prune-on-stale rather than a `delete!` override or an epoch marker), the save-path wiring, and the accompanying tests were developed with AI assistance.

--- a/changelog.d/fragments/20260728_120000_delano_365_stale_tracker_prune.rst
+++ b/changelog.d/fragments/20260728_120000_delano_365_stale_tracker_prune.rst
@@ -1,0 +1,30 @@
+Fixed
+-----
+
+- A record saved under a reused identifier no longer inherits the previous
+  record's index tracker. ``delete!`` removes only the main object hash, so the
+  instance-scoped index tracker (``_idx_scopes``) survived it — and the next
+  ``save`` under the same identifier replayed the stale entries, silently
+  joining the new record to every scope the *previous* record had been added to
+  (or raising ``Familia::RecordExistsError`` when the new value collided with
+  another record's entry). Save now detects the staleness — tracker entries can
+  only outlive the object hash when a previous incarnation was ``delete!``'d or
+  expired, since ``add_to_*`` refuses never-saved records — and prunes them
+  inside the save transaction: ``remove_from_*`` is replayed with the recorded
+  values, clearing the dead incarnation's index entries (previously orphaned
+  forever) along with the tracker itself. The new record starts with no
+  instance-scoped memberships; ``add_to_*`` remains the explicit opt-in.
+  ``save_if_not_exists!`` applies the same reconciliation (replacing its
+  previous behavior of re-syncing stale entries onto the resurrected record),
+  and the detection costs an EXISTS probe only when the tracker actually has
+  entries. Note that ``atomic_write`` performs no staleness detection (it has
+  no pre-transaction point to probe from), and once it has recreated the hash a
+  later ``save`` can no longer tell the inherited entries are stale — the first
+  write to a reused identifier should be a ``save``. (#365)
+
+AI Assistance
+-------------
+
+- The staleness-detection design (prune-on-stale rather than a ``delete!``
+  override or an epoch marker), the save-path wiring, and the accompanying
+  tests were developed with AI assistance.

--- a/docs/guides/feature-relationships-indexing.md
+++ b/docs/guides/feature-relationships-indexing.md
@@ -169,14 +169,18 @@ Two constraints follow from cleanup running write-only inside a transaction:
 Both are checked before the index write, so a rejected call leaves nothing
 behind.
 
-> **`delete!` does not clean up the tracker.** `delete!` removes only the main
-> object hash; related keys — the `_idx_scopes` tracker included — survive, per
-> its documented contract. If a *new* record is later saved under the same
-> identifier, save's refresh reads the stale tracker and re-joins the tracked
-> scopes on the new record's behalf (uniqueness is still validated, so a
-> colliding value raises rather than evicts). Use `destroy!` for the full
-> lifecycle; reach for `delete!` only when leftover related keys are
-> acceptable.
+> **`delete!` does not clean up the tracker — the next save does.** `delete!`
+> removes only the main object hash; related keys — the `_idx_scopes` tracker
+> included — survive, per its documented contract. Tracker entries that outlive
+> the hash can only describe a dead incarnation of the identifier, so when a
+> record is later saved under it (plain `save` or `save_if_not_exists!`), the
+> save prunes them instead of replaying them: the previous record's index
+> entries are removed inside the save transaction and the tracker is cleared.
+> The new record starts with no instance-scoped memberships — `add_to_*` it
+> explicitly where membership is intended. The same reconciliation applies when
+> the hash expired via TTL while the tracker survived. Other related keys
+> (sets, lists, counters) are still inherited as-is; use `destroy!` for the
+> full lifecycle.
 
 ### Generated Methods
 

--- a/docs/guides/feature-relationships-indexing.md
+++ b/docs/guides/feature-relationships-indexing.md
@@ -180,7 +180,11 @@ behind.
 > explicitly where membership is intended. The same reconciliation applies when
 > the hash expired via TTL while the tracker survived. Other related keys
 > (sets, lists, counters) are still inherited as-is; use `destroy!` for the
-> full lifecycle.
+> full lifecycle. One escape hatch to avoid: `atomic_write` performs no
+> staleness detection (it has no pre-transaction point to probe from), and
+> once it has recreated the hash a later `save` can no longer tell the
+> inherited entries are stale — so make the first write to a reused
+> identifier a `save`, not an `atomic_write`.
 
 ### Generated Methods
 

--- a/lib/familia/horreum/atomic_write.rb
+++ b/lib/familia/horreum/atomic_write.rb
@@ -93,6 +93,15 @@ module Familia
       #   once before the retry loop, not on each attempt. This matches
       #   +save_if_not_exists!+ behaviour and keeps timestamps consistent
       #   across retries.
+      # @note Instance-scoped index entries are neither refreshed nor
+      #   reconciled here: +persist_to_storage+ runs inside the already-open
+      #   MULTI, so there is no pre-transaction point to snapshot the
+      #   +_idx_scopes+ tracker or probe it for staleness. In particular,
+      #   recreating a +delete!+'d identifier via atomic_write leaves the
+      #   dead incarnation's tracker and index entries in place -- and once
+      #   the new hash exists, a later +save+ can no longer tell they are
+      #   stale and will treat them as live memberships (#365). Use +save+
+      #   for the first write to a reused identifier.
       #
       # @see Persistence#save_with_collections For sequential (non-atomic)
       #   scalar+collection writes (supports cross-database configurations).

--- a/lib/familia/horreum/database_commands.rb
+++ b/lib/familia/horreum/database_commands.rb
@@ -255,10 +255,12 @@ module Familia
       # It does not delete the related fields keys. See destroy!
       #
       # @note Because related keys survive, a record saved later under the
-      #   same identifier inherits them — including ORM bookkeeping such as
-      #   the instance-scoped index tracker (+_idx_scopes+), which save
-      #   replays, re-joining scopes the previous record was added to. Use
-      #   destroy! when the identifier may be reused.
+      #   same identifier inherits them — sets, lists, counters and the like.
+      #   The instance-scoped index tracker (+_idx_scopes+) is the exception:
+      #   save detects that its entries outlived the object hash and prunes
+      #   them, removing the previous record's index entries instead of
+      #   re-joining its scopes (#365). Other leftovers are not reconciled;
+      #   use destroy! when the identifier may be reused.
       #
       # @return [Boolean] true if the key was deleted, false otherwise
       def delete!

--- a/lib/familia/horreum/persistence.rb
+++ b/lib/familia/horreum/persistence.rb
@@ -135,6 +135,14 @@ module Familia
         # with the recorded values, which also clears the index entries the
         # dead incarnation left behind. The EXISTS probe costs a round trip
         # only when the tracker has entries.
+        #
+        # The probe runs before the MULTI, so a concurrent delete! landing
+        # between the two makes a live tracker look stale and the save prunes
+        # memberships that were valid an instant earlier. That is the
+        # accepted conservative failure mode -- losing memberships for a
+        # record that was just deleted beats joining the wrong scopes -- and
+        # the same read-window race save already accepts for its guards
+        # (MULTI-only by design, no WATCH).
         stale_tracker = !tracked_scopes.empty? && !exists?
 
         # Validate instance-scoped unique constraints here too -- same reason
@@ -150,7 +158,7 @@ module Familia
         # Everything in ONE transaction for complete atomicity
         result = transaction do |_conn|
           persist_to_storage(update_expiration, tracked_index_scopes: tracked_scopes,
-                                                stale_index_scopes: stale_tracker)
+                                                prune_stale_tracker: stale_tracker)
         end
 
         # Structured lifecycle logging and instrumentation
@@ -317,7 +325,7 @@ module Familia
 
           Familia::Connection::TransactionCore.execute_normal_transaction(-> { conn }) do |_m|
             persist_to_storage(update_expiration, tracked_index_scopes: tracked_scopes,
-                                                  stale_index_scopes: true)
+                                                  prune_stale_tracker: true)
           end
         end
 
@@ -1118,14 +1126,14 @@ module Familia
       #   call this from inside a MULTI they already opened, so there is no
       #   pre-transaction point available to them and they default to empty,
       #   leaving instance-scoped indexes untouched.
-      # @param stale_index_scopes [Boolean] true when the caller determined
+      # @param prune_stale_tracker [Boolean] true when the caller determined
       #   the tracker entries belong to a dead incarnation of this identifier
       #   (object hash absent while entries survive -- delete! or expiry).
       #   Stale entries are pruned via remove_from_* replay instead of being
       #   re-joined onto the record being written (#365).
       # @return [Object] The result of the hmset operation
       #
-      def persist_to_storage(update_expiration, tracked_index_scopes: {}, stale_index_scopes: false)
+      def persist_to_storage(update_expiration, tracked_index_scopes: {}, prune_stale_tracker: false)
         # 1. Save all non-nil fields to hashkey at once
         prepared_h = to_h_for_storage
         hmset_result = hmset(prepared_h)
@@ -1149,7 +1157,7 @@ module Familia
         # previous incarnation whose hash was delete!'d or expired -- are
         # pruned instead, removing that incarnation's index buckets and the
         # tracker itself rather than joining its scopes (#365).
-        if stale_index_scopes
+        if prune_stale_tracker
           remove_tracked_index_entries!(tracked_index_scopes) if respond_to?(:remove_tracked_index_entries!)
         elsif respond_to?(:auto_update_instance_indexes)
           auto_update_instance_indexes(tracked_index_scopes)

--- a/lib/familia/horreum/persistence.rb
+++ b/lib/familia/horreum/persistence.rb
@@ -126,16 +126,31 @@ module Familia
           {}
         end
 
+        # A non-empty tracker with no object hash can only belong to a dead
+        # incarnation of this identifier: add_to_* refuses never-saved
+        # records, so entries outliving the hash mean delete! (or expiry)
+        # removed the hash out from under them. Replaying them would silently
+        # re-join whatever scopes the PREVIOUS record occupied (#365), so the
+        # transaction below prunes them instead -- replaying remove_from_*
+        # with the recorded values, which also clears the index entries the
+        # dead incarnation left behind. The EXISTS probe costs a round trip
+        # only when the tracker has entries.
+        stale_tracker = !tracked_scopes.empty? && !exists?
+
         # Validate instance-scoped unique constraints here too -- same reason
         # prepare_for_save runs guard_unique_indexes! outside the transaction
         # (the guard reads). guard_unique_indexes! only covers class-level
         # relationships; without this, the refresh below could evict another
-        # record's index entry silently.
-        guard_tracked_index_scopes!(tracked_scopes) if respond_to?(:guard_tracked_index_scopes!)
+        # record's index entry silently. Stale entries are pruned rather than
+        # replayed, so there is no membership to validate.
+        if !stale_tracker && respond_to?(:guard_tracked_index_scopes!)
+          guard_tracked_index_scopes!(tracked_scopes)
+        end
 
         # Everything in ONE transaction for complete atomicity
         result = transaction do |_conn|
-          persist_to_storage(update_expiration, tracked_index_scopes: tracked_scopes)
+          persist_to_storage(update_expiration, tracked_index_scopes: tracked_scopes,
+                                                stale_index_scopes: stale_tracker)
         end
 
         # Structured lifecycle logging and instrumentation
@@ -289,20 +304,20 @@ module Familia
           # rather than before the watched block so a WATCH abort re-reads it
           # on retry. Usually empty (this path only proceeds when the object
           # hash is absent), but a hash removed out of band -- delete!, or
-          # expiry -- can leave tracker entries whose index buckets still
-          # point here; refreshing re-syncs them to the resurrected record.
+          # expiry -- can leave entries behind. Those entries describe the
+          # previous incarnation of this identifier, not the record being
+          # created, so the transaction prunes them (#365): remove_from_* is
+          # replayed with the recorded values and the tracker cleared. No
+          # uniqueness guard is needed -- nothing is being joined.
           tracked_scopes = if respond_to?(:read_instance_index_scopes)
             read_instance_index_scopes
           else
             {}
           end
 
-          # Instance-scoped uniqueness, validated in the same read window as
-          # the existence check above and for the same reason (see #save).
-          guard_tracked_index_scopes!(tracked_scopes) if respond_to?(:guard_tracked_index_scopes!)
-
           Familia::Connection::TransactionCore.execute_normal_transaction(-> { conn }) do |_m|
-            persist_to_storage(update_expiration, tracked_index_scopes: tracked_scopes)
+            persist_to_storage(update_expiration, tracked_index_scopes: tracked_scopes,
+                                                  stale_index_scopes: true)
           end
         end
 
@@ -1103,9 +1118,14 @@ module Familia
       #   call this from inside a MULTI they already opened, so there is no
       #   pre-transaction point available to them and they default to empty,
       #   leaving instance-scoped indexes untouched.
+      # @param stale_index_scopes [Boolean] true when the caller determined
+      #   the tracker entries belong to a dead incarnation of this identifier
+      #   (object hash absent while entries survive -- delete! or expiry).
+      #   Stale entries are pruned via remove_from_* replay instead of being
+      #   re-joined onto the record being written (#365).
       # @return [Object] The result of the hmset operation
       #
-      def persist_to_storage(update_expiration, tracked_index_scopes: {})
+      def persist_to_storage(update_expiration, tracked_index_scopes: {}, stale_index_scopes: false)
         # 1. Save all non-nil fields to hashkey at once
         prepared_h = to_h_for_storage
         hmset_result = hmset(prepared_h)
@@ -1122,10 +1142,18 @@ module Familia
         # 3. Update class-level indexes
         auto_update_class_indexes
 
-        # 3b. Refresh instance-scoped indexes for scopes already registered
-        # via add_to_*. Uses the tracker snapshot read before this
-        # transaction opened; the initial add_to_* remains manual.
-        auto_update_instance_indexes(tracked_index_scopes) if respond_to?(:auto_update_instance_indexes)
+        # 3b. Reconcile instance-scoped indexes using the tracker snapshot
+        # read before this transaction opened. Live entries (the object hash
+        # existed) are refreshed for scopes already registered via add_to_*;
+        # the initial add_to_* remains manual. Stale entries -- left by a
+        # previous incarnation whose hash was delete!'d or expired -- are
+        # pruned instead, removing that incarnation's index buckets and the
+        # tracker itself rather than joining its scopes (#365).
+        if stale_index_scopes
+          remove_tracked_index_entries!(tracked_index_scopes) if respond_to?(:remove_tracked_index_entries!)
+        elsif respond_to?(:auto_update_instance_indexes)
+          auto_update_instance_indexes(tracked_index_scopes)
+        end
 
         # 4. Touch instances timeline (delegates to touch_instances!).
         #

--- a/try/unit/horreum/destroy_index_cleanup_try.rb
+++ b/try/unit/horreum/destroy_index_cleanup_try.rb
@@ -370,6 +370,45 @@ end
 [@aw_co.badge_index.has_key?('B-AW1'), @aw_co.badge_index.has_key?('B-AW2')]
 #=> [false, false]
 
+## atomic_write does NOT prune a stale tracker either (documented gap, #365)
+# Same root cause as the refresh gap: persist_to_storage runs inside the
+# already-open MULTI, so there is no pre-transaction point to probe EXISTS
+# or snapshot the tracker. Recreating a delete!'d identifier via
+# atomic_write therefore leaves the dead incarnation's index entry and
+# tracker in place.
+@awr_co = Widget241ScopedCompany.create!(company_id: 'w241co-awr')
+@awr_old = Widget241ScopedEmployee.create!(emp_id: 'w241emp-awr', badge: 'B-AWR-OLD')
+@awr_old.add_to_widget241scoped_company_badge_index(@awr_co)
+@awr_old.delete!
+@awr_new = Widget241ScopedEmployee.new(emp_id: 'w241emp-awr')
+@awr_new.atomic_write { @awr_new.badge = 'B-AWR-NEW' }
+[@awr_co.badge_index.get('B-AWR-OLD'),
+ @awr_new.send(:_index_scope_tracker).hgetall.empty?]
+#=> ['w241emp-awr', false]
+
+## Once atomic_write recreated the hash, staleness is undetectable (#365)
+# This test keeps the YARD note honest: the hash now EXISTS, so a later
+# save has no way to tell the inherited tracker belongs to a dead
+# incarnation -- it replays the membership as live, and the record joins
+# the previous incarnation's scope. This is why the first write to a
+# reused identifier should be a save, never an atomic_write. If
+# atomic_write ever gains a pre-transaction staleness probe, this
+# expectation must change.
+@awr_new.save
+@awr_co.badge_index.get('B-AWR-NEW')
+#=> 'w241emp-awr'
+
+## Reused identifier with an EMPTY tracker takes the ordinary create path
+# The staleness probe is gated on the tracker having entries, so a
+# delete!'d identifier with no instance-scoped memberships is re-saved
+# with no EXISTS probe, no prune, and no error -- a plain create.
+@empty_co = Widget241ScopedCompany.create!(company_id: 'w241co-empty')
+@empty_old = Widget241ScopedEmployee.create!(emp_id: 'w241emp-empty', badge: 'B-EMPTY')
+@empty_old.delete!
+@empty_new = Widget241ScopedEmployee.new(emp_id: 'w241emp-empty', badge: 'B-EMPTY2')
+[@empty_new.save, @empty_new.send(:_index_scope_tracker).hgetall]
+#=> [true, {}]
+
 ## DataType rejects an unrecognized dirty_write_warnings mode
 # Without the check a typo would fall through warn_if_dirty! to the :once
 # branch, silently changing the diagnostic level instead of failing.

--- a/try/unit/horreum/destroy_index_cleanup_try.rb
+++ b/try/unit/horreum/destroy_index_cleanup_try.rb
@@ -242,22 +242,28 @@ end
 @ref_co.find_by_badge('B-BEFORE')&.identifier
 #=> 'w241emp-ref2'
 
-## save_if_not_exists! refreshes tracked indexes too
+## save_if_not_exists! prunes tracker entries that outlived the hash (#365)
 # The object hash is removed out of band (delete!), leaving tracker entries
-# whose index bucket still points here. Re-creating via save_if_not_exists!
-# re-syncs them to the resurrected record rather than leaving them stale.
+# whose index bucket still points here. Entries without a hash can only
+# describe a dead incarnation of the identifier, so re-creating via
+# save_if_not_exists! removes the old bucket and does NOT re-join the
+# scope -- instance-scoped membership stays opt-in for the new record.
 @sine_co = Widget241ScopedCompany.create!(company_id: 'w241co-sine')
 @sine_emp = Widget241ScopedEmployee.create!(emp_id: 'w241emp-sine', badge: 'B-SINE')
 @sine_emp.add_to_widget241scoped_company_badge_index(@sine_co)
 @sine_emp.delete!
 @sine_emp.badge = 'B-SINE2'
 @sine_emp.save_if_not_exists!
-[@sine_co.badge_index.has_key?('B-SINE'), @sine_co.badge_index.get('B-SINE2')]
-#=> [false, 'w241emp-sine']
+[@sine_co.badge_index.has_key?('B-SINE'), @sine_co.badge_index.has_key?('B-SINE2')]
+#=> [false, false]
+
+## The prune clears the tracker itself, leaving a genuinely clean slate
+@sine_emp.send(:_index_scope_tracker).hgetall
+#=> {}
 
 ## save_if_not_exists! re-reads the tracker after a WATCH abort
 # The snapshot is taken INSIDE the watched block, so a retry re-reads it
-# rather than replaying a stale one. Simulated deterministically: the first
+# rather than pruning from a stale copy. Simulated deterministically: the first
 # pass touches the watched key (dbkey), which invalidates the WATCH and
 # aborts EXEC; the probe counter proves the block ran more than once.
 @sir_co = Widget241ScopedCompany.create!(company_id: 'w241co-sir')
@@ -283,9 +289,67 @@ end
 @sir_emp.probe_count > 1
 #=> true
 
-## The retried save_if_not_exists! still refreshed the index correctly
-[@sir_co.badge_index.has_key?('S-1'), @sir_co.badge_index.get('S-2')]
-#=> [false, 'w241emp-sir']
+## The retried save_if_not_exists! still pruned the stale entries correctly
+[@sir_co.badge_index.has_key?('S-1'), @sir_co.badge_index.has_key?('S-2')]
+#=> [false, false]
+
+## Reused identifier: plain save prunes the previous record's tracker (#365)
+# delete! removes only the object hash; the tracker survives. A NEW record
+# saved under the same identifier used to replay the stale tracker and
+# silently join the scopes the previous record was added to. save now
+# detects that the entries outlived the hash (an EXISTS probe, paid only
+# when the tracker is non-empty) and prunes them: the dead incarnation's
+# bucket is removed and the new record joins nothing.
+@reuse_co = Widget241ScopedCompany.create!(company_id: 'w241co-reuse')
+@reuse_a = Widget241ScopedEmployee.create!(emp_id: 'w241emp-reuse', badge: 'R-OLD')
+@reuse_a.add_to_widget241scoped_company_badge_index(@reuse_co)
+@reuse_a.delete!
+@reuse_b = Widget241ScopedEmployee.new(emp_id: 'w241emp-reuse', badge: 'R-NEW')
+@reuse_b.save
+[@reuse_co.badge_index.has_key?('R-OLD'), @reuse_co.badge_index.has_key?('R-NEW')]
+#=> [false, false]
+
+## Reused identifier: the tracker is cleared along with the index entries
+@reuse_b.send(:_index_scope_tracker).hgetall
+#=> {}
+
+## Reused identifier: a fresh add_to_* then behaves like a first membership
+# The new record opts in explicitly and gets the ordinary lifecycle,
+# destroy! cleanup included.
+@reuse_b.add_to_widget241scoped_company_badge_index(@reuse_co)
+@reuse_joined = @reuse_co.badge_index.get('R-NEW')
+@reuse_b.destroy!
+[@reuse_joined, @reuse_co.badge_index.has_key?('R-NEW')]
+#=> ['w241emp-reuse', false]
+
+## Reused identifier with a COLLIDING value no longer raises (#365)
+# Previously the stale replay tripped the uniqueness guard when the new
+# record's value matched another record's entry, failing the save of a
+# record that never asked to join the scope. With stale entries pruned
+# instead of replayed there is nothing to guard: the save succeeds and the
+# other record's entry is untouched.
+@col_holder = Widget241ScopedEmployee.create!(emp_id: 'w241emp-col-holder', badge: 'C-HELD')
+@col_holder.add_to_widget241scoped_company_badge_index(@reuse_co)
+@col_a = Widget241ScopedEmployee.create!(emp_id: 'w241emp-col', badge: 'C-A')
+@col_a.add_to_widget241scoped_company_badge_index(@reuse_co)
+@col_a.delete!
+@col_b = Widget241ScopedEmployee.new(emp_id: 'w241emp-col', badge: 'C-HELD')
+@col_b.save
+[@reuse_co.badge_index.get('C-HELD'), @reuse_co.badge_index.has_key?('C-A')]
+#=> ['w241emp-col-holder', false]
+
+## Same-object save after delete! is also a fresh start (#365)
+# Re-saving the very object that was delete!'d (a stand-in for the hash
+# expiring via TTL while the tracker survived) goes through the same
+# staleness detection: the membership is pruned, not preserved. An object
+# whose hash is gone is gone; memberships do not survive death.
+@exp_co = Widget241ScopedCompany.create!(company_id: 'w241co-exp')
+@exp_emp = Widget241ScopedEmployee.create!(emp_id: 'w241emp-exp', badge: 'E-1')
+@exp_emp.add_to_widget241scoped_company_badge_index(@exp_co)
+@exp_emp.delete!
+@exp_emp.save
+[@exp_co.badge_index.has_key?('E-1'), @exp_emp.send(:_index_scope_tracker).hgetall]
+#=> [false, {}]
 
 ## atomic_write does NOT refresh instance-scoped indexes (documented gap)
 # atomic_write calls persist_to_storage from inside a MULTI it already
@@ -639,6 +703,24 @@ end
  @multi_co.dept_index_for('before').members, @multi_co.dept_index_for('after').members,
  @multi_co_b.dept_index_for('before').members, @multi_co_b.dept_index_for('after').members]
 #=> [4, [], [], [], []]
+
+## Reused identifier: multi_index buckets are pruned too (#365)
+# Every bucket the dead incarnation occupied is cleared on the new
+# record's save, exactly as destroy! would have cleared them, and the new
+# record joins none of them.
+@mre_co = Widget282MultiCompany.create!(company_id: 'w282mco-reuse')
+@mre_a = Widget282MultiEmployee.create!(emp_id: 'w282memp-reuse', department: 'eng')
+@mre_a.add_to_widget282multi_company_dept_index(@mre_co)
+@mre_a.department = 'ops'
+@mre_a.save
+@mre_a.delete!
+@mre_b = Widget282MultiEmployee.new(emp_id: 'w282memp-reuse', department: 'qa')
+@mre_b.save
+[@mre_co.dept_index_for('eng').members,
+ @mre_co.dept_index_for('ops').members,
+ @mre_co.dept_index_for('qa').members,
+ @mre_b.send(:_index_scope_tracker).hgetall]
+#=> [[], [], [], {}]
 
 ## Two scope classes sharing an index name each clean up their own entry
 # The tracker records the scope config alongside the index name. Matching


### PR DESCRIPTION
Resolves the hazard deferred out of #352 and tracked in #365: after `delete!`, a record saved under the same identifier inherited the surviving `_idx_scopes` tracker, and the save replay silently joined the new record to every scope the *previous* record had been added to (or raised `Familia::RecordExistsError` when the new value collided with a third record's entry).

> Stacked on #352 (`feature/282-unique-index-instance`), which introduced the tracker and the save-path replay.

**Design: prune-on-stale.** Of the options listed in #365 — a feature-level `delete!` override, an epoch marker, or accepting the documented contract — this takes a fourth path that keeps the layering intact:

- A non-empty tracker whose object hash is absent can only belong to a **dead incarnation** of the identifier: `add_to_*` refuses never-saved records (a #352 guard), so entries outliving the hash mean `delete!` (or TTL expiry) removed the hash out from under them.
- `save` now probes `EXISTS` when the pre-read tracker is non-empty (no cost otherwise). On a miss it **prunes** inside the save MULTI instead of replaying: `remove_tracked_index_entries!` replays `remove_from_*` with the recorded values — clearing the dead incarnation's index entries, which `delete!` previously orphaned forever — and clears the tracker. The new record starts with no instance-scoped memberships; `add_to_*` remains the explicit opt-in. The uniqueness guard is skipped on this path, since nothing is being joined.
- `save_if_not_exists!` reaches its persist step only when the hash is absent, so it always prunes. This **replaces** the #352 behavior of re-syncing stale entries onto the "resurrected" record — that re-sync is precisely the silent join #365 flags, and a record whose hash is gone losing its memberships is the conservative failure mode (the two cases are indistinguishable without a persisted per-incarnation marker).
- `delete!` stays a single `DEL` — no feature-level override, no `delete!` ≈ `destroy!` collapse. The reconciliation lives where tracker knowledge already lives (Indexing feature + the save pre-read added in #352). An epoch marker was rejected as it would require persisting a per-incarnation token in the object hash solely to distinguish resurrection-after-expiry from reuse-after-delete.

**Changes**

- `lib/familia/horreum/persistence.rb` — staleness detection in `save`, always-prune in `save_if_not_exists!`, `stale_index_scopes:` branch in `persist_to_storage`
- `lib/familia/horreum/database_commands.rb` — `delete!` rdoc note updated (tracker is now the reconciled exception among surviving related keys)
- `docs/guides/feature-relationships-indexing.md` — caveat rewritten for the new behavior
- `try/unit/horreum/destroy_index_cleanup_try.rb` — the two `save_if_not_exists!` re-sync tests now assert pruning; new coverage for reuse via plain `save` (unique + multi + colliding value + same-object re-save + fresh `add_to_*` lifecycle afterwards)
- Changelog fragment

**Testing**

- `try/unit/horreum/destroy_index_cleanup_try.rb`: 72/72 pass
- Full suite: only pre-existing failures (4 encoding-related tests in `try/features/encryption/` and `try/unit/data_types/stringkey_extended_try.rb`, verified failing on the clean base tree as well)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S3hERKeYmkPiEByYSrYwdk

---
_Generated by [Claude Code](https://claude.ai/code/session_01S3hERKeYmkPiEByYSrYwdk)_