### PR TITLE
[#353] Document the OperationModeError from unclaimed in-MULTI index writes

### DIFF
--- a/docs/guides/feature-relationships-indexing.md
+++ b/docs/guides/feature-relationships-indexing.md
@@ -531,8 +531,7 @@ Index values (the object identifiers stored in hash keys and sets) are raw strin
   prevent dangling entries. Call `save` before indexing (class-level indexes
   populate automatically on save).
 
-**`Familia::OperationModeError` from `add_to_class_*` / `update_in_class_*`
-(`unique_index` only):**
+**`Familia::OperationModeError` from `add_to_class_*` / `update_in_class_*` (`unique_index` only):**
 
 - The write is inside a transaction *you* opened and the record holds no claim
   on the exact value being written. That in-MULTI `HSET` is only sound as a
@@ -563,12 +562,17 @@ Index values (the object identifiers stored in hash keys and sets) are raw strin
 
   The message names whichever mutator ran, so an `atomic_write` that changed a
   field reports `update_in_class_*` (the path dirty tracking routes to), not
-  `add_to_class_*`. The error propagates out of the transaction block, so the
-  MULTI is discarded whole: neither the index entry nor any scalar field queued
-  alongside it is written, and the record reloads with its previous values.
-  `update_all_indexes` routes to `update_in_class_*` and raises the same way.
-  Instance-scoped (`within:`) unique indexes are *not* claim-enforced: inside a
-  transaction they write blindly and log that the write is unenforced.
+  `add_to_class_*`. `update_all_indexes` routes there too and raises the same
+  way. Instance-scoped (`within:`) unique indexes are *not* claim-enforced:
+  inside a transaction they write blindly and say so via `Familia.debug`, which
+  is silent unless debug logging is on.
+
+  The error propagates out of the transaction block, so the MULTI is discarded
+  whole: neither the index entry nor any scalar field queued alongside it is
+  written. Only the stored state is rolled back, though — the in-memory record
+  keeps the assignments that triggered the error and stays dirty, so a plain
+  `save` afterwards is a valid recovery (it claims, then persists the pending
+  change). Call `refresh!` instead to discard it and reload what is stored.
 
 - Two neighbouring causes of the same error class, both pre-existing: `save`
   itself refuses to run inside a transaction, and `HashKey#claim_field` refuses

--- a/docs/guides/feature-relationships-indexing.md
+++ b/docs/guides/feature-relationships-indexing.md
@@ -563,9 +563,11 @@ Index values (the object identifiers stored in hash keys and sets) are raw strin
   The message names whichever mutator ran, so an `atomic_write` that changed a
   field reports `update_in_class_*` (the path dirty tracking routes to), not
   `add_to_class_*`. `update_all_indexes` routes there too and raises the same
-  way. Instance-scoped (`within:`) unique indexes are *not* claim-enforced:
-  inside a transaction they write blindly and say so via `Familia.debug`, which
-  is silent unless debug logging is on.
+  way. Instance-scoped (`within:`) unique indexes are *not* claim-enforced —
+  inside a transaction they write blindly instead of raising, and the two paths
+  differ in how loudly: `add_to_*` says so via `Familia.debug`, which is silent
+  unless debug logging is on, while `update_in_*` skips the claim with no notice
+  at all.
 
   The error propagates out of the transaction block, so the MULTI is discarded
   whole: neither the index entry nor any scalar field queued alongside it is

--- a/docs/guides/feature-relationships-indexing.md
+++ b/docs/guides/feature-relationships-indexing.md
@@ -46,6 +46,17 @@ user.destroy
 User.find_by_email('alice.smith@example.com')  # => nil
 ```
 
+> **Uniqueness is enforced server-side, before the transaction opens.** `save`
+> claims the value with a single-key Lua compare-and-set, so two concurrent
+> saves of the same value cannot both see it as free — the loser raises
+> `Familia::RecordExistsError` carrying `existing_id`. The `HSET` inside save's
+> MULTI only re-affirms a claim the record already holds. Every save path
+> (`save`, `save_if_not_exists!`, `atomic_write`, `Familia.atomic_write`) claims
+> automatically; a transaction you open yourself does not, so writing an index
+> from inside one needs an explicit `claim_unique_<index>!` first — see
+> `Familia::OperationModeError` under [Troubleshooting](#troubleshooting) and
+> [ADR-0002](../adr/0002-watch-for-private-keys-lua-for-shared-keys.md).
+
 ### Generated Methods
 
 | Method                         | Description       |
@@ -519,6 +530,50 @@ Index values (the object identifiers stored in hash keys and sets) are raw strin
 - The object has never been saved; index writers reject unsaved objects to
   prevent dangling entries. Call `save` before indexing (class-level indexes
   populate automatically on save).
+
+**`Familia::OperationModeError` from `add_to_class_*` / `update_in_class_*`
+(`unique_index` only):**
+
+- The write is inside a transaction *you* opened and the record holds no claim
+  on the exact value being written. That in-MULTI `HSET` is only sound as a
+  re-affirmation of a server-side claim; without one it is a blind write that
+  can silently overwrite another record's ownership. Ordinary `save` never hits
+  this — every save path claims first. Two shapes reach it:
+
+  ```ruby
+  # 1. Reassigning the indexed field inside atomic_write. The block runs
+  #    INSIDE the MULTI, after the claim was taken on the OLD value.
+  user.atomic_write { user.email = 'new@example.com' }   # raises
+
+  # Fix: set the field before the block, so the claim covers the new value.
+  user.email = 'new@example.com'
+  user.atomic_write { user.name = 'Alice' }
+  ```
+
+  ```ruby
+  # 2. Opening your own transaction after changing the field.
+  old_email = user.email
+  user.email = 'new@example.com'
+  User.transaction { user.update_in_class_email_lookup(old_email) }  # raises
+
+  # Fix: claim outside the MULTI, then write inside it.
+  user.claim_unique_email_lookup!
+  User.transaction { user.update_in_class_email_lookup(old_email) }
+  ```
+
+  The message names whichever mutator ran, so an `atomic_write` that changed a
+  field reports `update_in_class_*` (the path dirty tracking routes to), not
+  `add_to_class_*`. The error propagates out of the transaction block, so the
+  MULTI is discarded whole: neither the index entry nor any scalar field queued
+  alongside it is written, and the record reloads with its previous values.
+  `update_all_indexes` routes to `update_in_class_*` and raises the same way.
+  Instance-scoped (`within:`) unique indexes are *not* claim-enforced: inside a
+  transaction they write blindly and log that the write is unenforced.
+
+- Two neighbouring causes of the same error class, both pre-existing: `save`
+  itself refuses to run inside a transaction, and `HashKey#claim_field` refuses
+  too — a CAS verdict inside MULTI would come back as a `Future`, with nothing
+  left to abort.
 
 **`Familia::NoIdentifier` / `ArgumentError` from `add_to_*` / `update_in_*`:**
 


### PR DESCRIPTION
Follow-up to #362 (docs only, no behaviour change).

The claim assertion that #362 added is a behaviour change a caller can hit, but it was only described in ADR-0002 and in the error message itself. The indexing guide's troubleshooting section listed `PersistenceError`, `NoIdentifier`, and `RecordExistsError` and stopped there.

## What this adds

A troubleshooting entry for `Familia::OperationModeError` from `add_to_class_*` / `update_in_class_*`, with the two shapes that actually reach it and the fix for each:

- an `atomic_write` block that reassigns the indexed field (the block runs inside the MULTI, after the claim was taken on the old value) — fix: set the field before the block
- a caller-opened transaction after a field change — fix: `claim_unique_<index>!` outside the MULTI

Plus the details that aren't obvious from the message: it names `update_in_class_*` rather than `add_to_class_*` when dirty tracking routes the write; `update_all_indexes` raises identically; instance-scoped (`within:`) indexes are not claim-enforced and their unenforced-write notice goes through `Familia.debug`; and the rollback covers stored state only — the in-memory record keeps the assignment that triggered the error and stays dirty, so a plain `save` afterwards is a valid recovery and `refresh!` discards it.

A companion note under **Class-Level Unique Indexing** states the enforcement model (claim before the MULTI, in-`MULTI` `HSET` re-affirms) where the feature is introduced, not only where its errors are troubleshot.

## Verification

Every documented shape was run against the merged code — including on top of #366, which landed after #362 and touches the same guide and `persistence.rb`:

| Shape | Result |
| --- | --- |
| `atomic_write` reassigns indexed field | raises; index and object hash unchanged |
| field set before `atomic_write` block | no error |
| own transaction, no claim | raises |
| `claim_unique_<index>!` then own transaction | no error |
| `add_to_class_*` in own transaction | raises |
| `update_all_indexes` in own transaction | raises |
| plain `save` after field change | no error |
| `atomic_write` not touching indexed field | no error |
| in-memory state after a refused `atomic_write` | still mutated, `dirty_fields == [:email, :name]` |
| plain `save` after a refused `atomic_write` | succeeds, persists the pending change |
| `refresh!` after a refused `atomic_write` | restores stored values, clears dirty |

Each error shape is already covered by `try/features/relationships/unique_index_cas_try.rb`, so this documents tested behaviour rather than describing intent.

Full tryouts suite: 5840 passed. The 3 failures + 1 error are the encoding/locale artifacts present on `main` in this container (encryption and stringkey files, unrelated to indexing; all pass in isolation).