### PR TITLE
[#363] Scope tryouts encryption config to the file that sets it

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,13 @@ Run with `--agent` for token-efficient output (`--agent-focus summary|first-fail
 See `bundle exec try --help` for the full CLI, framework integration (`--rspec`,
 `--minitest`), and debugging flags.
 
+The whole suite runs in one process, so anything a file sets globally outlives
+it. For encryption keys use the scoped helpers rather than assigning
+`Familia.config.encryption_keys` directly: `set_test_encryption_keys(keys,
+current_version:)` in setup with `clear_test_encryption_keys` in teardown, or
+`with_test_encryption_keys(keys, current_version:) { ... }` for a single
+testcase. See @try/support/helpers/encryption_config.rb.
+
 ### Changelog
 
 Add a changelog fragment (RST) with each user-facing change. See @changelog.d/README.md

--- a/changelog.d/20260730_014823_claude_363_tryouts_encryption_config_leak.rst
+++ b/changelog.d/20260730_014823_claude_363_tryouts_encryption_config_leak.rst
@@ -1,0 +1,70 @@
+Fixed
+-----
+
+- Tryout files no longer leak their encryption config into the rest of the run.
+  ``Familia.config.encryption_keys`` and ``current_key_version`` are
+  process-global and the tryouts runner evaluates every file in one process, so
+  a file that set them and never cleared them left them installed for whatever
+  ran next. Running each such file followed by a probe that asserts both settings
+  are nil confirmed nineteen leakers. No test failed as a result, which was the
+  hazard: a file that believed it had configured its own key material could be
+  exercising a neighbour's, and an encryption test passing under the wrong key is
+  not testing what it claims. Adding a file that requires the keys to be *absent*
+  would also have passed or failed depending on where it sorted. Every file that
+  touches the encryption config now installs it through a scoped helper and hands
+  back the previous config when it finishes. #363
+
+- ``try/features/real_feature_integration_try.rb`` was the leak's confirmed
+  victim. It declares an ``encrypted_field`` and assigns it during setup but
+  never configured any key material, so it had been running on whatever the
+  previous file in the run happened to leave installed. It fails outright when
+  run on its own -- ``Key version cannot be nil`` -- which is what closing the
+  leak made it do in the full suite as well. It now installs its own keyring.
+  #363
+
+- ``try/features/encryption/module_loading_try.rb`` leaked too, under a spelling
+  the original survey missed: ``Familia.encryption_keys=`` and
+  ``Familia.config.encryption_keys=`` are the same setting, because
+  ``Familia.config`` returns ``Familia`` itself. The new helper's leak warning is
+  what surfaced it. #363
+
+- The teardown line ``Fiber[:familia_key_cache]&.clear`` in eight encryption
+  tryouts was a no-op -- the derived-key cache lives under
+  ``Fiber[:familia_request_cache]``, so nothing was ever cleared. Those teardowns
+  now go through the helper, which wipes the real cache. #363
+
+Added
+-----
+
+- ``try/support/helpers/encryption_config.rb``, loaded by ``test_helpers``, with
+  three helpers for tryouts that need encryption keys:
+  ``set_test_encryption_keys(keys, current_version:)`` installs a keyring and
+  records what it displaced, ``clear_test_encryption_keys`` puts that back (used
+  in teardown), and ``with_test_encryption_keys(keys, current_version:) { ... }``
+  scopes an override to a single test case and restores it even when the block
+  raises. Restoring means restoring the *previous* values rather than nilling
+  them, so the two forms nest. Repeat calls to ``set_test_encryption_keys`` in
+  one file are safe: only the first records the baseline. The baseline is scoped
+  to the file that recorded it, so a file that installs keys and then forgets its
+  teardown does not suppress the next file's leak check or become what that file
+  restores to -- the next install warns and baselines to the empty keyring, which
+  ends the leak there rather than passing it along. Each install and
+  restore also wipes the fiber-local derived-key cache, which is keyed by version
+  and context rather than by the master key an entry came from and so would
+  otherwise survive a keyring swap. When a file installs keys and finds the
+  config already populated -- the signature of an earlier file that forgot its
+  teardown -- the helper warns on stderr naming the file, so the next such
+  omission is loud instead of silent. #363
+
+AI Assistance
+-------------
+
+- AI wrote the scoped-config helper and migrated every tryout that touches the
+  encryption config to it: the files with no teardown, and the files that already
+  cleaned up by assigning ``nil`` or by hand-rolling their own save/restore.
+  Added ``try/support/encryption_config_helper_try.rb`` covering install/restore,
+  block nesting inside a file-scoped override, restoration when the block raises,
+  the repeat-install baseline rule, the clear-with-no-install fallback, the leak
+  warning, and the derived-key cache wipe. Verified the fix by running every
+  encryption-touching file followed by a leak probe -- nineteen fail that probe
+  before the change, none after. #363

--- a/try/edge_cases/fast_writer_transaction_guard_try.rb
+++ b/try/edge_cases/fast_writer_transaction_guard_try.rb
@@ -5,8 +5,7 @@ Familia.debug = false
 
 # Configure encryption for encrypted field tests
 test_keys = { v1: Base64.strict_encode64('a' * 32) }
-Familia.config.encryption_keys = test_keys
-Familia.config.current_key_version = :v1
+set_test_encryption_keys(test_keys, current_version: :v1)
 
 # Test class for fast writer transaction/pipeline behavior
 class FastWriterGuardTest < Familia::Horreum
@@ -107,5 +106,4 @@ true
 #=> true
 
 # Teardown - restore global encryption config so test order is not a factor
-Familia.config.encryption_keys = nil
-Familia.config.current_key_version = nil
+clear_test_encryption_keys

--- a/try/features/atomic_write_coverage_try.rb
+++ b/try/features/atomic_write_coverage_try.rb
@@ -12,8 +12,7 @@ Familia.debug = false
 # Configure encryption keys for the encrypted_field fixtures. Mirrors the
 # pattern used in try/features/encrypted_fields/encrypted_fields_core_try.rb.
 test_keys = { v1: Base64.strict_encode64('a' * 32) }
-Familia.config.encryption_keys = test_keys
-Familia.config.current_key_version = :v1
+set_test_encryption_keys(test_keys, current_version: :v1)
 
 # (a) Horreum with encrypted_field + a regular collection. Exercises the
 # encryption-on-assignment path inside an atomic_write block. The plaintext
@@ -144,5 +143,4 @@ AtomicWriteJsonPlan.instances.clear rescue nil
 AtomicWriteJsonPlan.all.each(&:destroy!) rescue nil
 AtomicWriteStringPlan.instances.clear rescue nil
 AtomicWriteStringPlan.all.each(&:destroy!) rescue nil
-Familia.config.encryption_keys = nil
-Familia.config.current_key_version = nil
+clear_test_encryption_keys

--- a/try/features/dirty_tracking_try.rb
+++ b/try/features/dirty_tracking_try.rb
@@ -15,8 +15,7 @@ end
 
 # Encrypted field model for dirty tracking tests
 # Encryption keys must be configured before defining the class
-Familia.config.encryption_keys = { v1: Base64.strict_encode64('a' * 32) }
-Familia.config.current_key_version = :v1
+set_test_encryption_keys({ v1: Base64.strict_encode64('a' * 32) }, current_version: :v1)
 
 class DirtyTrackSecureUser < Familia::Horreum
   feature :encrypted_fields
@@ -591,5 +590,4 @@ DirtyTrackSecureUser.instances.members.each do |id|
   obj = DirtyTrackSecureUser.new(id)
   obj.destroy! rescue nil
 end
-Familia.config.encryption_keys = nil
-Familia.config.current_key_version = nil
+clear_test_encryption_keys

--- a/try/features/encrypted_fields/aad_nil_fields_try.rb
+++ b/try/features/encrypted_fields/aad_nil_fields_try.rb
@@ -12,8 +12,7 @@ require_relative '../../support/helpers/test_helpers'
 test_keys = {
   v1: Base64.strict_encode64('a' * 32),
 }
-Familia.config.encryption_keys = test_keys
-Familia.config.current_key_version = :v1
+set_test_encryption_keys(test_keys, current_version: :v1)
 
 class AADNilFieldModel < Familia::Horreum
   feature :encrypted_fields
@@ -110,5 +109,4 @@ aad_two != aad_one
 #=> true
 
 Familia.dbclient.flushdb
-Familia.config.encryption_keys = nil
-Familia.config.current_key_version = nil
+clear_test_encryption_keys

--- a/try/features/encrypted_fields/aad_protection_try.rb
+++ b/try/features/encrypted_fields/aad_protection_try.rb
@@ -12,8 +12,7 @@ require_relative '../../support/helpers/test_helpers'
 test_keys = {
   v1: Base64.strict_encode64('a' * 32),
 }
-Familia.config.encryption_keys = test_keys
-Familia.config.current_key_version = :v1
+set_test_encryption_keys(test_keys, current_version: :v1)
 
 class AADProtectedModel < Familia::Horreum
   feature :encrypted_fields
@@ -138,5 +137,4 @@ decrypted_legit
 
 # Cleanup
 Familia.dbclient.flushdb
-Familia.config.encryption_keys = nil
-Familia.config.current_key_version = nil
+clear_test_encryption_keys

--- a/try/features/encrypted_fields/aad_roundtrip_try.rb
+++ b/try/features/encrypted_fields/aad_roundtrip_try.rb
@@ -12,8 +12,7 @@ require_relative '../../support/helpers/test_helpers'
 test_keys = {
   v1: Base64.strict_encode64('a' * 32),
 }
-Familia.config.encryption_keys = test_keys
-Familia.config.current_key_version = :v1
+set_test_encryption_keys(test_keys, current_version: :v1)
 
 class AADRoundtripModel < Familia::Horreum
   feature :encrypted_fields
@@ -98,5 +97,4 @@ result_enforced
 #=> "Familia::EncryptionError"
 
 Familia.dbclient.flushdb
-Familia.config.encryption_keys = nil
-Familia.config.current_key_version = nil
+clear_test_encryption_keys

--- a/try/features/encrypted_fields/aad_transient_fix_try.rb
+++ b/try/features/encrypted_fields/aad_transient_fix_try.rb
@@ -14,8 +14,7 @@ require_relative '../../support/helpers/test_helpers'
 test_keys = {
   v1: Base64.strict_encode64('a' * 32),
 }
-Familia.config.encryption_keys = test_keys
-Familia.config.current_key_version = :v1
+set_test_encryption_keys(test_keys, current_version: :v1)
 
 # Model with transient field in aad_fields
 class TransientAADModel < Familia::Horreum
@@ -160,5 +159,4 @@ end
 #=> true
 
 Familia.dbclient.flushdb
-Familia.config.encryption_keys = nil
-Familia.config.current_key_version = nil
+clear_test_encryption_keys

--- a/try/features/encrypted_fields/aad_transient_proof_try.rb
+++ b/try/features/encrypted_fields/aad_transient_proof_try.rb
@@ -28,8 +28,7 @@ require_relative '../../support/helpers/test_helpers'
 test_keys = {
   v1: Base64.strict_encode64('a' * 32),
 }
-Familia.config.encryption_keys = test_keys
-Familia.config.current_key_version = :v1
+set_test_encryption_keys(test_keys, current_version: :v1)
 
 # --- Model A: Current OTS behavior (no AAD) ---
 
@@ -249,5 +248,4 @@ end
 
 # Cleanup
 Familia.dbclient.flushdb
-Familia.config.encryption_keys = nil
-Familia.config.current_key_version = nil
+clear_test_encryption_keys

--- a/try/features/encrypted_fields/concealed_string_core_try.rb
+++ b/try/features/encrypted_fields/concealed_string_core_try.rb
@@ -10,9 +10,8 @@ require 'base64'
 Familia.debug = false
 
 # Configure encryption keys
-test_keys = { v1: Base64.strict_encode64('a' * 32) }
-Familia.config.encryption_keys = test_keys
-Familia.config.current_key_version = :v1
+set_test_encryption_keys({ v1: Base64.strict_encode64('a' * 32) },
+                         current_version: :v1)
 
 # Test class with encrypted fields
 class TestSecretDocument < Familia::Horreum
@@ -266,3 +265,4 @@ end
 
 # Teardown
 Familia.dbclient.flushdb
+clear_test_encryption_keys

--- a/try/features/encrypted_fields/context_isolation_try.rb
+++ b/try/features/encrypted_fields/context_isolation_try.rb
@@ -13,8 +13,7 @@ test_keys = {
   v1: Base64.strict_encode64('a' * 32),
   v2: Base64.strict_encode64('b' * 32)
 }
-Familia.config.encryption_keys = test_keys
-Familia.config.current_key_version = :v1
+set_test_encryption_keys(test_keys, current_version: :v1)
 
 class IsolationUser < Familia::Horreum
   feature :encrypted_fields
@@ -142,5 +141,4 @@ end
 #=> true
 
 # Cleanup
-Familia.config.encryption_keys = nil
-Familia.config.current_key_version = nil
+clear_test_encryption_keys

--- a/try/features/encrypted_fields/encrypted_data_try.rb
+++ b/try/features/encrypted_fields/encrypted_data_try.rb
@@ -12,8 +12,7 @@ require_relative '../../support/helpers/test_helpers'
 test_keys = {
   v1: Base64.strict_encode64('a' * 32),
 }
-Familia.config.encryption_keys = test_keys
-Familia.config.current_key_version = :v1
+set_test_encryption_keys(test_keys, current_version: :v1)
 
 @base = Familia::Encryption::EncryptedData.new(
   algorithm: 'xchacha20-poly1305',
@@ -147,5 +146,4 @@ Familia.config.current_key_version = :v1
 @from_old.has_key_material?
 #=> false
 
-Familia.config.encryption_keys = nil
-Familia.config.current_key_version = nil
+clear_test_encryption_keys

--- a/try/features/encrypted_fields/encrypted_fields_core_try.rb
+++ b/try/features/encrypted_fields/encrypted_fields_core_try.rb
@@ -193,4 +193,7 @@ provider = Familia::Encryption.manager.provider
            nonce_size: provider.nonce_size, tag_size: provider.auth_tag_size }
 #=> true
 
-Fiber[:familia_key_cache]&.clear if Fiber[:familia_key_cache]
+# Every test above installs its own keys inline. Clear the process-global
+# encryption config so the next file in the shared-context run does not inherit
+# them (issue #363).
+clear_test_encryption_keys

--- a/try/features/encrypted_fields/encrypted_fields_integration_try.rb
+++ b/try/features/encrypted_fields/encrypted_fields_integration_try.rb
@@ -212,3 +212,9 @@ encrypted_json = concealed_data.encrypted_value
 parsed_data = Familia::JsonSerializer.parse(encrypted_json, symbolize_names: true)
 [parsed_data[:algorithm], @aes_model2.secret_data.reveal { |data| data }]
 #=> ["aes-256-gcm", "aes-gcm integration test"]
+
+# TEARDOWN
+# Every test above installs its own keys inline. Clear the process-global
+# encryption config so the next file in the shared-context run does not inherit
+# them (issue #363).
+clear_test_encryption_keys

--- a/try/features/encrypted_fields/encrypted_fields_no_cache_security_try.rb
+++ b/try/features/encrypted_fields/encrypted_fields_no_cache_security_try.rb
@@ -13,8 +13,7 @@ test_keys = {
   v1: Base64.strict_encode64('a' * 32),
   v2: Base64.strict_encode64('b' * 32)
 }
-Familia.config.encryption_keys = test_keys
-Familia.config.current_key_version = :v1
+set_test_encryption_keys(test_keys, current_version: :v1)
 
 ## No persistent key cache exists
 ## Verify that we don't maintain a key cache at all
@@ -219,5 +218,4 @@ Familia.config.current_key_version = :v1
 
 # Teardown
 Fiber[:familia_key_cache] = nil
-Familia.config.encryption_keys = nil
-Familia.config.current_key_version = nil
+clear_test_encryption_keys

--- a/try/features/encrypted_fields/encrypted_fields_security_try.rb
+++ b/try/features/encrypted_fields/encrypted_fields_security_try.rb
@@ -379,3 +379,9 @@ user.instance_variable_set(:@password, tampered_json)
 user.password
 #=!> Familia::EncryptionError
 #==> error.message.include?("Unsupported algorithm")
+
+# TEARDOWN
+# Every test above installs its own keys inline. Clear the process-global
+# encryption config so the next file in the shared-context run does not inherit
+# them (issue #363).
+clear_test_encryption_keys

--- a/try/features/encrypted_fields/envelope_version_branching_try.rb
+++ b/try/features/encrypted_fields/envelope_version_branching_try.rb
@@ -13,8 +13,7 @@ require_relative '../../support/helpers/test_helpers'
 test_keys = {
   v1: Base64.strict_encode64('a' * 32),
 }
-Familia.config.encryption_keys = test_keys
-Familia.config.current_key_version = :v1
+set_test_encryption_keys(test_keys, current_version: :v1)
 
 class VersionBranchModel < Familia::Horreum
   feature :encrypted_fields
@@ -102,5 +101,4 @@ end
 #=> 2
 
 Familia.dbclient.flushdb
-Familia.config.encryption_keys = nil
-Familia.config.current_key_version = nil
+clear_test_encryption_keys

--- a/try/features/encrypted_fields/envelope_version_try.rb
+++ b/try/features/encrypted_fields/envelope_version_try.rb
@@ -13,8 +13,7 @@ require_relative '../../support/helpers/test_helpers'
 test_keys = {
   v1: Base64.strict_encode64('a' * 32),
 }
-Familia.config.encryption_keys = test_keys
-Familia.config.current_key_version = :v1
+set_test_encryption_keys(test_keys, current_version: :v1)
 
 # Model with aad_fields for envelope tests
 class EnvelopeVersionModel < Familia::Horreum
@@ -167,5 +166,4 @@ end
 #=> nil
 
 Familia.dbclient.flushdb
-Familia.config.encryption_keys = nil
-Familia.config.current_key_version = nil
+clear_test_encryption_keys

--- a/try/features/encrypted_fields/error_conditions_try.rb
+++ b/try/features/encrypted_fields/error_conditions_try.rb
@@ -13,8 +13,7 @@ require_relative '../../support/helpers/test_helpers'
   v1: Base64.strict_encode64('a' * 32),
   v2: Base64.strict_encode64('b' * 32)
 }
-Familia.config.encryption_keys = @test_keys
-Familia.config.current_key_version = :v1
+set_test_encryption_keys(@test_keys, current_version: :v1)
 
 class ErrorTest < Familia::Horreum
   feature :encrypted_fields
@@ -116,5 +115,4 @@ Familia.config.current_key_version = :v1
 #=> nil
 
 # Cleanup
-Familia.config.encryption_keys = nil
-Familia.config.current_key_version = nil
+clear_test_encryption_keys

--- a/try/features/encrypted_fields/fast_writer_try.rb
+++ b/try/features/encrypted_fields/fast_writer_try.rb
@@ -11,8 +11,7 @@ require_relative '../../support/helpers/test_helpers'
 test_keys = {
   v1: Base64.strict_encode64('a' * 32),
 }
-Familia.config.encryption_keys = test_keys
-Familia.config.current_key_version = :v1
+set_test_encryption_keys(test_keys, current_version: :v1)
 
 class EncryptedFastWriterModel < Familia::Horreum
   feature :encrypted_fields
@@ -65,5 +64,4 @@ decrypted_fast == decrypted_normal && decrypted_fast == 'shared-value'
 #=> true
 
 Familia.dbclient.flushdb
-Familia.config.encryption_keys = nil
-Familia.config.current_key_version = nil
+clear_test_encryption_keys

--- a/try/features/encrypted_fields/fresh_key_derivation_try.rb
+++ b/try/features/encrypted_fields/fresh_key_derivation_try.rb
@@ -12,8 +12,7 @@ test_keys = {
   v1: Base64.strict_encode64('a' * 32),
   v2: Base64.strict_encode64('b' * 32)
 }
-Familia.config.encryption_keys = test_keys
-Familia.config.current_key_version = :v1
+set_test_encryption_keys(test_keys, current_version: :v1)
 
 class FreshKeyDerivationTest < Familia::Horreum
   feature :encrypted_fields
@@ -128,5 +127,4 @@ retrieved = model.test_field   # ConcealedString (no decrypt)
 Familia::Encryption.derivation_count.value
 #=> 2
 
-Familia.config.encryption_keys = nil
-Familia.config.current_key_version = nil
+clear_test_encryption_keys

--- a/try/features/encrypted_fields/fresh_key_try.rb
+++ b/try/features/encrypted_fields/fresh_key_try.rb
@@ -7,8 +7,7 @@ require 'base64'
 
 # Setup encryption configuration
 @test_keys = { v1: Base64.strict_encode64('a' * 32) }
-Familia.config.encryption_keys = @test_keys
-Familia.config.current_key_version = :v1
+set_test_encryption_keys(@test_keys, current_version: :v1)
 
 class BasicEncryptedModel < Familia::Horreum
   feature :encrypted_fields
@@ -170,3 +169,6 @@ Fiber[:familia_request_cache] = nil if Fiber[:familia_request_cache]
 # With secure-by-default, field access returns ConcealedString
 model.persistent_data.to_s
 #=> '[CONCEALED]'
+
+# TEARDOWN
+clear_test_encryption_keys

--- a/try/features/encrypted_fields/key_material_try.rb
+++ b/try/features/encrypted_fields/key_material_try.rb
@@ -13,8 +13,7 @@ require_relative '../../support/helpers/test_helpers'
 test_keys = {
   v1: Base64.strict_encode64('a' * 32),
 }
-Familia.config.encryption_keys = test_keys
-Familia.config.current_key_version = :v1
+set_test_encryption_keys(test_keys, current_version: :v1)
 
 # Model with key_material from regular field
 class KeyMaterialModel < Familia::Horreum
@@ -201,5 +200,4 @@ result_km
 #=> "Familia::EncryptionError"
 
 Familia.dbclient.flushdb
-Familia.config.encryption_keys = nil
-Familia.config.current_key_version = nil
+clear_test_encryption_keys

--- a/try/features/encrypted_fields/key_rotation_try.rb
+++ b/try/features/encrypted_fields/key_rotation_try.rb
@@ -23,16 +23,16 @@ class RotationTest < Familia::Horreum
 end
 
 # Data encrypted with v1 can still be decrypted after rotation to v2
-Familia.config.encryption_keys = { v1: @test_keys[:v1] }
-Familia.config.current_key_version = :v1
+set_test_encryption_keys({ v1: @test_keys[:v1] }, current_version: :v1)
 
 @model = RotationTest.new(id: 'rot-1')
 @model.secret = 'original-secret'
 @v1_ciphertext = @model.instance_variable_get(:@secret)
 
-# Rotate to v2 with both keys available
-Familia.config.encryption_keys = { v1: @test_keys[:v1], v2: @test_keys[:v2] }
-Familia.config.current_key_version = :v2
+# Rotate to v2 with both keys available. Only the first install above records
+# the config to restore, so the teardown still hands back the pre-file state.
+set_test_encryption_keys({ v1: @test_keys[:v1], v2: @test_keys[:v2] },
+                         current_version: :v2)
 
 ## Manually set the old ciphertext and try to decrypt
 @model.instance_variable_set(:@secret, @v1_ciphertext)
@@ -123,5 +123,4 @@ Familia.config.current_key_version = :v2
 #=> 'v3-data'
 
 # Cleanup
-Familia.config.encryption_keys = nil
-Familia.config.current_key_version = nil
+clear_test_encryption_keys

--- a/try/features/encrypted_fields/memory_security_try.rb
+++ b/try/features/encrypted_fields/memory_security_try.rb
@@ -7,11 +7,8 @@
 require 'base64'
 require_relative '../../support/helpers/test_helpers'
 
-test_keys = {
-  v1: Base64.strict_encode64('a' * 32),
-}
-Familia.config.encryption_keys = test_keys
-Familia.config.current_key_version = :v1
+set_test_encryption_keys({ v1: Base64.strict_encode64('a' * 32) },
+                         current_version: :v1)
 
 ## Keys are wiped from memory after use
 # Note: This is difficult to test directly, but we can verify
@@ -39,3 +36,6 @@ model.secret
 # Should wipe master key after each derivation (2 operations = 2 wipes)
 wipe_calls >= 2
 #=> true
+
+# TEARDOWN
+clear_test_encryption_keys

--- a/try/features/encrypted_fields/nonce_uniqueness_try.rb
+++ b/try/features/encrypted_fields/nonce_uniqueness_try.rb
@@ -12,8 +12,7 @@ require_relative '../../support/helpers/test_helpers'
 test_keys = {
   v1: Base64.strict_encode64('a' * 32),
 }
-Familia.config.encryption_keys = test_keys
-Familia.config.current_key_version = :v1
+set_test_encryption_keys(test_keys, current_version: :v1)
 
 class NonceTest < Familia::Horreum
   feature :encrypted_fields
@@ -56,5 +55,4 @@ concealed_values.size == 1 && concealed_values.first == "[CONCEALED]"
 #=> true
 
 # Cleanup
-Familia.config.encryption_keys = nil
-Familia.config.current_key_version = nil
+clear_test_encryption_keys

--- a/try/features/encrypted_fields/per_field_algorithm_try.rb
+++ b/try/features/encrypted_fields/per_field_algorithm_try.rb
@@ -22,8 +22,8 @@
 require_relative '../../support/helpers/test_helpers'
 require 'base64'
 
-Familia.config.encryption_keys = { v1: Base64.strict_encode64('a' * 32) }
-Familia.config.current_key_version = :v1
+set_test_encryption_keys({ v1: Base64.strict_encode64('a' * 32) },
+                         current_version: :v1)
 Familia::Encryption::Registry.setup!
 
 class PerFieldAlgoModel < Familia::Horreum
@@ -162,3 +162,6 @@ cs = @clear_rec.aes_field
 cs.clear!
 [@clear_rec.encrypted_fields_status[:aes_field], cs.concealed?, cs.algorithm]
 #=> [{ encrypted: true, cleared: true }, false, nil]
+
+# TEARDOWN
+clear_test_encryption_keys

--- a/try/features/encrypted_fields/re_encrypt_fields_try.rb
+++ b/try/features/encrypted_fields/re_encrypt_fields_try.rb
@@ -23,18 +23,14 @@ require 'json'
 
 require_relative '../../support/helpers/test_helpers'
 
-# Capture original encryption state so teardown can restore it.
-@original_encryption_keys = Familia.config.encryption_keys
-@original_current_key_version = Familia.config.current_key_version
-
-# Two distinct versioned keys; v1 is current at setup time.
+# Two distinct versioned keys; v1 is current at setup time. The helper captures
+# whatever encryption state it displaces so teardown can put it back (#363).
 @test_keys = {
   v1: Base64.strict_encode64('a' * 32),
   v2: Base64.strict_encode64('b' * 32),
 }
 
-Familia.config.encryption_keys = @test_keys
-Familia.config.current_key_version = :v1
+set_test_encryption_keys(@test_keys, current_version: :v1)
 
 # Model with two encrypted fields and one plain field.
 class ReEncryptTarget < Familia::Horreum
@@ -222,19 +218,16 @@ Familia.config.current_key_version = :v1
 @orphan.save
 @created_ids << @orphan.id
 
-pre_block_keys = Familia.config.encryption_keys
-pre_block_version = Familia.config.current_key_version
 raised = begin
-  Familia.config.encryption_keys = { v2: @test_keys[:v2] }
-  Familia.config.current_key_version = :v2
-  orphan_fresh = ReEncryptTarget.load('re-enc-orphan')
-  orphan_fresh.re_encrypt_fields!
-  nil
+  # The block form restores the file's own keyring on exit, including the exit
+  # taken by the EncryptionError this test is provoking.
+  with_test_encryption_keys({ v2: @test_keys[:v2] }, current_version: :v2) do
+    orphan_fresh = ReEncryptTarget.load('re-enc-orphan')
+    orphan_fresh.re_encrypt_fields!
+    nil
+  end
 rescue Familia::EncryptionError => e
   e.class
-ensure
-  Familia.config.encryption_keys = pre_block_keys
-  Familia.config.current_key_version = pre_block_version
 end
 raised
 #=> Familia::EncryptionError
@@ -301,5 +294,4 @@ if @mixed_created_id
   end
 end
 
-Familia.config.encryption_keys = @original_encryption_keys
-Familia.config.current_key_version = @original_current_key_version
+clear_test_encryption_keys

--- a/try/features/encrypted_fields/secure_by_default_behavior_try.rb
+++ b/try/features/encrypted_fields/secure_by_default_behavior_try.rb
@@ -10,9 +10,8 @@ require 'base64'
 Familia.debug = false
 
 # Configure encryption keys
-test_keys = { v1: Base64.strict_encode64('a' * 32) }
-Familia.config.encryption_keys = test_keys
-Familia.config.current_key_version = :v1
+set_test_encryption_keys({ v1: Base64.strict_encode64('a' * 32) },
+                         current_version: :v1)
 
 # Test class demonstrating secure patterns
 class SecureUserAccount < Familia::Horreum
@@ -354,3 +353,4 @@ end
 
 # Teardown
 Familia.dbclient.flushdb
+clear_test_encryption_keys

--- a/try/features/encrypted_fields/thread_safety_try.rb
+++ b/try/features/encrypted_fields/thread_safety_try.rb
@@ -14,8 +14,7 @@ test_keys = {
   v1: Base64.strict_encode64('a' * 32),
   v2: Base64.strict_encode64('b' * 32)
 }
-Familia.config.encryption_keys = test_keys
-Familia.config.current_key_version = :v1
+set_test_encryption_keys(test_keys, current_version: :v1)
 
 class ThreadTest < Familia::Horreum
   feature :encrypted_fields
@@ -199,5 +198,4 @@ errors.empty? && Familia::Encryption.derivation_count.value == 50
 #=> true
 
 # Cleanup
-Familia.config.encryption_keys = nil
-Familia.config.current_key_version = nil
+clear_test_encryption_keys

--- a/try/features/encrypted_fields/universal_serialization_safety_try.rb
+++ b/try/features/encrypted_fields/universal_serialization_safety_try.rb
@@ -10,9 +10,8 @@ require 'base64'
 Familia.debug = false
 
 # Configure encryption keys
-test_keys = { v1: Base64.strict_encode64('a' * 32) }
-Familia.config.encryption_keys = test_keys
-Familia.config.current_key_version = :v1
+set_test_encryption_keys({ v1: Base64.strict_encode64('a' * 32) },
+                         current_version: :v1)
 
 # Test class with mixed field types
 class DataRecord < Familia::Horreum
@@ -193,3 +192,4 @@ end
 
 # Teardown
 Familia.dbclient.flushdb
+clear_test_encryption_keys

--- a/try/features/encryption/aes_gcm_salt_rotation_try.rb
+++ b/try/features/encryption/aes_gcm_salt_rotation_try.rb
@@ -13,8 +13,7 @@
 require_relative '../../support/helpers/test_helpers'
 require 'base64'
 
-Familia.config.encryption_keys = { v1: Base64.strict_encode64('a' * 32) }
-Familia.config.current_key_version = :v1
+set_test_encryption_keys({ v1: Base64.strict_encode64('a' * 32) }, current_version: :v1)
 
 @orig_salt = Familia.config.encryption_hkdf_salt
 @orig_history = Familia.config.encryption_hkdf_salt_history
@@ -209,8 +208,7 @@ Familia.config.encryption_hkdf_salt_history = ['WriteSalt']
 Familia.config.encryption_hkdf_salt = @orig_salt
 Familia.config.encryption_hkdf_salt_history = @orig_history
 Familia.config.encryption_personalization = @orig_personal
-Familia.config.encryption_keys = nil
-Familia.config.current_key_version = nil
+clear_test_encryption_keys
 # Restore the request-cache fiber-locals to their pristine (nil) state. The
 # cache tests above run with_request_cache, whose ensure leaves
 # `enabled=false`; in the shared full-suite process that would otherwise leak

--- a/try/features/encryption/algorithm_upgrade_try.rb
+++ b/try/features/encryption/algorithm_upgrade_try.rb
@@ -20,11 +20,9 @@
 require_relative '../../support/helpers/test_helpers'
 require 'base64'
 
-Familia.config.encryption_keys = {
-  v1: Base64.strict_encode64('a' * 32),
-  v2: Base64.strict_encode64('b' * 32),
-}
-Familia.config.current_key_version = :v2
+set_test_encryption_keys({ v1: Base64.strict_encode64('a' * 32),
+                           v2: Base64.strict_encode64('b' * 32) },
+                         current_version: :v2)
 
 class AlgorithmUpgradeSecret < Familia::Horreum
   feature :encrypted_fields
@@ -112,5 +110,7 @@ rescue Familia::EncryptionError
 end
 #=> 'failed-as-expected'
 
-# Restore config for any subsequent try files sharing the process.
-Familia.config.current_key_version = :v2
+# Restore config for any subsequent try files sharing the process. One test
+# above rewinds current_key_version to :v1 mid-file; this puts the whole
+# override back, keys included (issue #363).
+clear_test_encryption_keys

--- a/try/features/encryption/config_persistence_try.rb
+++ b/try/features/encryption/config_persistence_try.rb
@@ -13,10 +13,11 @@ require_relative '../../support/helpers/test_helpers'
 require 'familia/encryption/providers/xchacha20_poly1305_provider'
 
 # SETUP
-Familia.config.encryption_keys = {
-  v1: Base64.strict_encode64('a' * 32)
-}
-Familia.config.current_key_version = :v1
+# Config persistence across test sections is this file's subject, so the
+# override has to survive every test below -- but not the file itself. The
+# helper scopes it to exactly that (issue #363).
+set_test_encryption_keys({ v1: Base64.strict_encode64('a' * 32) },
+                         current_version: :v1)
 
 ## Check config in test
 keys = Familia.config.encryption_keys
@@ -228,4 +229,4 @@ true
 #=> true
 
 # TEARDOWN
-Fiber[:familia_key_cache]&.clear if Fiber[:familia_key_cache]
+clear_test_encryption_keys

--- a/try/features/encryption/core_try.rb
+++ b/try/features/encryption/core_try.rb
@@ -331,4 +331,7 @@ nonce_bytes_aes.length
 #=> 12
 
 # TEARDOWN
-Fiber[:familia_key_cache]&.clear if Fiber[:familia_key_cache]
+# Every test above installs its own keys inline. Clear the process-global
+# encryption config so the next file in the shared-context run does not inherit
+# them (issue #363).
+clear_test_encryption_keys

--- a/try/features/encryption/encoding_phase1_try.rb
+++ b/try/features/encryption/encoding_phase1_try.rb
@@ -354,4 +354,7 @@ decrypted = Familia::Encryption.decrypt(encrypted, context: context)
 #=> [true, "UTF-8", true]
 
 # TEARDOWN
-Fiber[:familia_key_cache]&.clear if Fiber[:familia_key_cache]
+# Every test above installs its own keys inline. Clear the process-global
+# encryption config so the next file in the shared-context run does not inherit
+# them (issue #363).
+clear_test_encryption_keys

--- a/try/features/encryption/encoding_phase2_try.rb
+++ b/try/features/encryption/encoding_phase2_try.rb
@@ -105,4 +105,7 @@ decrypted = Familia::Encryption.decrypt(legacy_json, context: context)
 #=> ["legacy payload", "UTF-8"]
 
 # TEARDOWN
-Fiber[:familia_key_cache]&.clear if Fiber[:familia_key_cache]
+# Every test above installs its own keys inline. Clear the process-global
+# encryption config so the next file in the shared-context run does not inherit
+# them (issue #363).
+clear_test_encryption_keys

--- a/try/features/encryption/instance_variable_scope_try.rb
+++ b/try/features/encryption/instance_variable_scope_try.rb
@@ -25,10 +25,11 @@ require_relative '../../support/helpers/test_helpers'
 #=> false
 
 ## UnsortedSet config and check immediately in same test
-Familia.config.encryption_keys = @test_keys
-Familia.config.current_key_version = :v1
-result = Familia::Encryption.encrypt('test', context: 'test')
-result.nil?
+# Block form: the override is scoped to this test case, so nothing is left
+# installed for the next file in the shared-context run (issue #363).
+with_test_encryption_keys(@test_keys, current_version: :v1) do
+  Familia::Encryption.encrypt('test', context: 'test').nil?
+end
 #=> false
 
 

--- a/try/features/encryption/module_loading_try.rb
+++ b/try/features/encryption/module_loading_try.rb
@@ -17,16 +17,18 @@ require_relative '../../support/helpers/test_helpers'
 defined?(Familia::Encryption)
 #=> "constant"
 
-## UnsortedSet and check configuration directly in test
-Familia.encryption_keys = { v1: Base64.strict_encode64('a' * 32) }
+## Configured keys read back through the Familia.* spelling of the setting
+# Familia.encryption_keys and Familia.config.encryption_keys are the same
+# setting -- Familia.config returns Familia itself -- so this spelling leaks
+# across files exactly like the other one (issue #363).
+set_test_encryption_keys({ v1: Base64.strict_encode64('a' * 32) }, current_version: :v1)
 Familia.encryption_keys.is_a?(Hash)
 #=> true
 
-## UnsortedSet and check current key version directly in test
-Familia.current_key_version = :v1
+## The current key version reads back through that spelling too
 Familia.current_key_version
 #=> :v1
 
 
 # TEARDOWN
-# Clean up
+clear_test_encryption_keys

--- a/try/features/encryption/providers/xchacha20_poly1305_provider_try.rb
+++ b/try/features/encryption/providers/xchacha20_poly1305_provider_try.rb
@@ -28,8 +28,7 @@ nonce.bytesize
 
 ## XChaCha20Poly1305 key derivation with default personalization
 test_keys = { v1: Base64.strict_encode64('a' * 32) }
-Familia.config.encryption_keys = test_keys
-Familia.config.current_key_version = :v1
+set_test_encryption_keys(test_keys, current_version: :v1)
 provider = Familia::Encryption::Providers::XChaCha20Poly1305Provider.new
 master_key = Base64.strict_decode64(test_keys[:v1])
 context = 'test-context'
@@ -170,4 +169,4 @@ test_key.length
 #=> 0
 
 # TEARDOWN
-Fiber[:familia_key_cache]&.clear if Fiber[:familia_key_cache]
+clear_test_encryption_keys

--- a/try/features/encryption/request_cache_try.rb
+++ b/try/features/encryption/request_cache_try.rb
@@ -12,11 +12,9 @@
 require_relative '../../support/helpers/test_helpers'
 require 'base64'
 
-Familia.config.encryption_keys = {
-  v1: Base64.strict_encode64('a' * 32),
-  v2: Base64.strict_encode64('b' * 32),
-}
-Familia.config.current_key_version = :v1
+set_test_encryption_keys({ v1: Base64.strict_encode64('a' * 32),
+                           v2: Base64.strict_encode64('b' * 32) },
+                         current_version: :v1)
 
 @mgr = Familia::Encryption::Manager.new
 @ctx = 'RequestCacheTest:secret:user1'
@@ -99,5 +97,4 @@ end
 #=> [nil, false]
 
 # TEARDOWN
-Familia.config.encryption_keys = nil
-Familia.config.current_key_version = nil
+clear_test_encryption_keys

--- a/try/features/encryption/roundtrip_validation_try.rb
+++ b/try/features/encryption/roundtrip_validation_try.rb
@@ -30,3 +30,6 @@ decrypted
 
 
 # TEARDOWN
+# Both tests install keys inline. Clear the process-global encryption config so
+# the next file in the shared-context run does not inherit them (issue #363).
+clear_test_encryption_keys

--- a/try/features/encryption/secure_memory_handling_try.rb
+++ b/try/features/encryption/secure_memory_handling_try.rb
@@ -9,10 +9,8 @@ require_relative '../../../lib/familia/encryption/providers/secure_xchacha20_pol
 require 'base64'
 
 # SETUP
-Familia.config.encryption_keys = {
-  v1: Base64.strict_encode64('a' * 32)
-}
-Familia.config.current_key_version = :v1
+set_test_encryption_keys({ v1: Base64.strict_encode64('a' * 32) },
+                         current_version: :v1)
 
 ## SecureXChaCha20Poly1305Provider is available when dependencies are loaded
 @provider_class = Familia::Encryption::Providers::SecureXChaCha20Poly1305Provider
@@ -126,4 +124,4 @@ nonce.bytesize
 #=> "xchacha20poly1305-secure"
 
 # TEARDOWN
-Fiber[:familia_key_cache]&.clear if Fiber[:familia_key_cache]
+clear_test_encryption_keys

--- a/try/features/real_feature_integration_try.rb
+++ b/try/features/real_feature_integration_try.rb
@@ -2,9 +2,16 @@
 #
 # frozen_string_literal: true
 
+require 'base64'
+
 require_relative '../support/helpers/test_helpers'
 
 Familia.debug = false
+
+# SafeDumpCategoryTest below declares an encrypted_field and the setup assigns
+# it, so this file needs a keyring of its own. Until #363 it had none and ran on
+# whatever the previous file in the shared-context run had left installed.
+set_test_encryption_keys({ v1: Base64.strict_encode64('a' * 32) }, current_version: :v1)
 
 # Real feature integration: expiration feature works with new system
 class ExpirationIntegrationTest < Familia::Horreum
@@ -152,3 +159,4 @@ DuplicateFeatureHandling.features_enabled
 @expiration_test = nil
 @safedump_test = nil
 @combined_test = nil
+clear_test_encryption_keys

--- a/try/integration/persistence_operations_try.rb
+++ b/try/integration/persistence_operations_try.rb
@@ -242,8 +242,7 @@ persisted_name = @mod_obj.name
 test_keys = {
   v1: Base64.strict_encode64('a' * 32),
 }
-Familia.config.encryption_keys = test_keys
-Familia.config.current_key_version = :v1
+set_test_encryption_keys(test_keys, current_version: :v1)
 
 class EncryptedPersistenceTest < Familia::Horreum
   feature :encrypted_fields
@@ -261,8 +260,7 @@ before_save = @enc_obj.exists?
 after_save = @enc_obj.exists?
 
 # Clean up encryption config
-Familia.config.encryption_keys = nil
-Familia.config.current_key_version = nil
+clear_test_encryption_keys
 
 [before_save, after_save]
 #=> [false, true]

--- a/try/support/encryption_config_helper_try.rb
+++ b/try/support/encryption_config_helper_try.rb
@@ -1,0 +1,114 @@
+# try/support/encryption_config_helper_try.rb
+#
+# frozen_string_literal: true
+
+# Covers try/support/helpers/encryption_config.rb -- the helpers that stop a
+# file's encryption config from outliving the file (issue #363).
+#
+# Every test below installs the config it needs and puts it back, so these
+# assertions hold wherever this file sorts in the run. That is the property
+# under test, applied to the test itself.
+
+require 'base64'
+
+require_relative 'helpers/test_helpers'
+
+@keyring_a = { v1: Base64.strict_encode64('a' * 32) }
+@keyring_b = { v2: Base64.strict_encode64('b' * 32) }
+
+## set_test_encryption_keys installs both halves of the config
+set_test_encryption_keys(@keyring_a, current_version: :v1)
+@installed = [Familia.config.encryption_keys == @keyring_a,
+              Familia.config.current_key_version]
+clear_test_encryption_keys
+@installed
+#=> [true, :v1]
+
+## clear_test_encryption_keys hands the next file an empty keyring
+set_test_encryption_keys(@keyring_a, current_version: :v1)
+clear_test_encryption_keys
+[Familia.config.encryption_keys, Familia.config.current_key_version]
+#=> [nil, nil]
+
+## a block override nests inside a file-scoped one, restoring it on exit
+set_test_encryption_keys(@keyring_a, current_version: :v1)
+@inside = with_test_encryption_keys(@keyring_b, current_version: :v2) do
+  [Familia.config.encryption_keys == @keyring_b, Familia.config.current_key_version]
+end
+@outside = [Familia.config.encryption_keys == @keyring_a,
+            Familia.config.current_key_version]
+clear_test_encryption_keys
+[@inside, @outside]
+#=> [[true, :v2], [true, :v1]]
+
+## a block that raises still restores what it displaced
+set_test_encryption_keys(@keyring_a, current_version: :v1)
+@raised = begin
+  with_test_encryption_keys(@keyring_b, current_version: :v2) { raise ArgumentError, 'boom' }
+rescue ArgumentError
+  :raised
+end
+@after_raise = [Familia.config.encryption_keys == @keyring_a,
+                Familia.config.current_key_version]
+clear_test_encryption_keys
+[@raised, @after_raise]
+#=> [:raised, [true, :v1]]
+
+## only the first install records the baseline, so widening a keyring is safe
+set_test_encryption_keys(@keyring_a, current_version: :v1)
+set_test_encryption_keys(@keyring_a.merge(@keyring_b), current_version: :v2)
+clear_test_encryption_keys
+[Familia.config.encryption_keys, Familia.config.current_key_version]
+#=> [nil, nil]
+
+## clear with no matching install falls back to an empty keyring
+# This is the shape of a file that only sets the config inline, inside its test
+# cases: there is no baseline to restore, and clearing outright is correct.
+Familia.config.encryption_keys = @keyring_a
+Familia.config.current_key_version = :v1
+clear_test_encryption_keys
+[Familia.config.encryption_keys, Familia.config.current_key_version]
+#=> [nil, nil]
+
+## installing over an unscoped config warns, naming the file that is installing
+# The config is populated but no helper put it there, which is what an earlier
+# file forgetting its teardown looks like from here.
+Familia.config.encryption_keys = @keyring_a
+Familia.config.current_key_version = :v1
+set_test_encryption_keys(@keyring_b, current_version: :v2)
+clear_test_encryption_keys # hands back the unscoped config it warned about...
+Familia.config.encryption_keys = nil
+Familia.config.current_key_version = nil # ...so drop that too
+#=2> /already installed on entry/
+#=2> /encryption_config_helper_try\.rb/
+
+## a previous file that forgot its teardown is caught, not inherited
+# The baseline belongs to the file that recorded it. Another file's outstanding
+# install must not make this file's install skip the leak check, and must not
+# become what this file restores to -- otherwise a forgotten teardown is silent
+# and the leak is handed to the file after this one.
+TestEncryptionConfig.install(@keyring_a, :v1, '/somewhere/else_try.rb')
+set_test_encryption_keys(@keyring_b, current_version: :v2)
+clear_test_encryption_keys
+[Familia.config.encryption_keys, Familia.config.current_key_version]
+#=> [nil, nil]
+#=2> /already installed on entry/
+#=2> /encryption_config_helper_try\.rb/
+
+## installing a keyring wipes the fiber-local derived-key cache
+# The cache is keyed by version and context, not by the master key the entry was
+# derived from, so an entry that outlived a keyring swap would be served under
+# the new keyring.
+Fiber[:familia_request_cache_enabled] = true
+Fiber[:familia_request_cache] = { 'aes-256-gcm:v1::ctx' => +'derived-under-keyring-a' }
+set_test_encryption_keys(@keyring_a, current_version: :v1)
+# Both fiber-locals go back to their pristine nil, not to the `false` that
+# Familia::Encryption.clear_request_cache! leaves behind -- request_cache_try
+# asserts an untouched fiber reads nil.
+@cache_after_install = [Fiber[:familia_request_cache], Fiber[:familia_request_cache_enabled]]
+clear_test_encryption_keys
+@cache_after_install
+#=> [nil, nil]
+
+# TEARDOWN
+clear_test_encryption_keys

--- a/try/support/helpers/encryption_config.rb
+++ b/try/support/helpers/encryption_config.rb
@@ -1,0 +1,169 @@
+# try/support/helpers/encryption_config.rb
+#
+# frozen_string_literal: true
+
+# Scoped encryption config for tryouts (issue #363).
+#
+# `Familia.config.encryption_keys` and `Familia.config.current_key_version` are
+# process-global, and the tryouts runner evaluates every file in a single
+# process. A file that assigns them directly leaves them installed for whatever
+# runs next, so a later file silently reads a neighbour's key material and the
+# suite becomes order-dependent. Nothing fails visibly -- which is the hazard: an
+# encryption test that passes under someone else's key is not testing what it
+# claims, and a file that needs the keys *absent* passes or fails depending on
+# where it sorts.
+#
+# Use these helpers instead of assigning the config directly.
+#
+# File-scoped, the common case -- setup installs, teardown restores:
+#
+#   set_test_encryption_keys({ v1: Base64.strict_encode64('a' * 32) },
+#                            current_version: :v1)
+#
+#   ## ...test cases...
+#
+#   clear_test_encryption_keys
+#
+# Calling #set_test_encryption_keys more than once in a file is fine: only the
+# first call records what to restore, so a setup that installs one keyring and
+# then widens it still hands back the pre-file config, not the intermediate one.
+#
+# Single test case, restoring itself even when the block raises:
+#
+#   ## Ciphertext under a retired key version still decrypts
+#   with_test_encryption_keys(@keys, current_version: :v2) do
+#     Familia::Encryption.decrypt(@envelope, context: 'ctx')
+#   end
+#   #=> 'plaintext'
+#
+# The block restores exactly what it displaced, so it nests inside a file-scoped
+# override: on exit the file's own keyring is back, not the empty keyring.
+module TestEncryptionConfig
+  Snapshot = Struct.new(:keys, :version)
+
+  # The config displaced by the current file's first #install, and which file
+  # that was. The baseline is only meaningful to its own file: a baseline still
+  # standing when a *different* file installs means the first file never
+  # restored, which #install treats as the leak it is rather than inheriting.
+  @baseline = nil
+  @baseline_file = nil
+
+  class << self
+    # Install +keys+/+current_version+ for the rest of +file+, recording the
+    # config it displaces the first time that file calls in.
+    def install(keys, current_version, file)
+      unless owns_baseline?(file)
+        @baseline = baseline_for(file)
+        @baseline_file = file
+      end
+
+      apply(keys, current_version)
+    end
+
+    # Put back the config #install displaced.
+    def restore
+      # A nil baseline means the file only ever set the config inline, inside
+      # test cases. Falling back to the suite-wide default of "no keys" is what
+      # those files need and is never wrong: nothing is left installed either way.
+      baseline = @baseline || Snapshot.new(nil, nil)
+      @baseline = nil
+      @baseline_file = nil
+      apply(baseline.keys, baseline.version)
+    end
+
+    # Install +keys+/+current_version+ for the duration of the block. Unlike
+    # #install this always restores what it displaced, so it nests.
+    def scoped(keys, current_version, file)
+      displaced = snapshot # first, so the ensure below always has one
+      warn_on_leaked_config(file) if leaked? && !owns_baseline?(file)
+
+      apply(keys, current_version)
+      yield
+    ensure
+      apply(displaced.keys, displaced.version)
+    end
+
+    private
+
+    # True when +file+ is the one whose install is currently outstanding. A
+    # second install from the same file must not re-baseline: a setup that
+    # installs a keyring and then widens it still has to restore the config from
+    # before the file, not the intermediate one.
+    def owns_baseline?(file)
+      !@baseline_file.nil? && @baseline_file == file
+    end
+
+    # What +file+ should be restored to when it finishes. Normally that is
+    # whatever it displaces. But if the config is already populated with nobody
+    # currently owning it, an earlier file either assigned it directly or forgot
+    # its teardown -- so baseline to the empty keyring instead. That ends the
+    # leak at this file rather than handing it on to the next one.
+    def baseline_for(file)
+      return snapshot unless leaked?
+
+      warn_on_leaked_config(file)
+      Snapshot.new(nil, nil)
+    end
+
+    def leaked?
+      !(Familia.config.encryption_keys.nil? &&
+        Familia.config.current_key_version.nil?)
+    end
+
+    def snapshot
+      Snapshot.new(Familia.config.encryption_keys, Familia.config.current_key_version)
+    end
+
+    def apply(keys, version)
+      Familia.config.encryption_keys = keys
+      Familia.config.current_key_version = version
+      wipe_derived_key_cache
+
+      keys
+    end
+
+    # Derived keys are cached per fiber under version+context, not under the
+    # master key they came from, so swapping the keyring without wiping the cache
+    # can hand back a key derived from the keyring we just replaced.
+    def wipe_derived_key_cache
+      Familia::Encryption.clear_request_cache!
+
+      # clear_request_cache! leaves the enabled flag `false`, but the suite's
+      # pristine value is nil -- request_cache_try asserts that an untouched
+      # fiber reads nil, not false. Put both fiber-locals fully back so installing
+      # a keyring never counts as having opted into (and out of) the cache.
+      Fiber[:familia_request_cache] = nil
+      Fiber[:familia_request_cache_enabled] = nil
+    end
+
+    # The config is populated and no file currently owns it: some earlier file
+    # assigned it directly, or forgot its teardown. Say so loudly -- that leak is
+    # what these helpers exist to prevent, and it is invisible otherwise.
+    def warn_on_leaked_config(file)
+      warn '[tryouts] Familia.config encryption keys were already installed on ' \
+           "entry to #{file}: an earlier file set them without restoring. " \
+           'See try/support/helpers/encryption_config.rb (issue #363).'
+    end
+  end
+end
+
+# Install encryption keys for the current try file. Pair with
+# #clear_test_encryption_keys in the file's teardown.
+#
+# The caller's path is what scopes the override to one file, so it is captured
+# here rather than inside the module: under the tryouts runner every section of
+# a file evaluates with that file as its source location.
+def set_test_encryption_keys(keys, current_version: nil)
+  TestEncryptionConfig.install(keys, current_version, caller_locations(1, 1)&.first&.path)
+end
+
+# Restore the encryption config displaced by #set_test_encryption_keys, or clear
+# it outright if the file only ever set the config inline.
+def clear_test_encryption_keys
+  TestEncryptionConfig.restore
+end
+
+# Install encryption keys for the duration of a block, restoring on exit.
+def with_test_encryption_keys(keys, current_version: nil, &block)
+  TestEncryptionConfig.scoped(keys, current_version, caller_locations(1, 1)&.first&.path, &block)
+end

--- a/try/support/helpers/test_helpers.rb
+++ b/try/support/helpers/test_helpers.rb
@@ -11,6 +11,7 @@
 require 'digest'
 
 require_relative '../../../lib/familia'
+require_relative 'encryption_config'
 
 Familia.enable_database_logging = true
 Familia.enable_database_counter = true

--- a/try/thread_safety/encryption_manager_cache_race_try.rb
+++ b/try/thread_safety/encryption_manager_cache_race_try.rb
@@ -22,8 +22,7 @@ test_keys = {
   v1: Base64.strict_encode64('a' * 32),
   v2: Base64.strict_encode64('b' * 32)
 }
-Familia.config.encryption_keys = test_keys
-Familia.config.current_key_version = :v1
+set_test_encryption_keys(test_keys, current_version: :v1)
 
 ## Concurrent manager cache initialization for default algorithm
 # Reset the managers cache to nil to simulate first access
@@ -162,5 +161,4 @@ access_counts.all? { |c| c == 50 }
 #=> true
 
 # Cleanup
-Familia.config.encryption_keys = nil
-Familia.config.current_key_version = nil
+clear_test_encryption_keys

--- a/try/unit/horreum/multi_field_update_try.rb
+++ b/try/unit/horreum/multi_field_update_try.rb
@@ -10,8 +10,7 @@
 require 'base64'
 require_relative '../../support/helpers/test_helpers'
 
-Familia.config.encryption_keys = { v1: Base64.strict_encode64('a' * 32) }
-Familia.config.current_key_version = :v1
+set_test_encryption_keys({ v1: Base64.strict_encode64('a' * 32) }, current_version: :v1)
 
 # Model with encrypted and transient fields for guard coverage
 class MultiFieldGuardModel < Familia::Horreum
@@ -294,5 +293,4 @@ end
 # test order is not a factor under the shared-context tryouts runner.
 @customer.destroy! rescue nil
 @guarded.destroy! rescue nil
-Familia.config.encryption_keys = nil
-Familia.config.current_key_version = nil
+clear_test_encryption_keys


### PR DESCRIPTION
Fixes #363.

**Two commits — the second is optional and can be dropped.**

| commit | files | what |
|---|---|---|
| `b7cecf8` | 25 | The helper + its tests, and the 20 files that actually leaked (or depended on a leak) |
| `c927ae3` | 26 | Files that were already correct, migrated to the same helper for one idiom |

Commit 1 stands alone: full suite green at that commit (6181 tests, 306/306 files). Drop commit 2 if you'd rather not take the churn.

## Problem

`Familia.config.encryption_keys` / `current_key_version` are process-global, and the tryouts runner evaluates every file in one process. A file that set them and never cleared them left them installed for whatever ran next. Nothing failed as a result, which was the hazard: a file that believed it had configured its own key material could be exercising a neighbour's.

## The helper

New `try/support/helpers/encryption_config.rb`, loaded by `test_helpers`:

```ruby
set_test_encryption_keys(keys, current_version: :v1)   # setup
clear_test_encryption_keys                             # teardown

with_test_encryption_keys(keys, current_version: :v2) { ... }   # one testcase
```

Design points worth a look:

- **Restore, don't nil.** `clear_test_encryption_keys` puts back what was displaced, so the two forms nest — a block inside a file-scoped override restores the file's keyring, not the empty one.
- **Repeat installs record only the first baseline**, so a setup that installs one keyring and then widens it (`key_rotation_try.rb`) still hands back the pre-file config rather than the intermediate one.
- **Each apply wipes the fiber-local derived-key cache.** It is keyed by version and context, not by the master key an entry came from, so an entry would otherwise survive a keyring swap. It restores both fiber-locals to their pristine `nil` rather than the `false` that `clear_request_cache!` leaves — `request_cache_try.rb` asserts an untouched fiber reads `nil`.
- **Installing over a config no helper put there warns on stderr, naming the file.** That is the signature of an earlier file forgetting its teardown, and it is what makes the next omission loud instead of silent.

## Two files the original survey missed

Both were found by this work rather than assumed from the issue:

- **`try/features/encryption/module_loading_try.rb` leaked under a different spelling.** `Familia.encryption_keys=` and `Familia.config.encryption_keys=` are the same setting — `Familia.config` returns `Familia` itself (`alias config configure`, and `configure` returns `self`). The issue's grep matched only the `.config.` form. The helper's leak warning surfaced it on the first full run.

- **`try/features/real_feature_integration_try.rb` was the victim** the issue predicted. It declares an `encrypted_field` and assigns it during setup with no key material of its own — it had been running on whatever the previous file left installed. On `main` it fails standalone with `Key version cannot be nil`, and closing the leak made it fail in the full suite too. It now installs its own keyring.

Also replaced the teardown line `Fiber[:familia_key_cache]&.clear` in eight files: nothing in `lib/` uses that fiber key (the cache lives under `Fiber[:familia_request_cache]`), so it never cleared anything.

## Verification

- Full suite green: **6181 tests across 306 files**, zero leak warnings — at commit 1 alone and at HEAD. Baseline on `main` is 6173 across 305 (the delta is this PR's 8 new tests plus its new file).
- **Leak probe, per file.** Ran each of the 53 encryption-touching files followed by a probe asserting both settings are `nil`. On `main`: **19 files fail the probe**. On this branch: **none do.** Same probe, same command, both trees.
- The same two-file order (`core_try.rb`, `module_loading_try.rb`, probe) fails on `main` and passes here.
- New `try/support/encryption_config_helper_try.rb` (8 tests) covers install/restore, block nesting inside a file-scoped override, restoration when the block raises, the repeat-install baseline rule, the clear-with-no-install fallback, the leak warning (via `#=2>`), and the derived-key cache wipe.

## Noted, not fixed

`try/features/encrypted_fields/encrypted_fields_no_cache_security_try.rb` asserts on `Fiber[:familia_key_cache]` in ~10 places. Nothing writes that key, so those assertions pass trivially — the same "test that isn't testing what it claims" shape as #363, but a distinct defect: fixing it means working out what each assertion intended against the real `:familia_request_cache`, and some may not hold. Left alone here to keep this diff to the config leak. Happy to file it separately.

## Scope

Test-suite only. No `lib/` changes.