### PR TITLE
fix: run the persisted guard before the index claim in update_in_* (#370 follow-up)

### DIFF
--- a/changelog.d/20260730_210000_claude_370_index_claim_leak_ordering.rst
+++ b/changelog.d/20260730_210000_claude_370_index_claim_leak_ordering.rst
@@ -1,0 +1,25 @@
+Fixed
+-----
+
+- ``update_in_<scope>_<index_name>`` (instance-scoped ``unique_index`` with
+  ``within:``) no longer leaks an index claim when called on an unsaved
+  record. The generated method claimed the new field value via the CAS
+  *before* running the persisted-record guard, so when
+  ``_ensure_persisted_before_index_write!`` raised
+  ``Familia::PersistenceError`` the already-written claim was never
+  released -- the value stayed pointing at a record that did not exist in
+  the database and no other record could ever claim it. The guard now runs
+  before the claim, matching the ordering the sibling generated methods
+  (``add_to_*``, ``add_to_class_*``, ``update_in_class_*``) already used.
+  Not reachable through the normal save flow (inside a save ``MULTI`` the
+  guard short-circuits and the claim path is skipped); it required a direct
+  call to the generated method on an unpersisted record. Found by the
+  2026-07-30 security audit. #370
+
+AI Assistance
+-------------
+
+- AI reordered the persisted-record guard ahead of the CAS claim in the
+  generated ``update_in_<scope>_<index_name>`` method and added regression
+  coverage asserting that a rejected unsaved record leaves no claim behind
+  and that the value remains claimable by a persisted record.

--- a/lib/familia/features/relationships/indexing/unique_index_generators.rb
+++ b/lib/familia/features/relationships/indexing/unique_index_generators.rb
@@ -374,6 +374,12 @@ module Familia
                 new_field_value = send(field)
                 index_hash = scope_instance.send(index_name)
 
+                # Before the claim, not after: claim_field HSETs on success, so
+                # a claim followed by a persistence failure leaves the value
+                # permanently held by a record that never existed. Same ordering
+                # as add_to_* above.
+                _ensure_persisted_before_index_write!(index_name, scope_instance)
+
                 # Claim before the MULTI opens (see ADR-0002). Inside an outer
                 # transaction there is nothing to claim against, so the writes
                 # below are unenforced -- same escape hatch as add_to_*.
@@ -386,8 +392,6 @@ module Familia
                     )
                   end
                 end
-
-                _ensure_persisted_before_index_write!(index_name, scope_instance)
 
                 # Use Familia's transaction method for atomicity with DataType abstraction
                 scope_instance.transaction do |_tx|

--- a/try/unit/horreum/automatic_index_validation_try.rb
+++ b/try/unit/horreum/automatic_index_validation_try.rb
@@ -268,6 +268,26 @@ rescue Familia::PersistenceError
 end
 #=> true
 
+## update_in_* rejection does not leak a claim on the new value
+## (the persisted guard must run before claim_field, which HSETs on
+## success -- a leaked claim would leave BADGE900 pointing at a record
+## that does not exist and block any other record from claiming it)
+@company.badge_index.has_key?('BADGE900')
+#=> false
+
+## The value rejected above is still claimable by a persisted record
+@emp9b_id = "emp_#{rand(1000000)}"
+@emp9b = AutoValidEmployee.new(emp_id: @emp9b_id, badge_number: 'BADGE900', email: 'emp9b@example.com')
+@emp9b.save
+@emp9b.add_to_auto_valid_company_badge_index(@company)
+@company.badge_index.get('BADGE900')
+#=> @emp9b_id
+
+## Release the value so @emp9 can take it after saving (below)
+@emp9b.remove_from_auto_valid_company_badge_index(@company)
+@company.badge_index.has_key?('BADGE900')
+#=> false
+
 ## After saving, the same instance can be indexed
 @emp9.save
 @emp9.add_to_auto_valid_company_badge_index(@company)
@@ -304,7 +324,7 @@ AutoValidEmployee.email_index.get('emp10@example.com')
 #=> @emp10_id
 
 # Teardown - clean up test objects
-[@emp1, @emp2, @emp3, @emp_nil, @emp4, @emp5, @emp6, @emp7, @emp8, @emp9, @emp10].compact.each do |obj|
+[@emp1, @emp2, @emp3, @emp_nil, @emp4, @emp5, @emp6, @emp7, @emp8, @emp9, @emp9b, @emp10].compact.each do |obj|
   obj.destroy! if obj.respond_to?(:destroy!) && obj.respond_to?(:exists?) && obj.exists?
 end
 


### PR DESCRIPTION
Companion code fix for the MEDIUM finding in the 2026-07-30 security audit (#370).

## What

`update_in_<scope>_<index_name>` — the instance-scoped `unique_index ... within:` update method generated in `lib/familia/features/relationships/indexing/unique_index_generators.rb` — called `claim_field` on the new field value **before** `_ensure_persisted_before_index_write!`. When the guard raised `Familia::PersistenceError`, the CAS claim had already HSET the value into the index with no rescue/rollback, leaving it permanently pointing at a record that doesn't exist in the database and blocking any other record from ever claiming it.

This PR reorders the two calls so the persisted guard runs first, matching the ordering the three sibling generated methods (`add_to_*`, `add_to_class_*`, `update_in_class_*`) already use.

## Reachability

Not reachable through the normal save flow: inside a save `MULTI` the guard short-circuits and the claim branch is skipped. It required a direct call to the generated method on an unpersisted record — hence MEDIUM.

## Tests

Extended `try/unit/horreum/automatic_index_validation_try.rb` (section 6) with regression coverage: after the `PersistenceError` from an unsaved record's `update_in_*` call, the index contains no entry for the value and a persisted record can still claim it. Verified the new assertions fail against the previous ordering (the leaked claim raises `RecordExistsError` for the second record). All 475 tests across the 10 indexing-related tryouts files pass with the fix.

Also adds a scriv changelog fragment per `changelog.d/README.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UjQU6UaWqnHUWHfxgLG5PB

---
_Generated by [Claude Code](https://claude.ai/code/session_01UjQU6UaWqnHUWHfxgLG5PB)_