### PR TITLE
fix: drop the no-op ConcealedString finalizer and its memory-wipe claim (#359)

### DIFF
--- a/changelog.d/20260730_213000_claude_359_concealed_string_finalizer.rst
+++ b/changelog.d/20260730_213000_claude_359_concealed_string_finalizer.rst
@@ -1,0 +1,22 @@
+Fixed
+-----
+
+- ``ConcealedString`` no longer registers a GC finalizer that could never do
+  anything. ``initialize`` freezes the encrypted buffer, while the finalizer
+  only cleared unfrozen strings -- mutually exclusive by construction, so the
+  advertised "best-effort memory clearing" was unconditionally a no-op. The
+  finalizer and the claim are gone: the class docs, ``clear!`` docs, and the
+  encryption guide now state plainly that ``clear!`` drops references and
+  blocks further reveals but cannot wipe memory, matching the honesty of the
+  ``RedactedString`` header's memory-model caveats. Behavior is unchanged
+  (the finalizer never did anything); ``ConcealedString.finalizer_proc`` is
+  removed. Not exploitable -- a truth-in-advertising fix from the 2026-07-19
+  internal code audit. #359
+
+AI Assistance
+-------------
+
+- AI removed the dead finalizer path, rewrote the memory-clearing claims in
+  the ``ConcealedString`` docs and the encryption guide to describe what
+  ``clear!`` actually does, and verified the encrypted/transient field
+  tryouts suites still pass.

--- a/docs/guides/encryption.md
+++ b/docs/guides/encryption.md
@@ -193,11 +193,13 @@ secret.reveal do |raw_value|
   HTTP.post('/api', headers: { 'X-Token' => raw_value })
 end
 
-# Check if cleared from memory
-secret.cleared?            # Returns true if wiped
+# Check if cleared
+secret.cleared?            # Returns true after clear!
 
-# Explicit cleanup
-secret.clear!              # Best-effort memory wiping
+# Explicit cleanup — drops references and blocks further reveals.
+# Does NOT wipe memory: Ruby cannot guarantee string wiping, so the
+# encrypted buffer persists until garbage collection reclaims it.
+secret.clear!
 ```
 
 ## Provider-Specific Features
@@ -418,7 +420,7 @@ Encrypted data is stored as JSON with algorithm-specific metadata:
 ### Memory Safety Limitations
 
 ⚠️ **Important**: Ruby provides NO memory safety guarantees:
-- No secure memory wiping (best-effort only)
+- No secure memory wiping (`clear!` drops references; it cannot zero the bytes)
 - Garbage collector may copy secrets
 - String operations create uncontrolled copies
 - Memory dumps may contain plaintext secrets

--- a/lib/familia/features/encrypted_fields/concealed_string.rb
+++ b/lib/familia/features/encrypted_fields/concealed_string.rb
@@ -22,7 +22,13 @@
 #   2. Debugging Safety - inspect, logging, console output shows [CONCEALED]
 #   3. Exception Safety - never leaks plaintext in error messages
 #   4. Future-proof - any new serialization method automatically safe
-#   5. Memory Clearing - best-effort encrypted data clearing
+#   5. Explicit Lifecycle - clear! drops references and blocks further reveals
+#
+# What this class does NOT do: wipe memory. Ruby cannot guarantee string
+# wiping (copies, GC compaction, immutable internals), and the encrypted
+# buffer here is frozen besides. clear! releases references and marks the
+# wrapper unusable; reclaiming the bytes is left to the GC. See the
+# RedactedString header for the full list of Ruby memory caveats.
 #
 # Critical Design Principles:
 #   - Secure by default - no auto-decryption anywhere
@@ -65,8 +71,6 @@ class ConcealedString
         raise Familia::EncryptionError, "Invalid encrypted data: #{e.message}"
       end
     end
-
-    ObjectSpace.define_finalizer(self, self.class.finalizer_proc(@encrypted_data))
   end
 
   # Primary API: reveal the decrypted plaintext in a controlled block
@@ -126,10 +130,14 @@ class ConcealedString
     "#{@record.class.name}:#{@field_type.name}:#{@record.identifier}"
   end
 
-  # Clear the encrypted data from memory
+  # Release the encrypted data and make the wrapper unusable
   #
-  # Safe to call multiple times. This provides best-effort memory
-  # clearing within Ruby's limitations.
+  # Safe to call multiple times. Drops the references to the encrypted
+  # data and its record/field context, so further reveals raise
+  # SecurityError and the buffers become eligible for GC. This does NOT
+  # wipe memory -- the frozen encrypted string persists until the GC
+  # reclaims it, and Ruby offers no way to guarantee otherwise (see the
+  # class header).
   #
   def clear!
     return if @cleared
@@ -315,15 +323,6 @@ class ConcealedString
   # Prevent exposure in Rails serialization (as_json -> to_json)
   def as_json(*)
     '[CONCEALED]'
-  end
-
-  # Finalizer to attempt memory cleanup
-  def self.finalizer_proc(encrypted_data)
-    proc do
-      # Best effort cleanup - Ruby doesn't guarantee memory security
-      # Only clear if not frozen to avoid FrozenError
-      encrypted_data.clear if encrypted_data.respond_to?(:clear) && !encrypted_data.frozen?
-    end
   end
 
   private


### PR DESCRIPTION
Closes #359.

## What

`ConcealedString#initialize` freezes the encrypted buffer (`@encrypted_data = encrypted_data.freeze`), while `finalizer_proc` only cleared *unfrozen* strings ("Only clear if not frozen to avoid FrozenError"). The two conditions are mutually exclusive by construction, so the advertised best-effort memory wipe was unconditionally a no-op.

Per the issue's recommendation, this takes the simpler, more honest path — drop the finalizer and the claim rather than unfreeze the buffer:

- Removed the `ObjectSpace.define_finalizer` registration and the `ConcealedString.finalizer_proc` class method (nothing in `lib/`, `try/`, or `docs/` referenced it for ConcealedString — the similarly-named `RedactedString.finalizer_proc`, already an intentional documented no-op, is untouched).
- Rewrote the class header's "Memory Clearing" feature bullet and the `clear!` docs to say what actually happens: `clear!` drops references and blocks further reveals; reclaiming the bytes is left to the GC, and Ruby cannot guarantee wiping. Points at the `RedactedString` header for the full memory-model caveats.
- Fixed the same overclaim in `docs/guides/encryption.md` ("Best-effort memory wiping" → an accurate description).

No behavior change — the finalizer never did anything.

## Tests

No new tests: the removed code was dead, and `clear!` semantics are already covered by `try/features/encrypted_fields/concealed_string_core_try.rb`. All 486 tests across `try/features/encrypted_fields/` and `try/features/transient_fields/` pass. (Two files error with `invalid byte sequence in US-ASCII` in a locale-less environment — pre-existing on `main`, they pass under `LANG=C.UTF-8`.)

Also adds a scriv changelog fragment per `changelog.d/README.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UjQU6UaWqnHUWHfxgLG5PB

---
_Generated by [Claude Code](https://claude.ai/code/session_01UjQU6UaWqnHUWHfxgLG5PB)_