### PR TITLE
[#357] Preserve the secret when SingleUseRedactedString#expose is called without a block

### DIFF
--- a/lib/familia/features/transient_fields/single_use_redacted_string.rb
+++ b/lib/familia/features/transient_fields/single_use_redacted_string.rb
@@ -44,13 +44,19 @@ class SingleUseRedactedString < RedactedString
   # This ensures the value can only be accessed once via expose,
   # providing maximum security for single-use secrets.
   #
+  # The guard clauses run *before* the begin/ensure region so that misuse
+  # (calling without a block) raises without destroying the secret. Only a
+  # call that actually reaches the yield consumes the single use.
+  #
   def expose
     raise ArgumentError, 'Block required' unless block_given?
     raise SecurityError, 'Value already cleared' if cleared?
 
-    yield @value
-  ensure
-    clear! # Automatically clear after single use
+    begin
+      yield @value
+    ensure
+      clear! # Automatically clear after single use
+    end
   end
 
   # Override value accessor to prevent direct access

--- a/try/features/transient_fields/single_use_redacted_string_try.rb
+++ b/try/features/transient_fields/single_use_redacted_string_try.rb
@@ -71,6 +71,38 @@ rescue ArgumentError => e
 end
 #=> "Block required"
 
+## expose without a block preserves the secret (no single use consumed)
+single_use_no_block_preserved = SingleUseRedactedString.new(@otp_code)
+begin
+  single_use_no_block_preserved.expose
+rescue ArgumentError
+  # Misuse must not destroy the value
+end
+single_use_no_block_preserved.cleared?
+#=> false
+
+## Secret remains usable after a blockless expose attempt
+single_use_no_block_usable = SingleUseRedactedString.new("123456")
+begin
+  single_use_no_block_usable.expose
+rescue ArgumentError
+  # Misuse must not destroy the value
+end
+result = nil
+single_use_no_block_usable.expose { |val| result = val.dup }
+[result, single_use_no_block_usable.cleared?]
+#=> ["123456", true]
+
+## expose on an already-cleared value leaves it cleared (SecurityError guard)
+single_use_cleared_guard = SingleUseRedactedString.new(@auth_token)
+single_use_cleared_guard.clear!
+begin
+  single_use_cleared_guard.expose { |val| val }
+rescue SecurityError => e
+  [e.message, single_use_cleared_guard.cleared?]
+end
+#=> ["Value already cleared", true]
+
 ## expose method provides access to original value
 single_use_expose = SingleUseRedactedString.new("123456")
 result = nil

--- a/try/features/transient_fields/single_use_redacted_string_try.rb
+++ b/try/features/transient_fields/single_use_redacted_string_try.rb
@@ -73,25 +73,27 @@ end
 
 ## expose without a block preserves the secret (no single use consumed)
 single_use_no_block_preserved = SingleUseRedactedString.new(@otp_code)
-begin
+raised = begin
   single_use_no_block_preserved.expose
-rescue ArgumentError
-  # Misuse must not destroy the value
+  nil  # falling through means the block guard is gone
+rescue ArgumentError => e
+  e.message
 end
-single_use_no_block_preserved.cleared?
-#=> false
+[raised, single_use_no_block_preserved.cleared?]
+#=> ["Block required", false]
 
 ## Secret remains usable after a blockless expose attempt
 single_use_no_block_usable = SingleUseRedactedString.new("123456")
-begin
+raised = begin
   single_use_no_block_usable.expose
-rescue ArgumentError
-  # Misuse must not destroy the value
+  nil  # falling through means the block guard is gone
+rescue ArgumentError => e
+  e.message
 end
 result = nil
 single_use_no_block_usable.expose { |val| result = val.dup }
-[result, single_use_no_block_usable.cleared?]
-#=> ["123456", true]
+[raised, result, single_use_no_block_usable.cleared?]
+#=> ["Block required", "123456", true]
 
 ## expose on an already-cleared value leaves it cleared (SecurityError guard)
 single_use_cleared_guard = SingleUseRedactedString.new(@auth_token)


### PR DESCRIPTION
Fixes #357.

## Problem

`SingleUseRedactedString#expose` used a method-level `ensure clear!`, which in Ruby covers the *entire* method body — including the guard clauses at the top:

```ruby
def expose
  raise ArgumentError, 'Block required' unless block_given?
  raise SecurityError, 'Value already cleared' if cleared?

  yield @value
ensure
  clear! # runs even when the ArgumentError above was raised
end
```

A caller who forgot the block got an `ArgumentError` saying "Block required" while the single-use secret was silently wiped. The error message pointed at the calling convention; the actual damage — an unrecoverable OTP, token, or key — was invisible.

## Fix

Scope the `ensure` to the `yield` only, so the guard clauses run before the ensure region applies:

```ruby
def expose
  raise ArgumentError, 'Block required' unless block_given?
  raise SecurityError, 'Value already cleared' if cleared?

  begin
    yield @value
  ensure
    clear! # Automatically clear after single use
  end
end
```

Only a call that actually reaches the `yield` consumes the single use. Behavior that is deliberately unchanged:

- The value is still wiped after a successful `expose`.
- The value is still wiped when the block raises or returns early (`ensure` covers the yield).
- A second `expose`, or an `expose` after a manual `clear!`, still raises `SecurityError` and leaves the object cleared — `clear!` is idempotent, so hoisting the `cleared?` guard out of the ensure region changes nothing there.

## Tests

Three tryouts added to `try/features/transient_fields/single_use_redacted_string_try.rb`:

- blockless `expose` leaves `cleared?` false
- the secret is still usable via a subsequent proper `expose` after a blockless attempt
- `expose` on an already-cleared value raises `SecurityError` and stays cleared (guards the hoisted `cleared?` check)

The first two fail on the pre-fix code; verified by stashing the library change and re-running. Full suite passes: 306/306 files.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SbcY6Tqn7BUmZY8whGE1BV)_