### PR TITLE
[#356] Stop derive_key from mutating the caller's context string

### DIFF
--- a/changelog.d/20260730_223000_claude_356_derive_key_context_mutation.rst
+++ b/changelog.d/20260730_223000_claude_356_derive_key_context_mutation.rst
@@ -1,0 +1,25 @@
+Fixed
+-----
+
+- ``SecureXChaCha20Poly1305Provider#derive_key`` no longer mutates the context
+  string it is given. It passed ``context.force_encoding('BINARY')`` to
+  BLAKE2b, and ``force_encoding`` mutates its receiver: the caller's string
+  came back re-tagged as ``ASCII-8BIT``, and a frozen context (routine under
+  ``# frozen_string_literal: true``) raised ``FrozenError`` instead of
+  deriving a key. The provider now hashes a fresh binary copy via
+  ``context.to_s.b``, matching the fix made to the sibling
+  ``XChaCha20Poly1305Provider`` in #250 -- which also means a ``Symbol`` or
+  ``nil`` context no longer raises ``NoMethodError``. Derived keys are
+  byte-for-byte unchanged (only the encoding tag differed, never the bytes
+  hashed), so no stored ciphertext needs re-encryption. Found by the
+  2026-07-19 security audit. #356
+
+AI Assistance
+-------------
+
+- AI reproduced both symptoms (caller-string encoding flip and ``FrozenError``
+  on a frozen context) against the unfixed provider, applied the ``to_s.b``
+  fix, and added regression coverage asserting that the caller's encoding is
+  preserved, that a frozen context derives successfully, that non-String
+  contexts are tolerated, and that the derived key still matches the sibling
+  provider byte for byte.

--- a/lib/familia/encryption/providers/secure_xchacha20_poly1305_provider.rb
+++ b/lib/familia/encryption/providers/secure_xchacha20_poly1305_provider.rb
@@ -113,7 +113,12 @@ module Familia
 
           # Perform derivation and immediately clear intermediate values
           derived_key = RbNaCl::Hash.blake2b(
-            context.force_encoding('BINARY'),
+            # to_s before .b: tolerate non-String contexts (Symbol, nil) and
+            # always operate on a fresh BINARY copy. force_encoding mutates its
+            # receiver, which flipped the caller's context string to BINARY and
+            # raised FrozenError on frozen literals (#356, mirroring the fix
+            # made to XChaCha20Poly1305Provider in #250).
+            context.to_s.b,
             key: master_key,
             digest_size: KEY_SIZE,
             personal: personal_string

--- a/try/features/encryption/secure_memory_handling_try.rb
+++ b/try/features/encryption/secure_memory_handling_try.rb
@@ -47,6 +47,31 @@ derived_key = provider.derive_key(master_key, context, personal: 'test_personal'
 derived_key.bytesize
 #=> 32
 
+## derive_key leaves the caller's context string encoding untouched (#356)
+provider = @provider_class.new
+context = (+'TestModel:field:user123').force_encoding(Encoding::UTF_8)
+provider.derive_key('a' * 32, context)
+context.encoding
+#=> Encoding::UTF_8
+
+## derive_key accepts a frozen context string without raising (#356)
+provider = @provider_class.new
+provider.derive_key('a' * 32, 'TestModel:field:user123'.freeze).bytesize
+#=> 32
+
+## derive_key tolerates non-String contexts (#356)
+provider = @provider_class.new
+provider.derive_key('a' * 32, :symbol_context).bytesize
+#=> 32
+
+## derive_key output is unchanged by the no-mutation fix: still matches the
+## sibling provider byte for byte, so existing ciphertexts stay decryptable
+provider = @provider_class.new
+sibling = Familia::Encryption::Providers::XChaCha20Poly1305Provider.new
+context = 'TestModel:field:user123'
+provider.derive_key('a' * 32, context) == sibling.derive_key('a' * 32, context)
+#=> true
+
 ## encrypt operation clears key after use (demonstration)
 provider = @provider_class.new
 master_key = ('a' * 32).dup  # Make mutable copy


### PR DESCRIPTION
Fixes #356.

## Problem

`SecureXChaCha20Poly1305Provider#derive_key` passed `context.force_encoding('BINARY')` to BLAKE2b. `force_encoding` mutates its receiver, so:

- the caller's context string came back re-tagged as `ASCII-8BIT`, and
- a frozen context — routine under `# frozen_string_literal: true` — raised `FrozenError` instead of deriving a key.

Reproduced against the unfixed provider:

```
before: UTF-8
after:  ASCII-8BIT
frozen: FrozenError: can't modify frozen String: "TestModel:field:user123"
```

The sibling `XChaCha20Poly1305Provider` had the identical defect and was fixed in #250; this provider was missed.

## Fix

`lib/familia/encryption/providers/secure_xchacha20_poly1305_provider.rb` — hash a fresh binary copy via `context.to_s.b`, exactly matching the sibling's fix. The `to_s` also means a `Symbol` or `nil` context no longer raises `NoMethodError`.

## Compatibility

Only the encoding *tag* differed, never the bytes handed to BLAKE2b, so derived keys are byte-for-byte unchanged and **no stored ciphertext needs re-encryption**. Verified directly against the old expression for ASCII, UTF-8 and long contexts, and against the sibling provider — all identical. A new testcase pins the sibling parity so a future change to this line can't silently shift derived keys.

## Testing

Four regression testcases added to `try/features/encryption/secure_memory_handling_try.rb`: caller's encoding preserved, frozen context derives successfully, non-String context tolerated, and derived key matches the sibling provider.

All three behavioral ones fail against the unfixed provider:

```
L60: FrozenError: can't modify frozen String: "TestModel:field:user123"
L65: NoMethodError: undefined method `force_encoding' for an instance of Symbol
L55: expected UTF-8, got ASCII-8BIT
```

and pass with it. Full suite, run against a CI-matching environment (Valkey on port 2525 per `ci.yml`, UTF-8 locale) on Ruby 3.3.6: **6189 testcases passed, 0 failed across 306 files.**

## Why existing tests never caught this

Tryouts runs each testcase body through `container.instance_eval(code, path, line)` (`tryouts-3.7.1/lib/tryouts/test_batch.rb:248`). An eval'd string is its own compilation unit and `frozen_string_literal` is per-unit, so the file's header magic comment never applies to the testcase body — string literals in `*_try.rb` bodies are not frozen, and `force_encoding` on them silently succeeded. The new frozen-context testcase therefore uses an explicit `.freeze` rather than relying on the file header. (RuboCop would flag that as `Style/RedundantFreeze`, but `try/**/*.rb` is excluded from RuboCop, so it does not surface in a normal run — and dropping the `.freeze` would make the test vacuous.)

`bundle exec rubocop` reports no new offenses (the 2 remaining in the provider are pre-existing and present on `main`).
