### PR TITLE
[#355] Report a WATCH-aborted MULTI as unsuccessful instead of crashing

### DIFF
--- a/changelog.d/20260730_223000_claude_355_multiresult_nil_abort.rst
+++ b/changelog.d/20260730_223000_claude_355_multiresult_nil_abort.rst
@@ -57,10 +57,15 @@ Changed
   missing. ``to_h`` now returns ``{success:, aborted:, results:}``. Code
   comparing the hash by equality needs the extra key.
 
-- ``Familia::MultiResult#errors`` returns a frozen array on every path. It was
-  already frozen for aborted results, so mutating it used to succeed or raise
-  depending on the outcome. It is derived state backing a memo, so mutating it
-  was never meaningful. ``#results`` stays mutable and per-instance.
+- ``Familia::MultiResult`` instances are now read-only: both ``#results`` and
+  ``#errors`` are frozen. ``#errors`` was previously frozen only for aborted
+  results, so mutating it succeeded or raised depending on the outcome. And
+  because ``#errors`` is a memo derived from ``#results``, a mutable
+  ``#results`` let the two drift — appending an exception after ``#errors``
+  had been read left a stale error list, and ``to_h[:results]`` handed out a
+  live reference to internal state. A result describes an operation that has
+  already finished, so neither array was ever meaningful to modify. Code that
+  mutates either in place should work on a ``dup``.
 
 AI Assistance
 -------------

--- a/changelog.d/20260730_223000_claude_355_multiresult_nil_abort.rst
+++ b/changelog.d/20260730_223000_claude_355_multiresult_nil_abort.rst
@@ -9,25 +9,66 @@ Fixed
   reporting the transaction as unsuccessful. A caller doing the right thing
   (checking ``result.successful?`` and retrying on contention) crashed exactly
   when contention occurred. An aborted result now reports ``successful? ==
-  false`` with an empty ``errors`` array and ``size == 0``, and ``results``
-  still holds ``nil`` so an abort remains distinguishable from a transaction
-  that committed zero commands. #355
+  false`` with an empty ``errors`` array and ``size == 0``. #355
 
 Added
 -----
 
 - ``Familia::MultiResult#aborted?`` reports whether a transaction was discarded
-  before ``EXEC`` ran, letting callers tell a WATCH abort (retry) apart from a
-  transaction where an individual command failed (inspect ``errors``). Note the
-  resulting asymmetry: an aborted transaction is not ``successful?``, yet
-  ``errors?`` is false — it ran no commands, so no command errored.
+  before ``EXEC`` ran, letting callers tell a WATCH abort (retry the whole
+  transaction) apart from one where an individual command failed (inspect
+  ``errors``). Note the deliberate asymmetry: an aborted transaction is not
+  ``successful?``, yet ``errors?`` is false — it ran no commands, so no command
+  errored. ``successful?`` remains the method to test for the overall outcome.
+
+- ``Familia::MultiResult#inspect`` summarizes the outcome
+  (``#<Familia::MultiResult aborted size=0>``) instead of using the default
+  object dump. It deliberately omits the command return values, which
+  routinely carry field values read back out of the database and have no
+  business landing in a log line by default.
+
+Changed
+-------
+
+- ``Familia::MultiResult#results`` is now always an Array. It previously
+  exposed redis-rb's raw return value, which is ``nil`` for an aborted
+  transaction, pushing a nil check onto every caller that indexes or iterates
+  it — the same class of crash as #355, one level out. An abort now reports an
+  empty array, and ``#aborted?`` carries the distinction the ``nil`` used to
+  carry:
+
+  .. code-block:: ruby
+
+     # before
+     result.results        # => nil on a WATCH abort
+     result.results.nil?   # the only way to detect an abort
+
+     # after
+     result.results        # => [] on a WATCH abort
+     result.aborted?       # => true
+     result.results[0]     # => nil, instead of NoMethodError
+
+  Code testing ``results.nil?`` to detect an abort should call ``aborted?``.
+  Note that an abort and a transaction that committed zero commands both
+  report ``results == []``; ``aborted?`` is what separates them.
+
+- ``Familia::MultiResult#to_h`` gained an ``:aborted`` key, so a dumped
+  failure says why it failed rather than reading as a result whose errors went
+  missing. ``to_h`` now returns ``{success:, aborted:, results:}``. Code
+  comparing the hash by equality needs the extra key.
+
+- ``Familia::MultiResult#errors`` returns a frozen array on every path. It was
+  already frozen for aborted results, so mutating it used to succeed or raise
+  depending on the outcome. It is derived state backing a memo, so mutating it
+  was never meaningful. ``#results`` stays mutable and per-instance.
 
 AI Assistance
 -------------
 
-- Claude Code implemented the nil-result handling, added
-  ``try/unit/multi_result_try.rb`` covering clean, error-carrying, empty, and
-  aborted results plus a real WATCH-aborted ``MULTI`` driven against the
-  database from two connections, and switched
-  ``TransactionCore.execute_watched_transaction``'s abort detection to the new
-  ``aborted?`` predicate.
+- Claude Code implemented the nil handling and the accessor normalization,
+  added ``try/unit/multi_result_try.rb`` covering clean, error-carrying,
+  empty, and aborted results across every accessor and alias — including that
+  an abort stays distinguishable from a zero-command commit — plus a real
+  WATCH-aborted ``MULTI`` driven against the database from two connections,
+  and switched ``TransactionCore.execute_watched_transaction``'s abort
+  detection to the new ``aborted?`` predicate.

--- a/changelog.d/20260730_223000_claude_355_multiresult_nil_abort.rst
+++ b/changelog.d/20260730_223000_claude_355_multiresult_nil_abort.rst
@@ -1,0 +1,33 @@
+Fixed
+-----
+
+- ``Familia::MultiResult`` no longer raises ``NoMethodError`` when it wraps an
+  aborted transaction. A WATCH-guarded ``MULTI`` whose watched key is modified
+  by another client has its ``EXEC`` discarded, and redis-rb returns ``nil``
+  rather than an array of command results — so ``errors``, ``errors?``,
+  ``successful?``, ``size``, and ``to_h`` all blew up on ``nil`` instead of
+  reporting the transaction as unsuccessful. A caller doing the right thing
+  (checking ``result.successful?`` and retrying on contention) crashed exactly
+  when contention occurred. An aborted result now reports ``successful? ==
+  false`` with an empty ``errors`` array and ``size == 0``, and ``results``
+  still holds ``nil`` so an abort remains distinguishable from a transaction
+  that committed zero commands. #355
+
+Added
+-----
+
+- ``Familia::MultiResult#aborted?`` reports whether a transaction was discarded
+  before ``EXEC`` ran, letting callers tell a WATCH abort (retry) apart from a
+  transaction where an individual command failed (inspect ``errors``). Note the
+  resulting asymmetry: an aborted transaction is not ``successful?``, yet
+  ``errors?`` is false — it ran no commands, so no command errored.
+
+AI Assistance
+-------------
+
+- Claude Code implemented the nil-result handling, added
+  ``try/unit/multi_result_try.rb`` covering clean, error-carrying, empty, and
+  aborted results plus a real WATCH-aborted ``MULTI`` driven against the
+  database from two connections, and switched
+  ``TransactionCore.execute_watched_transaction``'s abort detection to the new
+  ``aborted?`` predicate.

--- a/lib/familia/connection/transaction_core.rb
+++ b/lib/familia/connection/transaction_core.rb
@@ -204,7 +204,7 @@ module Familia
           # MultiResult(nil) on abort, while one that drives conn.multi directly
           # would see a bare nil (aborted EXEC). Treat both as an abort so the
           # retry fires either way.
-          if txn_result.nil? || (txn_result.is_a?(MultiResult) && txn_result.results.nil?)
+          if txn_result.nil? || (txn_result.is_a?(MultiResult) && txn_result.aborted?)
             raise WatchAbortError,
                   "WATCH detected concurrent modification of #{watch_keys.join(', ')}"
           end

--- a/lib/familia/multi_result.rb
+++ b/lib/familia/multi_result.rb
@@ -9,21 +9,31 @@ module Familia
   # providing access to both the command results and derived success status
   # based on the presence of errors in the results.
   #
-  # Success is determined by checking for Exception objects in the results array.
-  # When Redis commands fail within a transaction or pipeline, they return
-  # exception objects rather than raising them, allowing other commands to
-  # continue executing.
+  # A multi-command operation has three possible outcomes:
   #
-  # A third outcome exists for transactions: an *aborted* MULTI. redis-rb
-  # returns nil (not an array) from #multi when EXEC is discarded, which is the
-  # documented result of a WATCH-guarded transaction whose watched key was
-  # modified by another client. Such a result carries no command return values
-  # at all, so it is neither successful nor a carrier of errors -- see
-  # {#aborted?}.
+  # 1. **Committed cleanly** -- every queued command returned a value.
+  # 2. **Committed with errors** -- the commands ran, but one or more returned
+  #    an Exception object. Redis returns failed commands inside a transaction
+  #    as exception objects rather than raising them, so the remaining commands
+  #    still execute. {#errors} collects them.
+  # 3. **Aborted** -- EXEC was discarded and no command ran at all. This is the
+  #    documented outcome of a WATCH-guarded transaction whose watched key was
+  #    modified by another client; redis-rb signals it by returning nil instead
+  #    of an array. See {#aborted?}.
   #
-  # @attr_reader results [Array, nil] Array of return values from the Database commands.
-  #   Values can be strings, integers, booleans, or Exception objects for failed commands.
-  #   nil when the transaction was aborted before EXEC ran.
+  # An aborted operation is a failure, but not an *error* in the sense of (2):
+  # no command ran, so there is nothing for {#errors} to report. {#successful?}
+  # is the method to test for the overall outcome; {#errors?} answers the
+  # narrower question of whether any individual command failed.
+  #
+  # {#results} is always an Array -- an aborted operation reports an empty one
+  # rather than nil, so callers can index and iterate it unconditionally.
+  # Use {#aborted?} to tell an abort apart from an operation that committed
+  # zero commands.
+  #
+  # @attr_reader results [Array] Array of return values from the Database commands.
+  #   Values can be strings, integers, booleans, or Exception objects for failed
+  #   commands. Empty when the operation queued no commands or was aborted.
   #
   # @example Creating a MultiResult instance
   #   result = Familia::MultiResult.new(["OK", "OK", 1])
@@ -47,75 +57,75 @@ module Familia
   #     end
   #   end
   #
-  # @example Handling a WATCH-aborted transaction
-  #   result = Familia::MultiResult.new(nil)
-  #   result.aborted?     # => true
-  #   result.successful?  # => false
-  #   result.errors       # => []
+  # @example Distinguishing an abort from a clean commit
+  #   if result.aborted?
+  #     retry_the_transaction   # a watched key changed; nothing was applied
+  #   elsif result.errors?
+  #     report(result.errors)   # the commands ran; some of them failed
+  #   end
   #
   class MultiResult
-    # Returned by {#errors} for an aborted transaction so callers can iterate
-    # the value without a nil check. Frozen because it is shared across every
-    # aborted result.
-    NO_ERRORS = [].freeze
-
-    # @return [Array, nil] The raw return values from the Database commands,
-    #   or nil when the transaction was aborted before EXEC ran
+    # @return [Array] The raw return values from the Database commands. Always
+    #   an Array; empty for an aborted operation
     attr_reader :results
 
     # Creates a new MultiResult instance.
     #
     # @param results [Array, nil] The raw results from Database commands.
     #   Exception objects in the array indicate command failures. nil means
-    #   the transaction was discarded rather than executed (see {#aborted?}).
+    #   the transaction was discarded rather than executed, and is normalized
+    #   to an empty array with {#aborted?} recording the distinction.
     def initialize(results)
-      @results = results
+      @aborted = results.nil?
+      @results = results || []
     end
 
-    # Whether the transaction was discarded instead of executed.
+    # Whether the operation was discarded instead of executed.
     #
-    # redis-rb returns nil from #multi when EXEC is aborted, which happens
-    # when a WATCH-guarded transaction detects that a watched key changed
-    # under it. An aborted transaction applied none of its commands, so it
-    # reports no errors ({#errors} is empty) but is also not successful --
-    # callers should retry rather than treat it as a no-op success.
+    # redis-rb returns nil from #multi when EXEC is aborted, which happens when
+    # a WATCH-guarded transaction detects that a watched key changed under it.
+    # An aborted transaction applied none of its commands, so it reports no
+    # errors ({#errors} is empty) but is also not successful -- callers should
+    # retry rather than treat it as a no-op success.
     #
-    # @return [Boolean] true if no command results were returned
+    # This is the only way to distinguish an abort from an operation that
+    # committed zero commands, since both report an empty {#results}.
+    #
+    # @return [Boolean] true if EXEC was discarded before any command ran
     def aborted?
-      results.nil?
+      @aborted
     end
 
     # Returns all Exception objects from the results array.
     #
     # This method is memoized for performance when called multiple times
-    # on the same MultiResult instance.
+    # on the same MultiResult instance. The returned array is frozen: it is
+    # derived state backing that memo, not a collection for callers to modify.
     #
-    # @return [Array<Exception>] Array of exceptions that occurred during
-    #   execution; always empty for an aborted transaction, which ran no
+    # @return [Array<Exception>] Frozen array of exceptions that occurred
+    #   during execution; always empty for an aborted operation, which ran no
     #   commands and therefore produced no per-command failures
     def errors
-      return NO_ERRORS if aborted?
-
-      @errors ||= results.select { |ret| ret.is_a?(Exception) }
+      @errors ||= results.grep(Exception).freeze
     end
 
-    # Checks if any errors occurred during execution.
+    # Checks if any individual command failed.
     #
-    # An aborted transaction reports false here -- it failed, but not because
-    # a command errored. Use {#successful?} to test the overall outcome.
+    # An aborted operation reports false here -- it failed, but not because a
+    # command errored. Use {#successful?} to test the overall outcome.
     #
-    # @return [Boolean] true if at least one command failed, false otherwise
+    # @return [Boolean] true if at least one command returned an Exception
     def errors?
       !errors.empty?
     end
 
-    # Checks if all commands completed successfully (no exceptions).
+    # Checks if the operation ran and all commands completed successfully.
     #
     # This is the primary method for determining if a multi-command
     # operation completed without errors.
     #
-    # @return [Boolean] true if the transaction ran and no exceptions are in
-    #   results, false otherwise (including an aborted transaction)
+    # @return [Boolean] true if the operation ran and no exceptions are in
+    #   results, false otherwise (including an aborted operation)
     def successful?
       !aborted? && errors.empty?
     end
@@ -126,8 +136,7 @@ module Familia
     #
     # @return [Array] A tuple containing the success status and the raw results.
     #   The success status is a boolean indicating if all commands succeeded.
-    #   The raw results is an array of return values from the Database commands,
-    #   or nil for an aborted transaction.
+    #   The raw results is an array of return values from the Database commands.
     #
     # @example
     #   [true, ["OK", true, 1]]
@@ -140,18 +149,44 @@ module Familia
     # Returns the number of results in the multi-operation.
     #
     # @return [Integer] The number of individual command results returned;
-    #   0 for an aborted transaction
+    #   0 for an aborted operation
     def size
-      return 0 if aborted?
-
       results.size
     end
 
     # Returns a hash representation of the result.
     #
-    # @return [Hash] Hash with :success and :results keys
+    # Includes :aborted so a failed result is self-describing -- otherwise a
+    # dumped abort is indistinguishable from a failure whose errors went
+    # missing.
+    #
+    # @return [Hash] Hash with :success, :aborted, and :results keys
     def to_h
-      { success: successful?, results: results }
+      { success: successful?, aborted: aborted?, results: results }
+    end
+
+    # Returns a summary of the outcome for logging and debugging.
+    #
+    # Deliberately omits the command return values: they routinely carry field
+    # values read back out of the database, which have no business landing in
+    # a log line or an exception trace by default. Reach for {#results} when
+    # the values are what you actually want.
+    #
+    # @return [String] e.g. +#<Familia::MultiResult aborted size=0>+
+    def inspect
+      "#<#{self.class.name} #{outcome} size=#{size}>"
+    end
+
+    private
+
+    # One-word summary of which of the three outcomes this result represents.
+    #
+    # @return [String] 'aborted', 'errors=N', or 'ok'
+    def outcome
+      return 'aborted' if aborted?
+      return "errors=#{errors.size}" if errors?
+
+      'ok'
     end
   end
 end

--- a/lib/familia/multi_result.rb
+++ b/lib/familia/multi_result.rb
@@ -31,9 +31,13 @@ module Familia
   # Use {#aborted?} to tell an abort apart from an operation that committed
   # zero commands.
   #
-  # @attr_reader results [Array] Array of return values from the Database commands.
-  #   Values can be strings, integers, booleans, or Exception objects for failed
-  #   commands. Empty when the operation queued no commands or was aborted.
+  # Instances are read-only: {#results} and {#errors} are both frozen, since
+  # this object describes an operation that has already finished.
+  #
+  # @attr_reader results [Array] Frozen array of return values from the Database
+  #   commands. Values can be strings, integers, booleans, or Exception objects
+  #   for failed commands. Empty when the operation queued no commands or was
+  #   aborted.
   #
   # @example Creating a MultiResult instance
   #   result = Familia::MultiResult.new(["OK", "OK", 1])
@@ -66,7 +70,7 @@ module Familia
   #
   class MultiResult
     # @return [Array] The raw return values from the Database commands. Always
-    #   an Array; empty for an aborted operation
+    #   a frozen Array; empty for an aborted operation
     attr_reader :results
 
     # Creates a new MultiResult instance.
@@ -77,7 +81,13 @@ module Familia
     #   to an empty array with {#aborted?} recording the distinction.
     def initialize(results)
       @aborted = results.nil?
-      @results = results || []
+      # Frozen because this object describes an operation that already
+      # finished -- its return values are history, not a working buffer. It
+      # also keeps the memo in #errors coherent: that array is derived from
+      # this one and cached, so a caller mutating this one afterwards would
+      # leave the two disagreeing. Each instance freezes its own array rather
+      # than sharing a constant, so no two results alias the same object.
+      @results = (results || []).freeze
     end
 
     # Whether the operation was discarded instead of executed.
@@ -159,6 +169,9 @@ module Familia
     # Includes :aborted so a failed result is self-describing -- otherwise a
     # dumped abort is indistinguishable from a failure whose errors went
     # missing.
+    #
+    # The :results value is this object's own frozen array, not a copy, so a
+    # caller cannot reach through the hash to mutate internal state.
     #
     # @return [Hash] Hash with :success, :aborted, and :results keys
     def to_h

--- a/lib/familia/multi_result.rb
+++ b/lib/familia/multi_result.rb
@@ -14,8 +14,16 @@ module Familia
   # exception objects rather than raising them, allowing other commands to
   # continue executing.
   #
-  # @attr_reader results [Array] Array of return values from the Database commands.
+  # A third outcome exists for transactions: an *aborted* MULTI. redis-rb
+  # returns nil (not an array) from #multi when EXEC is discarded, which is the
+  # documented result of a WATCH-guarded transaction whose watched key was
+  # modified by another client. Such a result carries no command return values
+  # at all, so it is neither successful nor a carrier of errors -- see
+  # {#aborted?}.
+  #
+  # @attr_reader results [Array, nil] Array of return values from the Database commands.
   #   Values can be strings, integers, booleans, or Exception objects for failed commands.
+  #   nil when the transaction was aborted before EXEC ran.
   #
   # @example Creating a MultiResult instance
   #   result = Familia::MultiResult.new(["OK", "OK", 1])
@@ -39,16 +47,42 @@ module Familia
   #     end
   #   end
   #
+  # @example Handling a WATCH-aborted transaction
+  #   result = Familia::MultiResult.new(nil)
+  #   result.aborted?     # => true
+  #   result.successful?  # => false
+  #   result.errors       # => []
+  #
   class MultiResult
-    # @return [Array] The raw return values from the Database commands
+    # Returned by {#errors} for an aborted transaction so callers can iterate
+    # the value without a nil check. Frozen because it is shared across every
+    # aborted result.
+    NO_ERRORS = [].freeze
+
+    # @return [Array, nil] The raw return values from the Database commands,
+    #   or nil when the transaction was aborted before EXEC ran
     attr_reader :results
 
     # Creates a new MultiResult instance.
     #
-    # @param results [Array] The raw results from Database commands.
-    #   Exception objects in the array indicate command failures.
+    # @param results [Array, nil] The raw results from Database commands.
+    #   Exception objects in the array indicate command failures. nil means
+    #   the transaction was discarded rather than executed (see {#aborted?}).
     def initialize(results)
       @results = results
+    end
+
+    # Whether the transaction was discarded instead of executed.
+    #
+    # redis-rb returns nil from #multi when EXEC is aborted, which happens
+    # when a WATCH-guarded transaction detects that a watched key changed
+    # under it. An aborted transaction applied none of its commands, so it
+    # reports no errors ({#errors} is empty) but is also not successful --
+    # callers should retry rather than treat it as a no-op success.
+    #
+    # @return [Boolean] true if no command results were returned
+    def aborted?
+      results.nil?
     end
 
     # Returns all Exception objects from the results array.
@@ -56,12 +90,19 @@ module Familia
     # This method is memoized for performance when called multiple times
     # on the same MultiResult instance.
     #
-    # @return [Array<Exception>] Array of exceptions that occurred during execution
+    # @return [Array<Exception>] Array of exceptions that occurred during
+    #   execution; always empty for an aborted transaction, which ran no
+    #   commands and therefore produced no per-command failures
     def errors
+      return NO_ERRORS if aborted?
+
       @errors ||= results.select { |ret| ret.is_a?(Exception) }
     end
 
     # Checks if any errors occurred during execution.
+    #
+    # An aborted transaction reports false here -- it failed, but not because
+    # a command errored. Use {#successful?} to test the overall outcome.
     #
     # @return [Boolean] true if at least one command failed, false otherwise
     def errors?
@@ -73,9 +114,10 @@ module Familia
     # This is the primary method for determining if a multi-command
     # operation completed without errors.
     #
-    # @return [Boolean] true if no exceptions in results, false otherwise
+    # @return [Boolean] true if the transaction ran and no exceptions are in
+    #   results, false otherwise (including an aborted transaction)
     def successful?
-      errors.empty?
+      !aborted? && errors.empty?
     end
     alias success? successful?
     alias areyouhappynow? successful?
@@ -84,7 +126,8 @@ module Familia
     #
     # @return [Array] A tuple containing the success status and the raw results.
     #   The success status is a boolean indicating if all commands succeeded.
-    #   The raw results is an array of return values from the Database commands.
+    #   The raw results is an array of return values from the Database commands,
+    #   or nil for an aborted transaction.
     #
     # @example
     #   [true, ["OK", true, 1]]
@@ -96,8 +139,11 @@ module Familia
 
     # Returns the number of results in the multi-operation.
     #
-    # @return [Integer] The number of individual command results returned
+    # @return [Integer] The number of individual command results returned;
+    #   0 for an aborted transaction
     def size
+      return 0 if aborted?
+
       results.size
     end
 

--- a/try/unit/horreum/serialization_try.rb
+++ b/try/unit/horreum/serialization_try.rb
@@ -71,7 +71,7 @@ Familia.dbclient.set('debug:ending_save_if_not_exists_tests', Familia.now.to_s)
 # name already exists (returns 0).
 @result = @customer.multi_field_update(name: 'Jane Windows', email: 'jane@example.com')
 @result.to_h
-#=> {:success=>true, :results=>[0, 1, false, true]}
+#=> {:success=>true, :aborted=>false, :results=>[0, 1, false, true]}
 
 ## multi_field_update returns successful result, successful?
 @result.successful?
@@ -185,7 +185,7 @@ result.successful?
 @fresh_customer.remove_field('planid')
 @fresh_result = @fresh_customer.multi_field_update(role: 'admin', planid: 'premium')
 @fresh_result.to_h
-#=> {:success=>true, :results=>[1, 1, true, true]}
+#=> {:success=>true, :aborted=>false, :results=>[1, 1, true, true]}
 
 ## Fresh customer fields are set correctly
 [@fresh_customer.role, @fresh_customer.planid]

--- a/try/unit/multi_result_try.rb
+++ b/try/unit/multi_result_try.rb
@@ -6,11 +6,15 @@
 # transaction or a pipeline.
 #
 # Three outcomes are distinguished:
-#   - committed cleanly    -> results is an array with no Exception members
-#   - committed with errors -> results is an array containing Exception objects
-#   - aborted (issue #355)  -> results is nil, because redis-rb returns nil from
-#     #multi when EXEC is discarded (a WATCH-guarded transaction whose watched
-#     key changed under it). Accessors must report failure, not raise.
+#   - committed cleanly     -> results has no Exception members
+#   - committed with errors  -> results contains Exception objects
+#   - aborted (issue #355)   -> redis-rb returned nil from #multi because EXEC
+#     was discarded (a WATCH-guarded transaction whose watched key changed
+#     under it). Accessors must report failure, not raise.
+#
+# #results is normalized to an Array in every case, so callers can index and
+# iterate it unconditionally; #aborted? carries the abort/empty-commit
+# distinction that the nil used to carry.
 
 require_relative '../support/helpers/test_helpers'
 
@@ -53,9 +57,13 @@ require_relative '../support/helpers/test_helpers'
 @ok.tuple
 #=> [true, ['OK', 'OK', 1]]
 
-## A clean result hashes to success: true
+## A clean result hashes to success: true, aborted: false
 @ok.to_h
-#=> { success: true, results: ['OK', 'OK', 1]  }
+#=> { success: true, aborted: false, results: ['OK', 'OK', 1] }
+
+## A clean result inspects without dumping the command return values
+@ok.inspect
+#=> '#<Familia::MultiResult ok size=3>'
 
 # ============================================================
 # Results carrying command errors
@@ -81,8 +89,12 @@ require_relative '../support/helpers/test_helpers'
 @failed.size
 #=> 3
 
+## A result with an Exception member inspects with the error count
+@failed.inspect
+#=> '#<Familia::MultiResult errors=1 size=3>'
+
 # ============================================================
-# Empty results (a transaction that queued no commands)
+# Empty results (an operation that queued no commands)
 # ============================================================
 
 ## An empty result is successful -- nothing ran, nothing failed
@@ -98,7 +110,7 @@ require_relative '../support/helpers/test_helpers'
 #=> 0
 
 # ============================================================
-# Aborted results (nil) -- issue #355
+# Aborted results -- issue #355
 # ============================================================
 
 ## An aborted result reports aborted?
@@ -125,40 +137,84 @@ require_relative '../support/helpers/test_helpers'
 @aborted.errors?
 #=> false
 
-## The empty errors array is frozen, since it is shared across aborted results
-@aborted.errors.frozen?
-#=> true
-
 ## An aborted result has size zero (previously raised)
 @aborted.size
 #=> 0
 
-## An aborted result preserves nil in #results, so callers can tell it apart
-## from a transaction that committed zero commands
-@aborted.results
-#=> nil
+## An aborted result normalizes nil to an empty array, so callers can index
+## and iterate #results without a nil check
+[@aborted.results, @aborted.results[0], @aborted.results.map(&:to_s)]
+#=> [[], nil, []]
 
-## An aborted result tuples to [false, nil]
+## An aborted result tuples to [false, []]
 @aborted.tuple
-#=> [false, nil]
+#=> [false, []]
 
 ## to_a is the tuple alias and also survives an aborted result
 @aborted.to_a
-#=> [false, nil]
+#=> [false, []]
 
-## An aborted result hashes to success: false (previously raised)
+## An aborted result hashes to success: false, aborted: true -- a dumped
+## failure has to say WHY it failed, or it reads as errors gone missing
 @aborted.to_h
-#=> { success: false, results: nil }
+#=> { success: false, aborted: true, results: [] }
+
+## An aborted result inspects as aborted
+@aborted.inspect
+#=> '#<Familia::MultiResult aborted size=0>'
 
 ## Repeated calls stay stable -- memoization must not cache a bad value
 [@aborted.errors, @aborted.errors, @aborted.successful?, @aborted.successful?]
 #=> [[], [], false, false]
 
 # ============================================================
+# Abort vs. zero-command commit
+# ============================================================
+
+## An abort and an empty commit both report an empty #results, so #aborted?
+## is the only thing that separates them -- the distinction the raw nil used
+## to carry has to survive the normalization
+[@aborted.results, @empty.results]
+#=> [[], []]
+
+## ... and it does: only one of them is an abort, and only one is successful
+[@aborted.aborted?, @empty.aborted?, @aborted.successful?, @empty.successful?]
+#=> [true, false, false, true]
+
+# ============================================================
+# #errors is frozen on every path
+# ============================================================
+
+## #errors is frozen for a clean result
+@ok.errors.frozen?
+#=> true
+
+## #errors is frozen for a result carrying command errors
+@failed.errors.frozen?
+#=> true
+
+## #errors is frozen for an aborted result, so mutating it fails the same way
+## regardless of outcome rather than only on some
+@aborted.errors.frozen?
+#=> true
+
+## Mutating #errors raises rather than silently corrupting the memo
+@ok.errors << 'nope'
+#=!> FrozenError
+
+## #results stays mutable, and each result owns its own array -- normalizing
+## must not hand every aborted result the same shared object
+a = Familia::MultiResult.new(nil)
+b = Familia::MultiResult.new(nil)
+a.results << 'local'
+[a.results, b.results, a.results.frozen?]
+#=> [['local'], [], false]
+
+# ============================================================
 # Real WATCH-aborted MULTI against the database
 # ============================================================
 
-## A WATCH abort really does produce a MultiResult wrapping nil.
+## A WATCH abort really does produce an aborted MultiResult.
 ## Drive WATCH + MULTI/EXEC on one connection while a SECOND connection
 ## dirties the watched key inside the WATCH window, so Redis discards EXEC.
 @conn = Redis.new(url: Familia.uri.to_s)
@@ -170,12 +226,12 @@ require_relative '../support/helpers/test_helpers'
     txn.set(@watch_key, 'from-transaction')
   end
 end
-[@real_abort.class, @real_abort.results]
-#=> [Familia::MultiResult, nil]
+[@real_abort.class, @real_abort.aborted?]
+#=> [Familia::MultiResult, true]
 
 ## The aborted transaction reports failure rather than raising NoMethodError
-[@real_abort.successful?, @real_abort.errors, @real_abort.errors?, @real_abort.size]
-#=> [false, [], false, 0]
+[@real_abort.successful?, @real_abort.errors, @real_abort.errors?, @real_abort.size, @real_abort.results]
+#=> [false, [], false, 0, []]
 
 ## The aborted transaction applied none of its commands
 @conn.get(@watch_key)
@@ -193,7 +249,7 @@ end
 
 ## execute_watched_transaction turns the abort into a retry, then raises
 ## OptimisticLockError once attempts are exhausted -- it must not crash on
-## the nil-carrying MultiResult it inspects to detect the abort.
+## the aborted MultiResult it inspects to detect the abort.
 @attempts = 0
 begin
   Familia::Connection::TransactionCore.execute_watched_transaction(

--- a/try/unit/multi_result_try.rb
+++ b/try/unit/multi_result_try.rb
@@ -1,0 +1,220 @@
+# try/unit/multi_result_try.rb
+#
+# frozen_string_literal: true
+
+# Tests for Familia::MultiResult - wraps the return values of a MULTI/EXEC
+# transaction or a pipeline.
+#
+# Three outcomes are distinguished:
+#   - committed cleanly    -> results is an array with no Exception members
+#   - committed with errors -> results is an array containing Exception objects
+#   - aborted (issue #355)  -> results is nil, because redis-rb returns nil from
+#     #multi when EXEC is discarded (a WATCH-guarded transaction whose watched
+#     key changed under it). Accessors must report failure, not raise.
+
+require_relative '../support/helpers/test_helpers'
+
+@ok = Familia::MultiResult.new(['OK', 'OK', 1])
+@failed = Familia::MultiResult.new(['OK', Redis::CommandError.new('WRONGTYPE'), 1])
+@empty = Familia::MultiResult.new([])
+@aborted = Familia::MultiResult.new(nil)
+
+@watch_key = 'multiresult:watch_abort'
+
+# ============================================================
+# Clean results
+# ============================================================
+
+## A clean result exposes the raw command return values
+@ok.results
+#=> ['OK', 'OK', 1]
+
+## A clean result is successful
+@ok.successful?
+#=> true
+
+## A clean result has no errors
+@ok.errors
+#=> []
+
+## A clean result reports errors? false
+@ok.errors?
+#=> false
+
+## A clean result is not aborted
+@ok.aborted?
+#=> false
+
+## A clean result counts its command return values
+@ok.size
+#=> 3
+
+## A clean result tuples to [true, results]
+@ok.tuple
+#=> [true, ['OK', 'OK', 1]]
+
+## A clean result hashes to success: true
+@ok.to_h
+#=> { success: true, results: ['OK', 'OK', 1]  }
+
+# ============================================================
+# Results carrying command errors
+# ============================================================
+
+## A result with an Exception member collects it in errors
+@failed.errors.size
+#=> 1
+
+## A result with an Exception member reports errors?
+@failed.errors?
+#=> true
+
+## A result with an Exception member is not successful
+@failed.successful?
+#=> false
+
+## A result with an Exception member is not aborted -- the commands did run
+@failed.aborted?
+#=> false
+
+## A result with an Exception member still counts every return value
+@failed.size
+#=> 3
+
+# ============================================================
+# Empty results (a transaction that queued no commands)
+# ============================================================
+
+## An empty result is successful -- nothing ran, nothing failed
+@empty.successful?
+#=> true
+
+## An empty result is not aborted
+@empty.aborted?
+#=> false
+
+## An empty result has size zero
+@empty.size
+#=> 0
+
+# ============================================================
+# Aborted results (nil) -- issue #355
+# ============================================================
+
+## An aborted result reports aborted?
+@aborted.aborted?
+#=> true
+
+## An aborted result is NOT successful (previously raised NoMethodError)
+@aborted.successful?
+#=> false
+
+## success? alias agrees with successful? on an aborted result
+@aborted.success?
+#=> false
+
+## areyouhappynow? alias agrees with successful? on an aborted result
+@aborted.areyouhappynow?
+#=> false
+
+## An aborted result returns an empty errors array (previously raised)
+@aborted.errors
+#=> []
+
+## An aborted result reports errors? false -- it failed, but no command errored
+@aborted.errors?
+#=> false
+
+## The empty errors array is frozen, since it is shared across aborted results
+@aborted.errors.frozen?
+#=> true
+
+## An aborted result has size zero (previously raised)
+@aborted.size
+#=> 0
+
+## An aborted result preserves nil in #results, so callers can tell it apart
+## from a transaction that committed zero commands
+@aborted.results
+#=> nil
+
+## An aborted result tuples to [false, nil]
+@aborted.tuple
+#=> [false, nil]
+
+## to_a is the tuple alias and also survives an aborted result
+@aborted.to_a
+#=> [false, nil]
+
+## An aborted result hashes to success: false (previously raised)
+@aborted.to_h
+#=> { success: false, results: nil }
+
+## Repeated calls stay stable -- memoization must not cache a bad value
+[@aborted.errors, @aborted.errors, @aborted.successful?, @aborted.successful?]
+#=> [[], [], false, false]
+
+# ============================================================
+# Real WATCH-aborted MULTI against the database
+# ============================================================
+
+## A WATCH abort really does produce a MultiResult wrapping nil.
+## Drive WATCH + MULTI/EXEC on one connection while a SECOND connection
+## dirties the watched key inside the WATCH window, so Redis discards EXEC.
+@conn = Redis.new(url: Familia.uri.to_s)
+@racer = Redis.new(url: Familia.uri.to_s)
+@conn.set(@watch_key, 'original')
+@real_abort = @conn.watch(@watch_key) do
+  @racer.set(@watch_key, 'changed-by-racer')
+  Familia::Connection::TransactionCore.execute_normal_transaction(-> { @conn }) do |txn|
+    txn.set(@watch_key, 'from-transaction')
+  end
+end
+[@real_abort.class, @real_abort.results]
+#=> [Familia::MultiResult, nil]
+
+## The aborted transaction reports failure rather than raising NoMethodError
+[@real_abort.successful?, @real_abort.errors, @real_abort.errors?, @real_abort.size]
+#=> [false, [], false, 0]
+
+## The aborted transaction applied none of its commands
+@conn.get(@watch_key)
+#=> 'changed-by-racer'
+
+## An uncontended WATCH-guarded transaction still commits normally
+@conn.set(@watch_key, 'original')
+@committed = @conn.watch(@watch_key) do
+  Familia::Connection::TransactionCore.execute_normal_transaction(-> { @conn }) do |txn|
+    txn.set(@watch_key, 'from-transaction')
+  end
+end
+[@committed.aborted?, @committed.successful?, @conn.get(@watch_key)]
+#=> [false, true, 'from-transaction']
+
+## execute_watched_transaction turns the abort into a retry, then raises
+## OptimisticLockError once attempts are exhausted -- it must not crash on
+## the nil-carrying MultiResult it inspects to detect the abort.
+@attempts = 0
+begin
+  Familia::Connection::TransactionCore.execute_watched_transaction(
+    -> { @conn }, watch_keys: [@watch_key], max_attempts: 2
+  ) do |conn|
+    @attempts += 1
+    @racer.set(@watch_key, "racer-#{@attempts}")
+    Familia::Connection::TransactionCore.execute_normal_transaction(-> { conn }) do |txn|
+      txn.set(@watch_key, 'should-not-persist')
+    end
+  end
+  :no_raise
+rescue Familia::OptimisticLockError
+  :raised
+end
+#=> :raised
+
+## Both attempts ran and the racer's value survived (no silent overwrite)
+[@attempts, @racer.get(@watch_key)]
+#=> [2, 'racer-2']
+
+@conn.del(@watch_key)
+@conn.close
+@racer.close

--- a/try/unit/multi_result_try.rb
+++ b/try/unit/multi_result_try.rb
@@ -182,7 +182,7 @@ require_relative '../support/helpers/test_helpers'
 #=> [true, false, false, true]
 
 # ============================================================
-# #errors is frozen on every path
+# A result is read-only -- it describes a finished operation
 # ============================================================
 
 ## #errors is frozen for a clean result
@@ -202,13 +202,35 @@ require_relative '../support/helpers/test_helpers'
 @ok.errors << 'nope'
 #=!> FrozenError
 
-## #results stays mutable, and each result owns its own array -- normalizing
-## must not hand every aborted result the same shared object
+## #results is frozen too. #errors is a memo derived from it, so a result
+## whose #results could still change after #errors was computed could hold
+## the two disagreeing -- freezing the source makes that unreachable.
+@ok.results << 'nope'
+#=!> FrozenError
+
+## The memo and its source cannot drift: appending an Exception to #results
+## after #errors is computed is refused outright rather than silently leaving
+## a stale error list behind
+drifter = Familia::MultiResult.new(['OK'])
+before = drifter.errors.size
+begin
+  drifter.results << Redis::CommandError.new('late')
+rescue FrozenError
+  :refused
+end.then { |outcome| [before, outcome, drifter.errors.size, drifter.successful?] }
+#=> [0, :refused, 0, true]
+
+## to_h hands out that same frozen array, so a caller cannot reach through
+## the hash to mutate internal state
+@ok.to_h[:results] << 'nope'
+#=!> FrozenError
+
+## Each result still owns its own array -- normalizing must not hand every
+## aborted result one shared object
 a = Familia::MultiResult.new(nil)
 b = Familia::MultiResult.new(nil)
-a.results << 'local'
-[a.results, b.results, a.results.frozen?]
-#=> [['local'], [], false]
+[a.results, b.results, a.results.equal?(b.results), a.results.frozen?]
+#=> [[], [], false, true]
 
 # ============================================================
 # Real WATCH-aborted MULTI against the database


### PR DESCRIPTION
Fixes #355.

## Problem

redis-rb returns `nil` — not an array — from `#multi` when `EXEC` is discarded. That is the documented outcome of a WATCH-guarded transaction whose watched key was modified by another client. `MultiResult.new(nil)` accepted it happily, and then every accessor that touched `@results` raised:

```ruby
result = Familia::MultiResult.new(nil)
result.errors       # NoMethodError: undefined method 'select' for nil
result.successful?  # NoMethodError (via #errors)
result.size         # NoMethodError
result.to_h         # NoMethodError (via #successful?)
```

So a caller doing exactly the right thing — checking `result.successful?` and retrying on contention — crashed precisely when contention occurred.

## Fix

A multi-command operation has three outcomes, and `MultiResult` now models all three:

| results | `aborted?` | `successful?` | `errors` | `errors?` | `size` |
|---|---|---|---|---|---|
| `["OK", 1]` | false | true | `[]` | false | 2 |
| `["OK", <Exception>]` | false | false | `[<Exception>]` | true | 2 |
| `[]` | false | true | `[]` | false | 0 |
| `nil` | **true** | **false** | `[]` | **false** | 0 |

**`#results` is normalized to an Array.** It previously exposed redis-rb's raw return value, which pushed a nil check onto every caller that indexes or iterates it — the same class of crash as the bug being fixed, one level out. Consumers reach for it exactly that way: `management.rb` `load_multi` does `results[i]`, `expiration.rb` does `ttl_values[0]`. Once `#aborted?` exists the nil is redundant state, a second encoding of a fact an explicit predicate already carries. Abortedness is captured at construction; the distinction the nil carried survives, the nil does not.

**`errors?` stays false for an abort** while `successful?` is false. An aborted transaction ran no commands, so no command errored, and the invariant `errors? == !errors.empty?` holds. Breaking it would make the class's own documented idiom silently wrong — `if result.errors?` followed by `result.errors.each` would iterate zero times. `successful?` is the method to test for the overall outcome; `errors?` answers the narrower question.

That asymmetry is only safe if abortedness is legible elsewhere, so:

- **`to_h` carries `:aborted`.** It previously returned `{success: false, results: nil}` — the exact hash that lands in a bug report — with no indication of *why* it failed, reading as a failure whose errors went missing.
- **`inspect` summarizes the outcome** (`#<Familia::MultiResult aborted size=0>`) instead of the default object dump. It omits the command return values deliberately: those routinely carry field values read back out of the database and have no business in a log line by default.
- **`#errors` is frozen on every path**, not just for aborts — mutating it used to succeed or raise depending on the outcome. It backs a memo, so mutating it was never meaningful. `#results` stays mutable and per-instance.

`TransactionCore.execute_watched_transaction` previously probed `results.nil?` by hand to detect the abort and fire its retry; it now asks `#aborted?`. The existing nil-tolerant call sites (`persisted_successfully?`, `atomic_write_success?`, `Operations#atomic_write`) already delegated to `successful?` for a `MultiResult` and now get a correct `false` instead of an exception, with no change needed.

## Public API changes

Both are documented with before/after in the changelog fragment:

- `#results` returns `[]` where it returned `nil`. Code testing `results.nil?` to detect an abort should call `aborted?`. An abort and a zero-command commit both report `[]` — `aborted?` is what separates them.
- `#to_h` gained a key. Code comparing the hash by equality needs it (the two `serialization_try.rb` cases doing so are updated in this PR).

Happy to promote the `Changed` section into `docs/migrating/` if you'd rather it land there at release.

## Testing

New `try/unit/multi_result_try.rb` — 44 testcases covering clean, error-carrying, empty, and aborted results across every accessor and alias, that an abort stays distinguishable from a zero-command commit, and the freezing/aliasing behavior of `errors` and `results`. Plus a real WATCH-aborted `MULTI` driven against the database from two connections:

- a second connection dirties the watched key inside the WATCH window, Redis discards `EXEC`, and the resulting `MultiResult` reports `aborted?` — accessors report failure rather than raising, and none of the transaction's commands were applied
- an uncontended WATCH-guarded transaction still commits normally
- `execute_watched_transaction` retries on the abort and raises `Familia::OptimisticLockError` once attempts are exhausted, without crashing on the aborted `MultiResult` it inspects

Verified red before the fix and green after.

Full suite: `5989 passed, 9 failed, 1 error` — the same 10 as on `main`, confirmed pre-existing by re-running those files with this branch's `lib/` changes stashed. They live in `try/features/encryption/encoding_phase{1,2}_try.rb`, `try/integration/examples/relationships_example_try.rb`, and `try/unit/data_types/stringkey_extended_try.rb`, none of which touch `MultiResult`.

`rubocop` is clean on `lib/familia/multi_result.rb` — including the pre-existing `Style/SelectByKind` offense, now resolved since the method was being rewritten anyway.
