### PR TITLE
[#358] Fix connection_provider examples that return a checked-in connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -377,12 +377,23 @@ end
 ```ruby
 require 'connection_pool'
 
+POOLS = {}
+POOLS_MUTEX = Mutex.new
+
 Familia.connection_provider = lambda do |uri|
-  ConnectionPool.new(size: 10, timeout: 5) do
-    Redis.new(url: uri)
-  end.with { |conn| yield conn if block_given?; conn }
+  POOLS_MUTEX.synchronize do
+    POOLS[uri] ||= ConnectionPool::Wrapper.new(size: 10, timeout: 5) do
+      Redis.new(url: uri)
+    end
+  end
 end
 ```
+
+Build each pool once, outside the lambda, and return a `ConnectionPool::Wrapper`
+— it checks a connection out for the duration of each command and checks it back
+in afterwards. Returning `pool.with { |conn| conn }` instead hands back a
+connection the pool already considers free, so concurrent callers share it. See
+[the provider contract](docs/reference/api-technical.md#provider-contract).
 
 ### Encryption Setup
 

--- a/changelog.d/20260730_233000_claude_358_connection_provider_doc_example.rst
+++ b/changelog.d/20260730_233000_claude_358_connection_provider_doc_example.rst
@@ -1,0 +1,6 @@
+Documentation
+-------------
+
+- Fixed the ``connection_provider`` examples, which ended with
+  ``pool.with { |conn| conn }`` -- a connection the pool has already checked
+  back in, so concurrent callers share it. #358

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -87,15 +87,18 @@ end
 ### Connection Pooling (Performance)
 ```ruby
 # Configure connection provider for multi-database pooling
+POOLS = {}
+POOLS_MUTEX = Mutex.new
+
 Familia.connection_provider = lambda do |uri|
-  parsed = URI.parse(uri) # => URI::Redis
-  pool_key = "#{parsed.host}:#{parsed.port}/#{parsed.db || 0}"
-
-  @pools[pool_key] ||= ConnectionPool.new(size: 10) do
-    Redis.new(host: parsed.host, port: parsed.port, db: parsed.db || 0)
+  # One wrapper per URI, built once. The wrapper checks a connection out for
+  # each command and back in afterwards; `pool.with { |conn| conn }` would
+  # hand back a connection the pool already considers free.
+  POOLS_MUTEX.synchronize do
+    POOLS[uri] ||= ConnectionPool::Wrapper.new(size: 10, timeout: 5) do
+      Redis.new(url: uri) # uri already carries the logical database
+    end
   end
-
-  @pools[pool_key].with { |conn| conn }
 end
 ```
 

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -618,16 +618,21 @@ Configure connection pooling for production environments:
 require 'connection_pool'
 
 pools = {
-  "redis://localhost:6379/0" => ConnectionPool.new(size: 10) { Redis.new(db: 0) }
+  'redis://localhost:6379/0' => ConnectionPool::Wrapper.new(size: 10) { Redis.new(db: 0) }
 }
 
 Familia.connection_provider = lambda do |uri|
-  pool = pools[uri]
-  pool.with { |conn| conn }
+  pools.fetch(uri)
 end
 ```
 
 This ensures efficient Valkey connection usage in multi-threaded applications.
+
+The provider hands back a `ConnectionPool::Wrapper`, which checks a connection
+out for the duration of each command and checks it back in afterwards. Do not
+return `pool.with { |conn| conn }`: `with` checks the connection back in when
+its block returns, so the client Familia receives is simultaneously available to
+other callers. See [the provider contract](reference/api-technical.md#provider-contract).
 
 ### Encrypted Fields
 
@@ -776,15 +781,15 @@ end
 # Multi-database with connection pooling
 require 'connection_pool'
 
-primary_pool = ConnectionPool.new(size: 20) { Redis.new(url: ENV['PRIMARY_REDIS_URL']) }
-cache_pool = ConnectionPool.new(size: 10) { Redis.new(url: ENV['CACHE_REDIS_URL']) }
+primary_pool = ConnectionPool::Wrapper.new(size: 20) { Redis.new(url: ENV['PRIMARY_REDIS_URL']) }
+cache_pool = ConnectionPool::Wrapper.new(size: 10) { Redis.new(url: ENV['CACHE_REDIS_URL']) }
 
 Familia.connection_provider = lambda do |uri|
   case uri
   when /primary/
-    primary_pool.with { |conn| yield conn }
+    primary_pool
   when /cache/
-    cache_pool.with { |conn| yield conn }
+    cache_pool
   else
     Redis.new(url: uri)
   end

--- a/docs/reference/api-technical.md
+++ b/docs/reference/api-technical.md
@@ -610,23 +610,71 @@ end
 # Custom connection provider with pooling
 require 'connection_pool'
 
+POOLS = {}
+POOLS_MUTEX = Mutex.new
+
 Familia.connection_provider = lambda do |uri|
-  # Provider MUST return connection already on correct database
-  parsed = URI.parse(uri)
-  pool_key = "#{parsed.host}:#{parsed.port}/#{parsed.db || 0}"
-
-  @pools ||= {}
-  @pools[pool_key] ||= ConnectionPool.new(size: 10, timeout: 5) do
-    Redis.new(
-      host: parsed.host,
-      port: parsed.port,
-      db: parsed.db || 0
-    )
+  # Provider MUST return a connection already on the correct database.
+  # Build each pool ONCE and hand back a wrapper (see the contract below).
+  POOLS_MUTEX.synchronize do
+    POOLS[uri] ||= ConnectionPool::Wrapper.new(size: 10, timeout: 5) do
+      Redis.new(url: uri)
+    end
   end
-
-  @pools[pool_key].with { |conn| conn }
 end
 ```
+
+#### Provider contract
+
+Familia calls the provider every time it needs a client and never hands the
+connection back — there is no check-in hook. The provider must therefore return
+a client that stays exclusively usable by the caller without a matching
+check-in, and it must not build a new pool per call.
+
+**Do not do this:**
+
+```ruby
+Familia.connection_provider = lambda do |uri|
+  pool = ConnectionPool.new { Redis.new(url: uri) }  # a new pool every call
+  pool.with { |conn| conn }                          # checked back in already
+end
+```
+
+`ConnectionPool#with` checks the connection back in the moment its block
+returns, so the client handed to Familia is simultaneously available to every
+other checkout — the pool reports it as free while Familia is still using it:
+
+```ruby
+pool = ConnectionPool.new(size: 5) { Redis.new }
+conn = pool.with { |c| c }
+pool.available  # => 5 of 5 — nothing is checked out, yet `conn` is in use
+```
+
+Under concurrency two threads then issue commands on one connection, and
+per-connection state (MULTI, WATCH, SELECT, SUBSCRIBE) crosses callers.
+
+**Use `ConnectionPool::Wrapper`** (alias `ConnectionPool.wrap`) instead. It
+proxies each command through `pool.with`, so a connection is checked out for
+exactly the duration of that command and checked back in afterwards.
+ConnectionPool's checkout is reentrant per fiber, so a MULTI/EXEC, a pipeline,
+or a WATCH-guarded transaction still runs entirely on one connection.
+
+**Or check out explicitly** when a request should pin one connection for its
+whole lifetime — then the checkout is yours to release at the boundary:
+
+```ruby
+Familia.connection_provider = ->(uri) { POOLS.fetch(uri).checkout }
+
+# Rack middleware / job wrapper
+def call(env)
+  @app.call(env)
+ensure
+  POOLS.each_value { |pool| pool.checkin(force: true) }
+end
+```
+
+Without that `ensure`, a bare `pool.checkout` in the provider leaks a
+connection on every call and the pool exhausts.
 
 ### Multi-Database Support
 Configure different logical databases for different models.
@@ -1120,19 +1168,22 @@ Configure connection pools based on application needs.
 
 ```ruby
 # High-throughput application
-Familia.connection_provider = lambda do |uri|
-  ConnectionPool.new(size: 25, timeout: 5) do
-    Redis.new(url: uri)
-  end.with { |conn| conn }
+HIGH_THROUGHPUT_POOL = ConnectionPool::Wrapper.new(size: 25, timeout: 5) do
+  Redis.new(url: ENV['REDIS_URL'])
 end
+Familia.connection_provider = ->(_uri) { HIGH_THROUGHPUT_POOL }
 
 # Memory-constrained environment
-Familia.connection_provider = lambda do |uri|
-  ConnectionPool.new(size: 5, timeout: 10) do
-    Redis.new(url: uri)
-  end.with { |conn| conn }
+SMALL_POOL = ConnectionPool::Wrapper.new(size: 5, timeout: 10) do
+  Redis.new(url: ENV['REDIS_URL'])
 end
+Familia.connection_provider = ->(_uri) { SMALL_POOL }
 ```
+
+Both build the pool once at boot. A single-pool provider like this ignores the
+`uri` it is given, so it only works when every model shares one logical
+database; see [Connection Provider Pattern](#connection-provider-pattern) for
+the per-URI form.
 
 ---
 

--- a/lib/familia/connection.rb
+++ b/lib/familia/connection.rb
@@ -34,11 +34,57 @@ module Familia
     # The provider should accept a URI string and return a Redis connection
     # already connected to the correct database specified in the URI.
     #
+    # ## Contract
+    #
+    # Familia calls the provider every time it needs a client and never hands
+    # the connection back -- there is no check-in hook. The provider must
+    # therefore return a client that remains exclusively usable by the caller
+    # without a matching check-in.
+    #
+    # `pool.with { |conn| conn }` does NOT satisfy that contract: `with` checks
+    # the connection back in the moment its block returns, so the client handed
+    # to Familia is simultaneously available to every other checkout. Under
+    # concurrency two threads end up issuing commands on one connection, and
+    # per-connection state (MULTI, WATCH, SELECT, SUBSCRIBE) crosses callers.
+    #
+    # `ConnectionPool::Wrapper` (alias `ConnectionPool.wrap`) does satisfy it:
+    # it proxies each command through `pool.with`, so a connection is checked
+    # out for exactly the duration of that command and checked back in
+    # afterwards. ConnectionPool's checkout is reentrant per fiber, so a
+    # MULTI/EXEC, a pipeline, or a WATCH-guarded transaction still runs
+    # entirely on one connection.
+    #
+    # Build the pool once, outside the lambda. A `ConnectionPool.new` inside
+    # the provider mints a fresh pool -- and eventually a fresh connection --
+    # on every call.
+    #
     # @example Setting a connection provider
-    #   Familia.connection_provider = ->(uri) do
-    #     pool = ConnectionPool.new { Redis.new(url: uri) }
-    #     pool.with { |conn| conn }
+    #   require 'connection_pool'
+    #
+    #   POOLS = {}
+    #   POOLS_MUTEX = Mutex.new
+    #
+    #   Familia.connection_provider = lambda do |uri|
+    #     POOLS_MUTEX.synchronize do
+    #       POOLS[uri] ||= ConnectionPool::Wrapper.new(size: 10, timeout: 5) do
+    #         Redis.new(url: uri) # uri already carries the logical database
+    #       end
+    #     end
     #   end
+    #
+    # @example Holding one connection per unit of work
+    #   # When a request should pin a single connection, check out in the
+    #   # provider and check back in at the boundary. Without the check-in a
+    #   # bare `checkout` leaks a connection per call and the pool exhausts.
+    #   Familia.connection_provider = ->(uri) { POOLS.fetch(uri).checkout }
+    #
+    #   def call(env)  # Rack middleware / job wrapper
+    #     @app.call(env)
+    #   ensure
+    #     POOLS.each_value { |pool| pool.checkin(force: true) }
+    #   end
+    #
+    # @see docs/reference/api-technical.md#connection-provider-pattern
     attr_reader :connection_provider
 
     # Sets the connection provider and bumps middleware version

--- a/lib/familia/connection/middleware.rb
+++ b/lib/familia/connection/middleware.rb
@@ -77,8 +77,10 @@ module Familia
       #   Familia.reconnect!
       #
       # @example In test suites
-      #   # Test file A creates pools
-      #   Familia.connection_provider = ->(uri) { pool.with { |c| c } }
+      #   # Test file A creates pools (values are ConnectionPool::Wrapper --
+      #   # see Familia.connection_provider for why `pool.with { |c| c }` is not
+      #   # a valid provider)
+      #   Familia.connection_provider = ->(uri) { pools.fetch(uri) }
       #
       #   # Test file B enables middleware
       #   Familia.enable_database_logging = true

--- a/lib/familia/connection/operations.rb
+++ b/lib/familia/connection/operations.rb
@@ -387,8 +387,15 @@ module Familia
       # Provides explicit access to a Database connection.
       #
       # This method is useful when you need direct access to a connection
-      # for operations not covered by other methods. The connection is
-      # properly managed and returned to the pool (if using connection_provider).
+      # for operations not covered by other methods. It resolves the client
+      # through the same chain as {#dbclient}.
+      #
+      # @note The block is not pinned to one connection. Familia has no
+      #   check-in hook, so a pooled provider hands back a per-command proxy
+      #   (see {Familia::Connection#connection_provider}) and successive
+      #   commands in the block may run on different connections. When several
+      #   commands must share one connection -- WATCH, MULTI, SUBSCRIBE --
+      #   use {#transaction}, {#pipelined}, or check out from your own pool.
       #
       # @yield [Redis] A Database connection
       # @return The result of the block

--- a/try/integration/connection/pools_try.rb
+++ b/try/integration/connection/pools_try.rb
@@ -14,20 +14,27 @@ require_relative '../../support/helpers/test_helpers'
 # Configure connection pooling via connection_provider
 require 'connection_pool'
 
-# Create pools for each logical database
+# Create pools for each logical database.
+#
+# Each pool is built ONCE per URI and the provider returns a
+# ConnectionPool::Wrapper, which checks a connection out for the duration of
+# each command and checks it back in afterwards. Returning
+# `pool.with { |conn| conn }` would hand back a connection the pool already
+# considers available, so concurrent callers would share it (issue #358).
 @pools = {}
+@pools_mutex = Mutex.new
 
 Familia.connection_provider = lambda do |uri|
-  @pools[uri] ||= ConnectionPool.new(size: 5, timeout: 2) do
-    parsed = URI.parse(uri)
-    Redis.new(
-      host: parsed.host,
-      port: parsed.port,
-      db: parsed.db || 0
-    )
+  @pools_mutex.synchronize do
+    @pools[uri] ||= ConnectionPool::Wrapper.new(size: 5, timeout: 2) do
+      parsed = URI.parse(uri)
+      Redis.new(
+        host: parsed.host,
+        port: parsed.port,
+        db: parsed.db || 0
+      )
+    end
   end
-
-  @pools[uri].with { |conn| conn }
 end
 
 # Test model for connection pool testing


### PR DESCRIPTION
Fixes #358. Docs + one tryout; no runtime behaviour changes.

## The bug

Every documented `connection_provider` ended with `pool.with { |conn| conn }`. `ConnectionPool#with` checks the connection back in the moment its block returns, so the client Familia received was simultaneously available to every other checkout:

```ruby
pool = ConnectionPool.new(size: 5) { Redis.new }
conn = pool.with { |c| c }
pool.available  # => 5 of 5 — nothing checked out, yet `conn` is in use
```

Reproduced against a live server: two "checkouts" through that provider handed back the same object while the pool reported every connection free. Under concurrency two threads then issue commands on one connection and per-connection state (MULTI, WATCH, SELECT, SUBSCRIBE) crosses callers. Anyone building a provider from the example inherited the race.

Two other defects rode along in the same examples:

- `ConnectionPool.new` **inside** the lambda — a fresh pool, and eventually a fresh connection, on every call (README, `api-technical.md`).
- `yield` inside the provider lambda (`.with { |conn| yield conn if block_given?; conn }`) — `yield` there refers to the enclosing method's block, not the provider's.

## The fix

The examples now return a `ConnectionPool::Wrapper` (alias `ConnectionPool.wrap`), built once per URI outside the lambda. It proxies each command through `pool.with`, so a connection is checked out for exactly the duration of that command and checked back in afterwards. ConnectionPool's checkout is reentrant per fiber (`Thread.current[@key]` is fiber-local), so a MULTI/EXEC, a pipeline, or a WATCH-guarded transaction still runs entirely on one connection.

```ruby
POOLS = {}
POOLS_MUTEX = Mutex.new

Familia.connection_provider = lambda do |uri|
  POOLS_MUTEX.synchronize do
    POOLS[uri] ||= ConnectionPool::Wrapper.new(size: 10, timeout: 5) do
      Redis.new(url: uri)
    end
  end
end
```

`api-technical.md` gains a **Provider contract** section stating the rule that makes the old example a bug — Familia calls the provider for every client and never checks one back in — with the do-not-do-this counter-example and the explicit `checkout`/`checkin`-at-the-boundary alternative for apps that pin one connection per request. The same contract is stated on the `connection_provider` attribute in source.

`Familia.with_dbclient` no longer claims the connection is "properly managed and returned to the pool"; it now notes that the block is *not* pinned to one connection under a pooled provider, and points at `transaction`/`pipelined` when several commands must share one.

## Sites updated

- `lib/familia/connection.rb` — the `@example` from the issue, plus the contract
- `lib/familia/connection/middleware.rb` — inline copy in the `reconnect!` example
- `lib/familia/connection/operations.rb` — `with_dbclient` docstring
- `README.md`, `docs/overview.md` (×2), `docs/guides/index.md`, `docs/reference/api-technical.md` (×2)
- `try/integration/connection/pools_try.rb` — the repo's executable copy of the same provider

## Verification

The replacement pattern was exercised against a live Redis before being documented: ad-hoc commands, `Familia.transaction` (MULTI/EXEC), `Familia.pipelined`, a WATCH-guarded `Familia.atomic_write` (proving WATCH and MULTI land on one connection through the wrapper), and eight concurrent threads — 0 instances of two threads holding the same connection at once, 0 save/load errors, exactly one pool created.

- `try/integration/connection/pools_try.rb`: 27 passed, before and after.
- Full suite: 306/306 files pass (`LANG=C.UTF-8 bin/try`).
- RuboCop: no new offences on the touched files.

---
_Generated by [Claude Code](https://claude.ai/code/session_017r9Q7M22A3uzA33ArvgKqy)_