### PR TITLE
[#354] Remove unused csv and stringio runtime dependencies

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,12 +4,10 @@ PATH
     familia (2.11.2)
       concurrent-ruby (~> 1.3)
       connection_pool (>= 2.4, < 4.0)
-      csv (~> 3.3)
       json_schemer (~> 2.0)
       logger (~> 1.7)
       oj (~> 3.16)
       redis (>= 5.0, < 6.0)
-      stringio (>= 3.1.1, < 3.3.0)
       uri-valkey (~> 1.4)
 
 GEM
@@ -21,7 +19,6 @@ GEM
     bigdecimal (4.1.2)
     concurrent-ruby (1.3.8)
     connection_pool (3.0.2)
-    csv (3.3.6)
     date (3.5.1)
     debug (1.11.1)
       irb (~> 1.10)

--- a/changelog.d/20260801_120000_claude_354_remove_unused_csv_stringio.rst
+++ b/changelog.d/20260801_120000_claude_354_remove_unused_csv_stringio.rst
@@ -1,0 +1,30 @@
+Removed
+-------
+
+- Dropped the unused ``csv`` and ``stringio`` runtime dependencies from the
+  gemspec. Neither was referenced anywhere in the shipped library — no
+  ``require``, no ``CSV.`` call, no ``StringIO`` reference in ``lib/``,
+  ``bin/``, or ``examples/`` — so both were leftovers from code paths that no
+  longer exist. Installing familia no longer pulls ``csv`` into a consumer's
+  bundle.
+
+  The ``stringio`` entry was the more pressing of the two: it pinned
+  ``>= 3.1.1, < 3.3.0`` on a Ruby **default gem**, so once a Ruby release ships
+  stringio 3.3.0 or newer, every consumer of familia on that Ruby would hit an
+  unresolvable dependency for a gem the library never used. Removing the
+  constraint takes that future breakage off the table.
+
+  Nothing needs to change on the consumer side. Both gems ship with Ruby, and
+  familia never loaded either, so an application that uses ``CSV`` or
+  ``StringIO`` in its own code is unaffected — though an application that was
+  relying on familia to declare ``csv`` for it should now declare it directly.
+  Test files under ``try/`` that use ``StringIO`` keep working: it is a default
+  gem and ``require 'stringio'`` resolves without a gemspec entry. #354
+
+AI Assistance
+-------------
+
+- Claude Code verified that neither dependency had any caller in the shipped
+  library, removed both from ``familia.gemspec``, regenerated ``Gemfile.lock``
+  (``stringio`` remains in the lockfile as a transitive dependency of ``psych``,
+  now uncapped), and confirmed the full tryouts suite stays green.

--- a/familia.gemspec
+++ b/familia.gemspec
@@ -21,12 +21,10 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'concurrent-ruby', '~> 1.3'
   spec.add_dependency 'connection_pool', '>= 2.4', '< 4.0'
-  spec.add_dependency 'csv', '~> 3.3'
   spec.add_dependency 'json_schemer', '~> 2.0'
   spec.add_dependency 'logger', '~> 1.7'
   spec.add_dependency 'oj', '~> 3.16'
   spec.add_dependency 'redis', '>= 5.0', '< 6.0'
-  spec.add_dependency 'stringio', '>= 3.1.1', '< 3.3.0'
   spec.add_dependency 'uri-valkey', '~> 1.4'
 
   spec.metadata['rubygems_mfa_required'] = 'true'


### PR DESCRIPTION
Closes #354.

## What

Removes two `add_dependency` lines from `familia.gemspec`:

```diff
-  spec.add_dependency 'csv', '~> 3.3'
-  spec.add_dependency 'stringio', '>= 3.1.1', '< 3.3.0'
```

…plus the corresponding `Gemfile.lock` entries and a changelog fragment. Five deletions of code in total.

## Why

Neither gem is used by the shipped library. There is no `require 'csv'`, no `CSV.` call, and no `StringIO` reference anywhere in `lib/`, `bin/`, or `examples/` — both are leftovers from code paths that no longer exist.

The `stringio` entry is the more pressing of the two. It pinned `>= 3.1.1, < 3.3.0` on a Ruby **default gem**, so once a Ruby release ships stringio 3.3.0 or newer, dependency resolution breaks for every consumer of familia on that Ruby — over a gem the library never loaded. Removing the constraint takes that future breakage off the table.

## Notes on the remaining references

Two sets of `csv`/`stringio` hits stay in the tree, and neither needs the gemspec entries:

- **`try/**/*_try.rb` using `StringIO`** (logger and middleware tests). `stringio` is a Ruby default gem — `require 'stringio'` resolves with no gemspec entry and no Gemfile line.
- **`CSV` under `try/support/prototypes/pooling/`.** Standalone stress-test/visualization scripts that the tryouts runner does not discover (they aren't `*_try.rb`), and one of them already guards its `require 'csv'` with a rescue.

In `Gemfile.lock`, `stringio` remains as a transitive dependency of `psych`, now uncapped. `csv` drops out of the bundle entirely — nothing else in the lockfile depends on it.

## Verification

- Full tryouts suite green against a live database: **6239 testcases passed, 0 failed, 307 files**, exit 0.
- `require 'familia'` loads successfully with `csv` absent from the bundle; `defined?(CSV)` is `nil` afterward, confirming nothing in `lib/` pulls it in.
- `gem build familia.gemspec` succeeds.
- `rubocop familia.gemspec` reports the same two pre-existing offenses as before the change (missing frozen-string-literal comment; `required_ruby_version` vs `TargetRubyVersion`) — no new ones.

## Compatibility

No consumer action required. Both gems ship with Ruby and familia never loaded either, so an application using `CSV` or `StringIO` in its own code is unaffected. An application that was relying on familia to declare `csv` transitively should now declare it directly.


---
_Generated by [Claude Code](https://claude.ai/code/session_01DApEaNBzhhbEDbndXWW3Tm)_