### PR TITLE
[#333] Add encryption_personalization_history for XChaCha20/BLAKE2b rotation

### DIFF
--- a/changelog.d/20260802_143000_delano_333_personalization_history.rst
+++ b/changelog.d/20260802_143000_delano_333_personalization_history.rst
@@ -1,0 +1,53 @@
+Added
+-----
+
+- New ``encryption_personalization_history`` setting: the BLAKE2b
+  personalization used by the XChaCha20-Poly1305 providers can now be rotated,
+  mirroring the AES-GCM ``encryption_hkdf_salt_history`` design from 2.11.0
+  (#311). Encryption always uses the current ``encryption_personalization``;
+  decryption tries the current value first, then each history entry in order,
+  then the pre-rotation built-in default (``'FamilialMatters'``), so existing
+  ciphertext keeps decrypting across rotations and upgrades. Candidates that
+  violate BLAKE2b's constraints (non-String, blank, null bytes, over 16 bytes)
+  are skipped rather than aborting the walk. The rotation logic lives in a new
+  shared ``Familia::Encryption::Providers::Blake2bPersonalization`` module
+  included by both XChaCha20 providers, so the registered provider and its
+  unregistered ``Secure`` sibling can no longer drift apart (as they did in
+  #250 and #356). The default personalization is unchanged, so unrotated
+  deployments encrypt and decrypt exactly as under 2.11. #333
+
+Changed
+-------
+
+- ``Manager#decrypt`` walks the XChaCha20 providers' personalization
+  candidates exactly as it walks AES-GCM's HKDF salts; each provider exposes
+  at most one rotation dimension, never both. A candidate that fails while
+  deriving now falls through to the next candidate instead of aborting the
+  walk, and an explicit over-long ``personal:`` passed to ``derive_key``
+  raises ``Familia::EncryptionError`` instead of leaking
+  ``RbNaCl::LengthError``. #333
+
+- The opt-in request-scoped key cache key gained a personalization segment
+  (``algorithm:version:salt:personal:context``), so derivations under
+  different rotation candidates never collide while an encrypt and a later
+  decrypt of the same value within one request still share a single derived
+  key. #333
+
+Documentation
+-------------
+
+- The encryption upgrade proof (``examples/encryption_upgrade_proof/``) no
+  longer pins "personalization is unrotatable" as a hazard: phase 2 now
+  proves that after rotating ``encryption_personalization``, envelopes
+  written under the built-in default keep decrypting via the legacy fallback
+  and via an explicit history entry. The encrypted-fields and encryption
+  guides, the overview, and the technical reference document
+  ``encryption_personalization_history`` alongside the salt history,
+  including a rotation example. #333
+
+AI Assistance
+-------------
+
+- The shared ``Blake2bPersonalization`` module, the manager decrypt-walk and
+  cache-key changes, the upgrade-proof and guide updates, and this changelog
+  entry were drafted with AI assistance. #333

--- a/docs/guides/encryption.md
+++ b/docs/guides/encryption.md
@@ -75,7 +75,7 @@ class Provider
 
   def encrypt(plaintext, key, additional_data)
   def decrypt(ciphertext, key, nonce, auth_tag, additional_data)
-  def derive_key(master_key, context, personal: nil)
+  def derive_key(master_key, context, personal: nil)  # AES-GCM also accepts salt:
   def generate_nonce
 end
 ```
@@ -90,6 +90,12 @@ Master Key + Field Context → Provider KDF → Field-Specific Key
 XChaCha20-Poly1305: BLAKE2b with personalization
 AES-256-GCM:        HKDF-SHA256
 ```
+
+Each derivation input can be rotated: encryption always uses the current
+value, while decryption tries the current value first, then each entry in the
+matching history setting (`encryption_personalization_history` for XChaCha20,
+`encryption_hkdf_salt_history` for AES-GCM), then the built-in default. See
+[Rotating Derivation Inputs](#rotating-derivation-inputs) below.
 
 ## Implementation Steps
 
@@ -115,7 +121,8 @@ Familia.configure do |config|
     v1: ENV['FAMILIA_ENCRYPTION_KEY_V1']
   }
   config.current_key_version = :v1
-  config.encryption_personalization = 'MyApp-2024'  # Optional
+  config.encryption_personalization = 'MyApp-2024'  # Optional, <= 16 bytes
+  # config.encryption_personalization_history = ['MyApp-2023']  # Prior values, for decryption
 end
 
 # Validate configuration at startup
@@ -339,6 +346,32 @@ vault.save
 
 # Step 4: After all data is re-encrypted, remove old key
 ```
+
+## Rotating Derivation Inputs
+
+The BLAKE2b personalization (XChaCha20) and the HKDF salt (AES-GCM) rotate
+the same way, without re-encrypting stored data: set the new value and move
+the old value into the matching history list. New writes use the current
+value; decryption tries the current value first, then each history entry in
+order, then the built-in default (`'FamilialMatters'`), so pre-rotation
+ciphertext keeps decrypting.
+
+```ruby
+Familia.configure do |config|
+  # Rotate the XChaCha20 BLAKE2b personalization (values <= 16 bytes)
+  config.encryption_personalization = 'MyApp2.0'
+  config.encryption_personalization_history = ['MyApp1.0']
+
+  # Rotate the AES-GCM HKDF salt (any length)
+  config.encryption_hkdf_salt = 'MyApp-2025'
+  config.encryption_hkdf_salt_history = ['MyApp-2024']
+end
+```
+
+Keep the history lists short — each stale entry adds one decryption attempt
+on a miss. History entries are subject to the same constraints as the current
+value (non-empty String, no null bytes, and for the personalization <= 16
+bytes); invalid entries are skipped on decrypt.
 
 ## Error Handling
 

--- a/docs/guides/feature-encrypted-fields.md
+++ b/docs/guides/feature-encrypted-fields.md
@@ -926,6 +926,8 @@ Familia.configure do |config|
   config.encryption_hkdf_salt = 'MyApp-2024'        # AES-GCM HKDF salt domain separation (any length)
   # When rotating the AES-GCM salt, keep prior values for backward-compatible decryption:
   # config.encryption_hkdf_salt_history = ['MyApp-2023']
+  # Same for the XChaCha20 personalization (entries obey the same <= 16-byte limit):
+  # config.encryption_personalization_history = ['MyApp-2023']
 end
 
 # Validate configuration

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -647,6 +647,8 @@ Familia.configure do |config|
   }
   config.current_key_version = :v2
   config.encryption_personalization = 'MyApp-2024'  # Optional
+  # If you later rotate the personalization, list prior values so old data still decrypts:
+  # config.encryption_personalization_history = ['MyApp-2023']
 end
 
 # Validate configuration before use
@@ -823,6 +825,9 @@ Familia.configure do |config|
   }
   config.current_key_version = :v3
   config.encryption_personalization = ENV['FAMILIA_ENCRYPTION_CONTEXT']
+  # After rotating the personalization, keep prior values for decryption
+  # (mirrors config.encryption_hkdf_salt_history for the AES-GCM salt):
+  # config.encryption_personalization_history = [ENV['FAMILIA_ENCRYPTION_CONTEXT_PREV']]
 
   # Validate configuration on startup
   Familia::Encryption.validate_configuration!

--- a/docs/reference/api-technical.md
+++ b/docs/reference/api-technical.md
@@ -162,6 +162,9 @@ Familia.configure do |config|
   config.current_key_version = :v2
   config.encryption_personalization = 'MyApp-2024'  # XChaCha20 BLAKE2b domain separation (<= 16 bytes)
   config.encryption_hkdf_salt = 'MyApp-2024'        # AES-GCM HKDF salt domain separation (any length)
+  # When rotating either value, keep prior values for backward-compatible decryption:
+  # config.encryption_personalization_history = ['MyApp-2023']
+  # config.encryption_hkdf_salt_history = ['MyApp-2023']
 end
 
 # Operations with encrypted fields

--- a/examples/encryption_upgrade_proof/README.md
+++ b/examples/encryption_upgrade_proof/README.md
@@ -67,10 +67,12 @@ These are *current behaviors* pinned by the proof so that any future change
 shows up as a failing check. See the accompanying findings report for the
 recommendations.
 
-- **Personalization is unrotatable**: changing
-  `encryption_personalization` breaks all existing XChaCha ciphertext; there
-  is no history/fallback mechanism (unlike `encryption_hkdf_salt_history`).
-  Pick the value *before* the first XChaCha write and treat it as permanent.
+- **Personalization rotates only through history**: since #333,
+  `encryption_personalization` rotates like the HKDF salt — decryption walks
+  the current value, then `encryption_personalization_history`, then the
+  built-in `'FamilialMatters'` fallback. Only the built-in default gets that
+  unconditional fallback: rotating away from a *non-default* value without
+  adding it to the history strands every envelope written under it.
 - **Wiping the current HKDF salt strands current-salt data**: the decrypt
   fallback list rescues legacy-salt envelopes, not envelopes written under
   the salt you just removed.
@@ -79,6 +81,7 @@ recommendations.
   and is never encrypted.
 - **The upgrade is a one-way door**: once one XChaCha envelope exists,
   every process that may read it needs libsodium. Nodes without it fail
-  cleanly (`Familia::EncryptionError: Unsupported algorithm`) but they fail.
+  cleanly (`Familia::EncryptionError` naming the unavailable provider and
+  its missing dependency) but they fail.
   Deploy libsodium to the whole fleet atomically, or accept read errors
   during the rollout window.

--- a/examples/encryption_upgrade_proof/gemfiles/Gemfile.dev-no-libsodium
+++ b/examples/encryption_upgrade_proof/gemfiles/Gemfile.dev-no-libsodium
@@ -2,3 +2,4 @@
 source 'https://rubygems.org'
 
 gem 'familia', path: '../../..'
+gem 'base64' # stdlib bundled gem on Ruby 3.4+; required by common.rb

--- a/examples/encryption_upgrade_proof/gemfiles/Gemfile.dev-with-libsodium
+++ b/examples/encryption_upgrade_proof/gemfiles/Gemfile.dev-with-libsodium
@@ -3,3 +3,4 @@ source 'https://rubygems.org'
 
 gem 'familia', path: '../../..'
 gem 'rbnacl', '~> 7.1', '>= 7.1.1'
+gem 'base64' # stdlib bundled gem on Ruby 3.4+; required by common.rb

--- a/examples/encryption_upgrade_proof/gemfiles/Gemfile.production-today
+++ b/examples/encryption_upgrade_proof/gemfiles/Gemfile.production-today
@@ -2,3 +2,4 @@
 source 'https://rubygems.org'
 
 gem 'familia', '2.10.1'
+gem 'base64' # stdlib bundled gem on Ruby 3.4+; required by common.rb

--- a/examples/encryption_upgrade_proof/phase2_libsodium_enabled.rb
+++ b/examples/encryption_upgrade_proof/phase2_libsodium_enabled.rb
@@ -224,20 +224,35 @@ Proof.check_raises('an unknown algorithm is rejected cleanly', Familia::Encrypti
                               context: ctx, additional_data: ctx)
 end
 
-# --- 9. Config-rotation behaviors (hazards the envelope does NOT cover) ------
-# The envelope does not record the BLAKE2b personalization: changing it breaks
-# decryption of all existing XChaCha data, and there is no history/fallback
-# mechanism (unlike the AES HKDF salt). This documents the hazard.
+# --- 9. Config-rotation behaviors --------------------------------------------
+# The envelope does not record the BLAKE2b personalization, but since #333 the
+# XChaCha decrypt path walks a candidate list -- the current value, then
+# encryption_personalization_history, then the built-in 'FamilialMatters'
+# default -- mirroring the AES HKDF salt rotation from #310/#311 below.
 begin
   Familia.encryption_personalization = 'DifferentApp'
-  Proof.check_raises('changing encryption_personalization breaks existing XChaCha data (no fallback!)',
+  Proof.check('after personalization rotation, envelopes under the built-in default decrypt via the legacy fallback') do
+    Familia::Encryption.decrypt(env, context: ctx, additional_data: ctx) == pt
+  end
+
+  # Only the built-in default gets an unconditional fallback. A NON-default
+  # personalization must be added to encryption_personalization_history when
+  # rotating away from it, or its data is stranded.
+  rotated_env = Familia::Encryption.encrypt(pt, context: ctx, additional_data: ctx)
+  Familia.encryption_personalization = 'DifferentApp2'
+  Proof.check_raises('rotating away from a NON-default personalization without history strands its data',
                      Familia::EncryptionError) do
-    Familia::Encryption.decrypt(env, context: ctx, additional_data: ctx)
+    Familia::Encryption.decrypt(rotated_env, context: ctx, additional_data: ctx)
+  end
+  Familia.encryption_personalization_history = ['DifferentApp']
+  Proof.check('...until the previous value is added to encryption_personalization_history') do
+    Familia::Encryption.decrypt(rotated_env, context: ctx, additional_data: ctx) == pt
   end
 ensure
   Familia.encryption_personalization = 'FamilialMatters'
+  Familia.encryption_personalization_history = []
 end
-Proof.check('restoring the personalization restores decryption') do
+Proof.check('restoring the personalization keeps existing data decryptable') do
   Familia::Encryption.decrypt(env, context: ctx, additional_data: ctx) == pt
 end
 

--- a/examples/encryption_upgrade_proof/phase3_rollback_hazard.rb
+++ b/examples/encryption_upgrade_proof/phase3_rollback_hazard.rb
@@ -35,7 +35,7 @@ xchacha_field   = phase2['envelopes'].find { |r| r['label'] == 'field-secret-xch
 aes_rec         = phase2['envelopes'].find { |r| r['label'] == 'manager-aes-211' }
 
 Proof.check_raises('XChaCha envelope fails CLEANLY without rbnacl (no silent garbage)',
-                   Familia::EncryptionError, /Unsupported algorithm/) do
+                   Familia::EncryptionError, /Unsupported algorithm|is not available on this node/) do
   Familia::Encryption.decrypt(xchacha_manager['envelope'],
                               context: xchacha_manager['context'],
                               additional_data: xchacha_manager['aad'])

--- a/lib/familia/encryption/manager.rb
+++ b/lib/familia/encryption/manager.rb
@@ -44,66 +44,92 @@ module Familia
         # Increment counter immediately to track all decryption attempts, even failed ones
         Familia::Encryption.derivation_count.increment
 
-        begin
-          # Delegate parsing and instantiation to EncryptedData.from_json
-          # Wrap validation errors for security (don't expose internal structure details)
-          begin
-            data = Familia::Encryption::EncryptedData.from_json(encrypted_json_or_hash)
-            raise EncryptionError, 'Failed to parse encrypted data' unless data
-          rescue EncryptionError => e
-            # Re-wrap validation errors with generic message for security
-            raise EncryptionError, "Decryption failed: #{e.message}"
-          end
+        data = parse_encrypted_data(encrypted_json_or_hash)
 
-          # Validate algorithm support
-          provider = Registry.get(data.algorithm)
+        # Validate algorithm support
+        provider = Registry.get(data.algorithm)
 
-          # Safely decode and validate sizes
-          nonce = decode_and_validate(data.nonce, provider.nonce_size, 'nonce')
-          ciphertext = decode_and_validate_ciphertext(data.ciphertext)
-          auth_tag = decode_and_validate(data.auth_tag, provider.auth_tag_size, 'auth_tag')
-
-          # Try each candidate HKDF salt, current first, so ciphertext written
-          # before a salt change still decrypts. Providers without salt rotation
-          # expose a single nil "salt" and are attempted exactly once. A wrong
-          # salt derives a different key and fails the authenticated decrypt
-          # cleanly, so iterating never yields a false positive. See #310 (S2).
-          salts = provider.respond_to?(:hkdf_salts) ? provider.hkdf_salts : [nil]
-          key = nil
-          plaintext = nil
-          last_error = nil
-          salts.each do |salt|
-            key = derive_key_without_increment(context, version: data.key_version, provider: provider, salt: salt)
-            begin
-              plaintext = provider.decrypt(ciphertext, key, nonce, auth_tag, additional_data)
-              break
-            rescue EncryptionError => e
-              last_error = e
-              plaintext = nil
-            ensure
-              Familia::Encryption.secure_wipe(key)
-            end
-          end
-          raise(last_error || EncryptionError.new('Decryption failed - invalid key or corrupted data')) if plaintext.nil?
-
-          plaintext.force_encoding(data.encoding || 'UTF-8')
-        rescue EncryptionError
-          raise
-        rescue Familia::SerializerError => e
-          raise EncryptionError, "Invalid JSON structure: #{e.message}"
-        rescue StandardError => e
-          raise EncryptionError, "Decryption failed: #{e.message}"
-        end
-      ensure
-        # Defensive backstop only. The salt-rotation loop's per-iteration `ensure`
-        # (around provider.decrypt) is the primary wipe and clears `key` on every
-        # path -- success, failure, and break -- so by here `key` is already wiped
-        # and this re-clear is a harmless no-op. It is kept so any future change to
-        # the loop structure still cannot leave a derived key unwiped (#311).
-        Familia::Encryption.secure_wipe(key) if key
+        plaintext = decrypt_with_candidates(provider, data, context, additional_data)
+        plaintext.force_encoding(data.encoding || 'UTF-8')
+      rescue EncryptionError
+        raise
+      rescue Familia::SerializerError => e
+        raise EncryptionError, "Invalid JSON structure: #{e.message}"
+      rescue StandardError => e
+        raise EncryptionError, "Decryption failed: #{e.message}"
       end
 
       private
+
+      # Delegate parsing and instantiation to EncryptedData.from_json
+      # Wrap validation errors for security (don't expose internal structure details)
+      def parse_encrypted_data(encrypted_json_or_hash)
+        data = Familia::Encryption::EncryptedData.from_json(encrypted_json_or_hash)
+        raise EncryptionError, 'Failed to parse encrypted data' unless data
+
+        data
+      rescue EncryptionError => e
+        # Re-wrap validation errors with generic message for security
+        raise EncryptionError, "Decryption failed: #{e.message}"
+      end
+
+      # Try each rotation candidate, current first, so ciphertext written
+      # before a config change still decrypts. A wrong candidate derives a
+      # different key and fails the authenticated decrypt cleanly, so
+      # iterating never yields a false positive. See #310 (S2).
+      def decrypt_with_candidates(provider, data, context, additional_data)
+        # Safely decode and validate sizes
+        nonce = decode_and_validate(data.nonce, provider.nonce_size, 'nonce')
+        ciphertext = decode_and_validate_ciphertext(data.ciphertext)
+        auth_tag = decode_and_validate(data.auth_tag, provider.auth_tag_size, 'auth_tag')
+
+        key = nil
+        plaintext = nil
+        last_error = nil
+        rotation_candidates(provider).each do |candidate|
+          # Derivation happens INSIDE the rescue so a candidate that raises
+          # while deriving falls through to the next candidate instead of
+          # aborting the walk. The candidate lists are pre-filtered, so only
+          # EncryptionError is expected here; anything else is a bug and
+          # should surface.
+
+          key = derive_key_without_increment(context, version: data.key_version, provider: provider, **candidate)
+          plaintext = provider.decrypt(ciphertext, key, nonce, auth_tag, additional_data)
+          break
+        rescue EncryptionError => e
+          last_error = e
+          plaintext = nil
+        ensure
+          Familia::Encryption.secure_wipe(key)
+        end
+        raise(last_error || EncryptionError.new('Decryption failed - invalid key or corrupted data')) if plaintext.nil?
+
+        plaintext
+      ensure
+        # Defensive backstop only. The candidate loop's per-iteration `ensure`
+        # (around derive + provider.decrypt) is the primary wipe and clears `key`
+        # on every path -- success, failure, and break -- so by here `key` is
+        # already wiped and this re-clear is a harmless no-op. It is kept so any
+        # future change to the loop structure still cannot leave a derived key
+        # unwiped (#311).
+        Familia::Encryption.secure_wipe(key) if key
+      end
+
+      # Each provider exposes at most ONE rotation dimension -- AES-GCM
+      # rotates HKDF salts (#310), the XChaCha20 providers rotate BLAKE2b
+      # personalizations (#333) -- never both. A provider responding to both
+      # would multiply into an N x M candidate matrix here; add a new
+      # dimension only by replacing the old one. Providers without rotation
+      # are attempted exactly once.
+      def rotation_candidates(provider)
+        if provider.respond_to?(:hkdf_salts)
+          provider.hkdf_salts.map { |salt| { salt: salt } }
+        elsif provider.respond_to?(:personalizations)
+          provider.personalizations.map { |personal| { personal: personal } }
+        else
+          [{}]
+        end
+      end
 
       def decode_and_validate(encoded, expected_size, component)
         decoded = Base64.strict_decode64(encoded)
@@ -127,7 +153,7 @@ module Familia
         derive_key_without_increment(context, version: version, provider: provider)
       end
 
-      def derive_key_without_increment(context, version: nil, provider: nil, salt: nil)
+      def derive_key_without_increment(context, version: nil, provider: nil, salt: nil, personal: nil)
         # Use provided provider or fall back to instance provider
         provider ||= @provider
 
@@ -140,34 +166,59 @@ module Familia
         # Disabled by default for maximum security (keys are not held in memory
         # longer than a single derivation). The cache key includes the algorithm
         # so different providers never share a derived key, the version so key
-        # rotation stays correct, and the resolved salt so rotated-salt derivations
-        # never collide. On a hit we return a copy and never fetch the master key,
-        # minimising master-key exposure.
+        # rotation stays correct, and the resolved rotation candidate (salt or
+        # personalization) so rotated derivations never collide. On a hit we
+        # return a copy and never fetch the master key, minimising master-key
+        # exposure.
         cache = Fiber[:familia_request_cache] if Fiber[:familia_request_cache_enabled]
         if cache
-          # Key on the *resolved* salt, not the raw argument. When salt is nil
-          # (the encrypt path) the provider derives with hkdf_salts.first; the
-          # decrypt loop later passes that same value explicitly. Keying on the
-          # raw argument would file those two identical derivations under
-          # different keys (nil vs the resolved salt), so an encrypt followed by a
-          # decrypt of the same value in one request would derive twice instead of
-          # hitting the cache. Providers without salt rotation have no effective
-          # salt (nil), so their cache key is unchanged.
-          effective_salt = salt || (provider.respond_to?(:hkdf_salts) ? provider.hkdf_salts.first : nil)
-          cache_key = "#{provider.algorithm}:#{version}:#{effective_salt}:#{context}"
+          cache_key = rotation_cache_key(provider, version, context, salt: salt, personal: personal)
           cached = cache[cache_key]
           return cached.dup if cached
         end
 
         master_key = get_master_key(version)
-        # Only forward an explicit salt to providers that accept one (the AES-GCM
-        # salt-rotation path). The default derivation keeps the original arity so
-        # providers without a salt parameter are unaffected.
-        derived = salt.nil? ? provider.derive_key(master_key, context) : provider.derive_key(master_key, context, salt: salt)
+        derived = derive_candidate_key(provider, master_key, context, salt: salt, personal: personal)
         cache[cache_key] = derived.dup if cache
         derived
       ensure
-        Familia::Encryption.secure_wipe(master_key) if master_key
+        # secure_wipe is nil-safe, so no guard: master_key is nil when the
+        # cache hit returned early or a validation raise preceded assignment.
+        Familia::Encryption.secure_wipe(master_key)
+      end
+
+      # Key on the *resolved* candidate, not the raw argument. When the
+      # candidate is nil (the encrypt path) the provider derives with its
+      # current value; the decrypt loop later passes that same value
+      # explicitly. Keying on the raw argument would file those two
+      # identical derivations under different keys (nil vs the resolved
+      # value), so an encrypt followed by a decrypt of the same value in
+      # one request would derive twice instead of hitting the cache. The
+      # personalization resolves through current_personalization -- NOT
+      # personalizations.first -- so a blank config still raises here
+      # exactly as the provider's own derivation would, instead of quietly
+      # caching under a fallback. Providers without rotation have no
+      # effective candidate (nil:nil), so their cache key shape is stable.
+      def rotation_cache_key(provider, version, context, salt:, personal:)
+        effective_salt = salt || (provider.respond_to?(:hkdf_salts) ? provider.hkdf_salts.first : nil)
+        effective_personal = personal ||
+                             (provider.respond_to?(:current_personalization) ? provider.current_personalization : nil)
+        "#{provider.algorithm}:#{version}:#{effective_salt}:#{effective_personal}:#{context}"
+      end
+
+      # Only forward an explicit rotation candidate to the provider (the
+      # decrypt walk). The default derivation keeps the original arity so
+      # providers resolve their own current value and providers without a
+      # rotation parameter are unaffected. A provider exposes at most one
+      # dimension (salt OR personal, see the decrypt walk), so at most one
+      # kwarg is ever set here.
+      def derive_candidate_key(provider, master_key, context, salt:, personal:)
+        candidate_kwargs = {}
+        candidate_kwargs[:salt] = salt unless salt.nil?
+        candidate_kwargs[:personal] = personal unless personal.nil?
+        return provider.derive_key(master_key, context) if candidate_kwargs.empty?
+
+        provider.derive_key(master_key, context, **candidate_kwargs)
       end
 
       def get_master_key(version)

--- a/lib/familia/encryption/providers/aes_gcm_provider.rb
+++ b/lib/familia/encryption/providers/aes_gcm_provider.rb
@@ -26,7 +26,7 @@ module Familia
   module Encryption
     module Providers
       class AESGCMProvider < Provider
-        ALGORITHM = 'aes-256-gcm'.freeze
+        ALGORITHM = 'aes-256-gcm'
         NONCE_SIZE = 12
         AUTH_TAG_SIZE = 16
         KEY_SIZE = 32

--- a/lib/familia/encryption/providers/blake2b_personalization.rb
+++ b/lib/familia/encryption/providers/blake2b_personalization.rb
@@ -1,0 +1,101 @@
+# lib/familia/encryption/providers/blake2b_personalization.rb
+#
+# frozen_string_literal: true
+
+module Familia
+  module Encryption
+    module Providers
+      # Shared BLAKE2b personalization handling for the XChaCha20-Poly1305
+      # providers (XChaCha20Poly1305Provider and its unregistered prototype
+      # sibling SecureXChaCha20Poly1305Provider). Both providers include this
+      # module so the personalization rotation logic exists exactly once --
+      # the two files have drifted apart before (#250, #356).
+      #
+      # Mirrors the AES-GCM HKDF salt rotation design from #310/#311:
+      # encryption uses the fail-closed current value, decryption walks a
+      # permissive candidate list ending with the pre-rotation default.
+      # See issue #333.
+      module Blake2bPersonalization
+        # The built-in personalization every deployment shipped with before
+        # rotation support (#333). Retained ONLY as a decryption fallback (see
+        # #personalizations) so data written under the default stays readable
+        # after an operator rotates to a deployment-specific value. Never used
+        # to encrypt new data once the config no longer resolves to it.
+        LEGACY_PERSONALIZATION = 'FamilialMatters'
+
+        # Ordered list of personalization strings to consider when DECRYPTING,
+        # current first.
+        #
+        # Decryption walks this list until the authenticated decrypt succeeds,
+        # so it is intentionally permissive: it reads the raw config value (not
+        # #current_personalization, which raises) and ends with the built-in
+        # default, so existing ciphertext stays readable even if the current
+        # config is broken. A wrong personalization derives a different key and
+        # fails Poly1305 authentication cleanly, so iterating never yields a
+        # false positive.
+        #
+        # The filter is load-bearing, not cosmetic: a candidate that is not a
+        # String, is blank, contains null bytes, or exceeds BLAKE2b's 16-byte
+        # personalization limit would raise mid-walk (EncryptionError or
+        # RbNaCl::LengthError) and abort the remaining candidates, so such
+        # entries are dropped here instead of attempted.
+        #
+        # ENCRYPTION does NOT use this list's head -- see
+        # #current_personalization, which fails closed rather than silently
+        # encrypting under a fallback value.
+        #
+        # @return [Array<String>] Valid candidates, current first, deduplicated
+        def personalizations
+          current = Familia.config.encryption_personalization
+          history = Familia.config.encryption_personalization_history
+          [current, *history, LEGACY_PERSONALIZATION].select do |candidate|
+            candidate.is_a?(String) && !candidate.empty? &&
+              !candidate.include?("\0") && candidate.bytesize <= 16
+          end.uniq
+        end
+
+        # The personalization string used to ENCRYPT new data.
+        #
+        # Unlike #personalizations (the permissive decryption candidate list),
+        # this fails CLOSED. A nil or empty encryption_personalization is a
+        # misconfiguration -- and the raw attr_writer can set one, bypassing
+        # the reader's guards -- so refuse rather than silently deriving under
+        # a fallback (#311). Null-byte padding to BLAKE2b's 16 bytes happens at
+        # derive time (ljust in #derive_key), not here.
+        #
+        # @return [String] The validated current personalization string
+        # @raise [EncryptionError] When the configured value is invalid
+        def current_personalization
+          validate_personalization!(Familia.config.encryption_personalization)
+        end
+
+        private
+
+        # Fail-closed validation for a single personalization value, applied to
+        # both the configured current value (#current_personalization) and any
+        # explicitly-passed `personal:` candidate in #derive_key. With
+        # #personalizations filtering the decrypt walk, this is defense in
+        # depth for direct callers.
+        #
+        # @param raw_personal [Object] Candidate personalization value
+        # @return [String] The value, unchanged, when valid
+        # @raise [EncryptionError] When the value is invalid
+        def validate_personalization!(raw_personal)
+          # Fail closed on a missing personalization rather than crashing with a
+          # NoMethodError on nil (#311): a blank value gives no domain separation,
+          # and the raw attr_writer can set nil/'' past the reader's guards.
+          unless raw_personal.is_a?(String) && !raw_personal.empty?
+            raise EncryptionError, 'encryption_personalization must be a non-empty string for key derivation'
+          end
+          raise EncryptionError, 'Personalization string must not contain null bytes' if raw_personal.include?("\0")
+          if raw_personal.bytesize > 16
+            raise EncryptionError,
+                  'Personalization string cannot exceed 16 bytes (BLAKE2b personalization limit)'
+          end
+
+          raw_personal
+        end
+      end
+    end
+  end
+end

--- a/lib/familia/encryption/providers/secure_xchacha20_poly1305_provider.rb
+++ b/lib/familia/encryption/providers/secure_xchacha20_poly1305_provider.rb
@@ -32,6 +32,8 @@ rescue LoadError
   # Dependencies not available - provider will report as unavailable
 end
 
+require_relative 'blake2b_personalization'
+
 module Familia
   module Encryption
     module Providers
@@ -47,7 +49,9 @@ module Familia
       # 4. Uses locked memory where possible (future enhancement)
       #
       class SecureXChaCha20Poly1305Provider < Provider
-        ALGORITHM = 'xchacha20poly1305-secure'.freeze
+        include Blake2bPersonalization
+
+        ALGORITHM = 'xchacha20poly1305-secure'
         NONCE_SIZE = 24
         AUTH_TAG_SIZE = 16
         KEY_SIZE = 32
@@ -97,18 +101,19 @@ module Familia
           RbNaCl::Random.random_bytes(NONCE_SIZE)
         end
 
-        # Enhanced key derivation with immediate cleanup
+        # Enhanced key derivation with immediate cleanup.
+        #
+        # Personalization resolution and validation are shared with
+        # XChaCha20Poly1305Provider via Blake2bPersonalization -- this file has
+        # drifted from its sibling before (#250, #356), so the two providers
+        # must stay on the identical code path (#333).
         def derive_key(master_key, context, personal: nil)
           validate_key_length!(master_key)
 
-          raw_personal = personal || Familia.config.encryption_personalization
-          # Fail closed on a missing personalization rather than crashing with a
-          # NoMethodError on nil (#311), mirroring XChaCha20Poly1305Provider.
-          unless raw_personal.is_a?(String) && !raw_personal.empty?
-            raise EncryptionError, 'encryption_personalization must be a non-empty string for key derivation'
-          end
-          raise EncryptionError, 'Personalization string must not contain null bytes' if raw_personal.include?("\0")
-
+          # validate_personalization! guards explicitly-passed candidates with
+          # the same fail-closed checks as the config path (defense in depth --
+          # #personalizations already filters the decrypt walk).
+          raw_personal = personal ? validate_personalization!(personal) : current_personalization
           personal_string = raw_personal.ljust(16, "\0")
 
           # Perform derivation and immediately clear intermediate values
@@ -121,7 +126,7 @@ module Familia
             context.to_s.b,
             key: master_key,
             digest_size: KEY_SIZE,
-            personal: personal_string
+            personal: personal_string,
           )
 
           # Clear personalization string from memory

--- a/lib/familia/encryption/providers/xchacha20_poly1305_provider.rb
+++ b/lib/familia/encryption/providers/xchacha20_poly1305_provider.rb
@@ -29,11 +29,18 @@ rescue LoadError
   # To add: gem 'rbnacl', '~> 7.1', '>= 7.1.1'
 end
 
+require_relative 'blake2b_personalization'
+
 module Familia
   module Encryption
     module Providers
+      # XChaCha20-Poly1305 AEAD provider backed by RbNaCl/libsodium. Derives
+      # per-context keys via BLAKE2b keyed hashing with a rotatable
+      # personalization string (see Blake2bPersonalization, #333).
       class XChaCha20Poly1305Provider < Provider
-        ALGORITHM = 'xchacha20poly1305'.freeze
+        include Blake2bPersonalization
+
+        ALGORITHM = 'xchacha20poly1305'
         NONCE_SIZE = 24
         AUTH_TAG_SIZE = 16
         KEY_SIZE = 32
@@ -88,21 +95,22 @@ module Familia
         # identical master keys and contexts. This prevents key reuse across
         # different applications or library versions.
         #
+        # `personal` defaults to the current configured personalization
+        # (Blake2bPersonalization#current_personalization), which fails closed
+        # on a nil/blank config. The decrypt path passes explicit candidates
+        # from #personalizations so ciphertext written under a previous
+        # personalization stays decryptable after a rotation (#333).
+        #
         # @param master_key [String] The master key (must be >= 32 bytes)
         # @param context [String] Context string for key derivation
         # @param personal [String, nil] Optional personalization override
         # @return [String] 32-byte derived key
         def derive_key(master_key, context, personal: nil)
           validate_key_length!(master_key)
-          raw_personal = personal || Familia.config.encryption_personalization
-          # Fail closed on a missing personalization rather than crashing with a
-          # NoMethodError on nil (#311): a blank value gives no domain separation,
-          # and the raw attr_writer can set nil/'' past the reader's guards.
-          unless raw_personal.is_a?(String) && !raw_personal.empty?
-            raise EncryptionError, 'encryption_personalization must be a non-empty string for key derivation'
-          end
-          raise EncryptionError, 'Personalization string must not contain null bytes' if raw_personal.include?("\0")
-
+          # validate_personalization! guards explicitly-passed candidates with
+          # the same fail-closed checks as the config path (defense in depth --
+          # #personalizations already filters the decrypt walk).
+          raw_personal = personal ? validate_personalization!(personal) : current_personalization
           personal_string = raw_personal.ljust(16, "\0")
 
           RbNaCl::Hash.blake2b(
@@ -112,7 +120,7 @@ module Familia
             context.to_s.b,
             key: master_key,
             digest_size: KEY_SIZE,
-            personal: personal_string
+            personal: personal_string,
           )
         end
 

--- a/lib/familia/features/encrypted_fields.rb
+++ b/lib/familia/features/encrypted_fields.rb
@@ -159,6 +159,8 @@ module Familia
     #     config.encryption_hkdf_salt = 'MyApp-2024'        # AES-GCM domain separation (any length)
     #     # When rotating the salt, keep prior values so old ciphertext still decrypts:
     #     # config.encryption_hkdf_salt_history = ['MyApp-2023']
+    #     # Same for the personalization (entries obey the same <= 16-byte limit):
+    #     # config.encryption_personalization_history = ['MyApp-2023']
     #   end
     #
     #   # Validate configuration before use

--- a/lib/familia/settings.rb
+++ b/lib/familia/settings.rb
@@ -5,15 +5,16 @@
 # Familia
 #
 module Familia
-  @delim = ':'.freeze
+  @delim = ':'
   @prefix = nil
   @suffix = :object
   @default_expiration = 0 # see update_expiration. Zero is skip. nil is an exception.
   @logical_database = nil
   @encryption_keys = nil
   @current_key_version = nil
-  @encryption_personalization = 'FamilialMatters'.freeze
-  @encryption_hkdf_salt = 'FamilialMatters'.freeze
+  @encryption_personalization = 'FamilialMatters'
+  @encryption_personalization_history = [].freeze
+  @encryption_hkdf_salt = 'FamilialMatters'
   @encryption_hkdf_salt_history = [].freeze
   @pipelined_mode = :warn
   @strict_write_order = false
@@ -29,9 +30,9 @@ module Familia
   #
   module Settings
     attr_writer :delim, :suffix, :default_expiration, :logical_database, :prefix, :encryption_keys,
-                :current_key_version, :encryption_personalization, :encryption_hkdf_salt,
-                :encryption_hkdf_salt_history, :transaction_mode, :schema_path, :schemas,
-                :schema_validator, :strict_write_order, :raise_on_unsaved_parent_write
+                :current_key_version, :encryption_personalization, :encryption_personalization_history,
+                :encryption_hkdf_salt, :encryption_hkdf_salt_history, :transaction_mode, :schema_path,
+                :schemas, :schema_validator, :strict_write_order, :raise_on_unsaved_parent_write
 
     def delim(val = nil)
       @delim = val if val
@@ -48,14 +49,14 @@ module Familia
       @suffix
     end
 
-    def default_expiration(v = nil)
-      @default_expiration = v unless v.nil?
+    def default_expiration(val = nil)
+      @default_expiration = val unless val.nil?
       @default_expiration
     end
 
-    def logical_database(v = nil)
-      Familia.trace :DB, nil, "#{@logical_database} #{v}" if Familia.debug?
-      @logical_database = v unless v.nil?
+    def logical_database(val = nil)
+      Familia.trace :DB, nil, "#{@logical_database} #{val}" if Familia.debug?
+      @logical_database = val unless val.nil?
       @logical_database
     end
 
@@ -86,6 +87,11 @@ module Familia
     # inputs separate avoids constraining one cipher family by the other's rules
     # (see issue #311).
     #
+    # Encryption always uses this current value; decryption tries it first, then
+    # each entry in #encryption_personalization_history, then the built-in
+    # default ('FamilialMatters'), so existing ciphertext keeps decrypting
+    # across rotations and upgrades (see issue #333).
+    #
     # @example Familia.configure do |config|
     #     config.encryption_personalization = 'MyApp1.0'
     #   end
@@ -102,6 +108,29 @@ module Familia
         @encryption_personalization = val
       end
       @encryption_personalization
+    end
+
+    # Previous #encryption_personalization values, kept so that rotating the
+    # BLAKE2b personalization used by the XChaCha20 providers stays
+    # backward-compatible. When you change the current value, list the prior
+    # value(s) here so existing ciphertext can still be decrypted. Encryption
+    # always uses the current value; decryption tries the current value first,
+    # then each entry here in order. Keep the list short -- every stale entry
+    # adds a decryption attempt on a miss. Entries are subject to the same
+    # BLAKE2b constraints as the current value (non-empty String, no null
+    # bytes, <= 16 bytes); entries that violate them are skipped on decrypt.
+    #
+    # @example Rotating the personalization without losing old data
+    #   Familia.configure do |config|
+    #     config.encryption_personalization = 'MyApp2.0'
+    #     config.encryption_personalization_history = ['MyApp1.0']
+    #   end
+    #
+    # @param val [Array<String>, nil] Ordered list of prior values, or nil to read
+    # @return [Array<String>] Current history list (possibly empty)
+    def encryption_personalization_history(val = nil)
+      @encryption_personalization_history = Array(val) unless val.nil?
+      @encryption_personalization_history || []
     end
 
     # HKDF salt for the AES-GCM provider's key derivation (RFC 5869). Provides
@@ -168,9 +197,10 @@ module Familia
     #
     def transaction_mode(val = nil)
       if val
-        unless [:strict, :warn, :permissive].include?(val)
+        unless %i[strict warn permissive].include?(val)
           raise ArgumentError, 'Transaction mode must be :strict, :warn, or :permissive'
         end
+
         @transaction_mode = val
       end
       @transaction_mode || :warn  # default to warn mode
@@ -193,18 +223,20 @@ module Familia
     #
     def pipelined_mode(val = nil)
       if val
-        unless [:strict, :warn, :permissive].include?(val)
+        unless %i[strict warn permissive].include?(val)
           raise ArgumentError, 'Pipeline mode must be :strict, :warn, or :permissive'
         end
+
         @pipelined_mode = val
       end
       @pipelined_mode || :warn  # default to warn mode
     end
 
     def pipelined_mode=(val)
-      unless [:strict, :warn, :permissive].include?(val)
+      unless %i[strict warn permissive].include?(val)
         raise ArgumentError, 'Pipeline mode must be :strict, :warn, or :permissive'
       end
+
       @pipelined_mode = val
     end
 
@@ -293,6 +325,7 @@ module Familia
         unless valid.include?(val)
           raise ArgumentError, "dirty_write_warnings must be one of #{valid.inspect}, got #{val.inspect}"
         end
+
         @dirty_write_warnings = val
       end
       @dirty_write_warnings || :once

--- a/try/features/encryption/config_persistence_try.rb
+++ b/try/features/encryption/config_persistence_try.rb
@@ -118,6 +118,30 @@ rescue ArgumentError => e
 end
 #=> [true, true]
 
+## encryption_personalization_history defaults to an empty list when unset (#333)
+@oh = Familia.config.encryption_personalization_history
+Familia.config.encryption_personalization_history = nil
+@default_history = Familia.config.encryption_personalization_history
+Familia.config.encryption_personalization_history = @oh
+@default_history
+#=> []
+
+## encryption_personalization_history (method form) coerces a scalar to an
+## Array, mirroring the reader/writer idiom of the other config knobs (#333)
+@oh = Familia.config.encryption_personalization_history
+@coerced = Familia.config.encryption_personalization_history('MyApp1.0')
+Familia.config.encryption_personalization_history = @oh
+@coerced
+#=> ['MyApp1.0']
+
+## encryption_personalization_history round-trips a list through the attr_writer
+@oh = Familia.config.encryption_personalization_history
+Familia.config.encryption_personalization_history = ['MyApp2.0', 'MyApp1.0']
+@stored = Familia.config.encryption_personalization_history
+Familia.config.encryption_personalization_history = @oh
+@stored
+#=> ['MyApp2.0', 'MyApp1.0']
+
 ## encryption_hkdf_salt has no length limit -- a >16-byte salt is accepted (#311)
 @orig_hkdf = Familia.config.encryption_hkdf_salt
 Familia.config.encryption_hkdf_salt = 'x' * 64
@@ -141,6 +165,18 @@ rescue NoMethodError
 end
 Familia.config.encryption_personalization = @op
 @nil_personal
+#=> 'clean-error'
+
+## XChaCha20 derive_key rejects an over-limit personalization with a clean
+## EncryptionError rather than letting RbNaCl raise LengthError mid-derivation
+## (#333 defense in depth -- the decrypt walk pre-filters, direct callers don't)
+provider = @provider_class.new
+begin
+  provider.derive_key('a' * 32, 'TestModel:field:user123', personal: 'x' * 17)
+  'no-error'
+rescue Familia::EncryptionError => e
+  e.message.include?('16 bytes') ? 'clean-error' : 'other-encryption-error'
+end
 #=> 'clean-error'
 
 ## derive_key validates master key length

--- a/try/features/encryption/providers/xchacha20_poly1305_provider_try.rb
+++ b/try/features/encryption/providers/xchacha20_poly1305_provider_try.rb
@@ -55,6 +55,55 @@ provider.derive_key(master_key, context, personal: "bad\0personal")
 #=!> Familia::EncryptionError
 #==> error.message.include?('null bytes')
 
+## XChaCha20Poly1305 key derivation rejects a >16-byte personalization with a
+## clean EncryptionError instead of surfacing RbNaCl::LengthError (#333)
+provider = Familia::Encryption::Providers::XChaCha20Poly1305Provider.new
+provider.derive_key('a' * 32, 'test-context', personal: 'x' * 17)
+#=!> Familia::EncryptionError
+#==> error.message.include?('16 bytes')
+
+## XChaCha20Poly1305 exposes the decrypt candidate list: current first, then
+## history, ending with the built-in legacy personalization (#333)
+provider = Familia::Encryption::Providers::XChaCha20Poly1305Provider.new
+@op = Familia.config.encryption_personalization
+@oh = Familia.config.encryption_personalization_history
+Familia.config.encryption_personalization = 'ProviderTry'
+Familia.config.encryption_personalization_history = ['OldProviderTry']
+@candidates = provider.personalizations
+Familia.config.encryption_personalization = @op
+Familia.config.encryption_personalization_history = @oh
+@candidates
+#=> ['ProviderTry', 'OldProviderTry', 'FamilialMatters']
+
+## XChaCha20Poly1305 current_personalization returns the configured write-path
+## value, not the candidate list head (#333)
+provider = Familia::Encryption::Providers::XChaCha20Poly1305Provider.new
+@op = Familia.config.encryption_personalization
+Familia.config.encryption_personalization = 'WritePathValue'
+@current = provider.current_personalization
+Familia.config.encryption_personalization = @op
+@current
+#=> 'WritePathValue'
+
+## XChaCha20Poly1305 current_personalization fails closed on a nil config while
+## personalizations stays permissive and still offers the legacy tail (#333)
+provider = Familia::Encryption::Providers::XChaCha20Poly1305Provider.new
+@op = Familia.config.encryption_personalization
+@oh = Familia.config.encryption_personalization_history
+Familia.config.encryption_personalization = nil
+Familia.config.encryption_personalization_history = []
+@failed_closed = begin
+  provider.current_personalization
+  'no-error'
+rescue Familia::EncryptionError => e
+  e.message.include?('non-empty') ? 'refused' : 'other-error'
+end
+@permissive = provider.personalizations
+Familia.config.encryption_personalization = @op
+Familia.config.encryption_personalization_history = @oh
+[@failed_closed, @permissive]
+#=> ['refused', ['FamilialMatters']]
+
 ## XChaCha20Poly1305 encryption produces expected structure
 test_keys = { v1: Base64.strict_encode64('a' * 32) }
 provider = Familia::Encryption::Providers::XChaCha20Poly1305Provider.new

--- a/try/features/encryption/secure_memory_handling_try.rb
+++ b/try/features/encryption/secure_memory_handling_try.rb
@@ -72,6 +72,54 @@ context = 'TestModel:field:user123'
 provider.derive_key('a' * 32, context) == sibling.derive_key('a' * 32, context)
 #=> true
 
+## Secure provider shares the personalization rotation list with its sibling
+## via Blake2bPersonalization: current first, then history, then the legacy
+## tail -- and byte-identical to the registered provider's list (#333). The two
+## files have drifted apart before (#250, #356), so identity matters, not just
+## shape.
+provider = @provider_class.new
+sibling = Familia::Encryption::Providers::XChaCha20Poly1305Provider.new
+@op = Familia.config.encryption_personalization
+@oh = Familia.config.encryption_personalization_history
+Familia.config.encryption_personalization = 'SecureTry'
+Familia.config.encryption_personalization_history = ['SecureOldTry']
+@rotation = [provider.personalizations, provider.personalizations == sibling.personalizations]
+Familia.config.encryption_personalization = @op
+Familia.config.encryption_personalization_history = @oh
+@rotation
+#=> [['SecureTry', 'SecureOldTry', 'FamilialMatters'], true]
+
+## Secure provider current_personalization returns the configured write-path value (#333)
+provider = @provider_class.new
+@op = Familia.config.encryption_personalization
+Familia.config.encryption_personalization = 'SecureCurrent'
+@current = provider.current_personalization
+Familia.config.encryption_personalization = @op
+@current
+#=> 'SecureCurrent'
+
+## Secure provider current_personalization fails closed on a nil config,
+## exactly like the sibling provider (#333)
+provider = @provider_class.new
+@op = Familia.config.encryption_personalization
+Familia.config.encryption_personalization = nil
+@refusal = begin
+  provider.current_personalization
+  'no-error'
+rescue Familia::EncryptionError => e
+  e.message.include?('non-empty') ? 'refused' : 'other-error'
+end
+Familia.config.encryption_personalization = @op
+@refusal
+#=> 'refused'
+
+## Secure provider derive_key rejects a >16-byte personalization with a clean
+## EncryptionError instead of RbNaCl::LengthError (#333)
+provider = @provider_class.new
+provider.derive_key('a' * 32, 'TestModel:field:user123', personal: 'x' * 17)
+#=!> Familia::EncryptionError
+#==> error.message.include?('16 bytes')
+
 ## encrypt operation clears key after use (demonstration)
 provider = @provider_class.new
 master_key = ('a' * 32).dup  # Make mutable copy

--- a/try/features/encryption/xchacha20_personalization_rotation_try.rb
+++ b/try/features/encryption/xchacha20_personalization_rotation_try.rb
@@ -1,0 +1,230 @@
+# try/features/encryption/xchacha20_personalization_rotation_try.rb
+#
+# frozen_string_literal: true
+
+# Locks in the backward-compatibility guarantee for BLAKE2b personalization
+# rotation (issue #333), mirroring the AES-GCM HKDF salt design from #310/#311:
+# the XChaCha20 personalization is driven by encryption_personalization plus a
+# dedicated history knob (encryption_personalization_history), and moving off
+# the built-in 'FamilialMatters' default must NOT make previously-encrypted
+# data unreadable. The providers expose an ordered candidate list (current
+# first, then rotation history, then the legacy default); decryption walks it
+# until the authenticated decrypt succeeds.
+
+require_relative '../../support/helpers/test_helpers'
+require 'base64'
+
+set_test_encryption_keys({ v1: Base64.strict_encode64('a' * 32) }, current_version: :v1)
+
+@orig_personal = Familia.config.encryption_personalization
+@orig_history = Familia.config.encryption_personalization_history
+@orig_salt = Familia.config.encryption_hkdf_salt
+
+@mgr = Familia::Encryption::Manager.new(algorithm: 'xchacha20poly1305')
+@ctx = 'PersonalizationRotationTest:secret:user1'
+
+## The candidate list always includes the pre-#333 built-in personalization
+provider = Familia::Encryption::Providers::XChaCha20Poly1305Provider.new
+provider.personalizations.include?(Familia::Encryption::Providers::Blake2bPersonalization::LEGACY_PERSONALIZATION)
+#=> true
+
+## Encryption uses the current encryption_personalization as the first candidate
+Familia.config.encryption_personalization = 'MyApp1.0'
+Familia.config.encryption_personalization_history = []
+Familia::Encryption::Providers::XChaCha20Poly1305Provider.new.personalizations.first
+#=> 'MyApp1.0'
+
+## The personalization is decoupled from the AES-GCM HKDF salt (#311): changing
+## encryption_hkdf_salt does NOT change the personalization candidate list.
+Familia.config.encryption_personalization = 'MyApp1.0'
+Familia.config.encryption_personalization_history = []
+Familia.config.encryption_hkdf_salt = 'SomeOtherSalt'
+Familia::Encryption::Providers::XChaCha20Poly1305Provider.new.personalizations.first
+#=> 'MyApp1.0'
+
+## A personalization at exactly the 16-byte BLAKE2b limit round-trips
+Familia.config.encryption_personalization = 'x' * 16
+Familia.config.encryption_personalization_history = []
+@mgr.decrypt(@mgr.encrypt('at limit ok', context: @ctx), context: @ctx)
+#=> 'at limit ok'
+
+## Ciphertext written before a personalization rotation still decrypts via history
+Familia.config.encryption_personalization = 'MyApp1.0'
+Familia.config.encryption_personalization_history = []
+@blob_v1 = @mgr.encrypt('rotate me', context: @ctx)
+Familia.config.encryption_personalization = 'MyApp2.0'
+Familia.config.encryption_personalization_history = ['MyApp1.0']
+@mgr.decrypt(@blob_v1, context: @ctx)
+#=> 'rotate me'
+
+## Round-trips under the new current personalization continue to work after rotation
+@mgr.decrypt(@mgr.encrypt('fresh', context: @ctx), context: @ctx)
+#=> 'fresh'
+
+## Without the prior value in history, rotated ciphertext no longer decrypts
+Familia.config.encryption_personalization = 'MyApp1.0'
+Familia.config.encryption_personalization_history = []
+@orphan = @mgr.encrypt('needs history', context: @ctx)
+Familia.config.encryption_personalization = 'MyApp-x9'
+Familia.config.encryption_personalization_history = []
+begin
+  @mgr.decrypt(@orphan, context: @ctx)
+  'decrypted-unexpectedly'
+rescue Familia::EncryptionError
+  'failed-as-expected'
+end
+#=> 'failed-as-expected'
+
+## Pre-#333 data (encrypted under the DEFAULT personalization) decrypts with
+## zero history configured -- the legacy tail. This is the production
+## Onetimesecret v0.26 story: nearly every 2.11 deployment encrypted under the
+## built-in 'FamilialMatters'; rotating to a deployment-specific value must not
+## orphan that data even when the operator configures no history at all.
+Familia.config.encryption_personalization = 'FamilialMatters'
+Familia.config.encryption_personalization_history = []
+@default_blob = @mgr.encrypt('v0.26 secret', context: @ctx)
+Familia.config.encryption_personalization = 'BrandNewApp'
+Familia.config.encryption_personalization_history = []
+@mgr.decrypt(@default_blob, context: @ctx)
+#=> 'v0.26 secret'
+
+## Legacy data crafted against the *literal* pre-#333 personalization string
+## (not the constant) still decrypts -- guards against the constant's value
+## drifting away from the hardcoded 'FamilialMatters' the old code shipped.
+@provider = Familia::Encryption::Providers::XChaCha20Poly1305Provider.new
+@master = Base64.strict_decode64(Familia.config.encryption_keys[:v1])
+@literal_key = @provider.derive_key(@master, @ctx, personal: 'FamilialMatters')
+@literal_enc = @provider.encrypt('literal legacy', @literal_key)
+@literal_blob = Familia::JsonSerializer.dump(
+  Familia::Encryption::EncryptedData.new(
+    algorithm: @provider.algorithm,
+    nonce: Base64.strict_encode64(@literal_enc[:nonce]),
+    ciphertext: Base64.strict_encode64(@literal_enc[:ciphertext]),
+    auth_tag: Base64.strict_encode64(@literal_enc[:auth_tag]),
+    key_version: :v1,
+    encoding: 'UTF-8'
+  ).to_h
+)
+Familia.config.encryption_personalization = 'AnotherFreshApp'
+Familia.config.encryption_personalization_history = []
+@mgr.decrypt(@literal_blob, context: @ctx)
+#=> 'literal legacy'
+
+## No false positive: a wrong personalization never "succeeds" into garbage --
+## Poly1305 auth must fail and raise rather than return a plausible wrong string.
+Familia.config.encryption_personalization = 'GoodPersonal'
+Familia.config.encryption_personalization_history = []
+@fp_blob = @mgr.encrypt('do not leak', context: @ctx)
+Familia.config.encryption_personalization = 'WrongPersonal'
+Familia.config.encryption_personalization_history = []
+begin
+  @mgr.decrypt(@fp_blob, context: @ctx)
+  'false-positive!'
+rescue Familia::EncryptionError
+  'rejected'
+end
+#=> 'rejected'
+
+## personalizations is current-first, deduplicated, and ends with the legacy value
+Familia.config.encryption_personalization = 'Curr'
+Familia.config.encryption_personalization_history = ['Curr', 'Prev', 'Prev']
+Familia::Encryption::Providers::XChaCha20Poly1305Provider.new.personalizations
+#=> ['Curr', 'Prev', 'FamilialMatters']
+
+## Invalid history entries (non-String, blank, null bytes, >16 bytes) are
+## filtered out of the candidate list -- each would otherwise raise mid-walk
+## (EncryptionError or RbNaCl::LengthError) and abort the remaining candidates.
+Familia.config.encryption_personalization = 'Curr'
+Familia.config.encryption_personalization_history = [nil, 123, '', "nul\0led", 'x' * 17, 'ValidOld']
+Familia::Encryption::Providers::XChaCha20Poly1305Provider.new.personalizations
+#=> ['Curr', 'ValidOld', 'FamilialMatters']
+
+## A decrypt walk configured with junk history entries still reaches the valid
+## candidate that sits behind them, instead of aborting on the junk.
+Familia.config.encryption_personalization = 'ValidOld'
+Familia.config.encryption_personalization_history = []
+@junk_blob = @mgr.encrypt('survives junk', context: @ctx)
+Familia.config.encryption_personalization = 'NewerApp'
+Familia.config.encryption_personalization_history = ['', "nul\0led", 'x' * 17, 'ValidOld']
+@mgr.decrypt(@junk_blob, context: @ctx)
+#=> 'survives junk'
+
+## Request cache keys by personalization: two blobs needing different values
+## both decrypt correctly inside one cache scope (a personalization-blind cache
+## key would corrupt one).
+Familia.config.encryption_personalization = 'CachePersA'
+Familia.config.encryption_personalization_history = []
+@cache_a = @mgr.encrypt('alpha', context: @ctx)
+Familia.config.encryption_personalization = 'CachePersB'
+Familia.config.encryption_personalization_history = []
+@cache_b = @mgr.encrypt('beta', context: @ctx)
+Familia.config.encryption_personalization = 'CachePersB'
+Familia.config.encryption_personalization_history = ['CachePersA']
+Familia::Encryption.with_request_cache do
+  [@mgr.decrypt(@cache_b, context: @ctx), @mgr.decrypt(@cache_a, context: @ctx)]
+end
+#=> ['beta', 'alpha']
+
+## Encrypt then decrypt the same value in one cache scope derives once. The
+## encrypt path (personal nil, resolved to current_personalization) and the
+## decrypt loop's first iteration (explicit personalizations.first) share a
+## single cache entry, instead of filing the same derived key under nil and
+## under the resolved value. A single cached entry proves the redundant second
+## derivation is gone (mirrors the #311 salt behaviour).
+Familia.config.encryption_personalization = 'CacheShared'
+Familia.config.encryption_personalization_history = []
+@shared_size = Familia::Encryption.with_request_cache do
+  blob = @mgr.encrypt('shared', context: @ctx)
+  @mgr.decrypt(blob, context: @ctx)
+  Fiber[:familia_request_cache].size
+end
+@shared_size
+#=> 1
+
+## Fail closed: a nil encryption_personalization refuses to ENCRYPT rather than
+## silently deriving under the legacy default (which would withhold the
+## per-deployment domain separation). The raw attr_writer can set nil past the
+## reader's guards, so the check lives at derivation time.
+Familia.config.encryption_personalization = nil
+Familia.config.encryption_personalization_history = []
+begin
+  @mgr.encrypt('should not encrypt', context: @ctx)
+  'encrypted-unexpectedly'
+rescue Familia::EncryptionError => e
+  e.message.include?('non-empty') ? 'refused' : 'wrong-error'
+end
+#=> 'refused'
+
+## An empty encryption_personalization is likewise refused for encryption
+Familia.config.encryption_personalization = ''
+Familia.config.encryption_personalization_history = []
+begin
+  @mgr.encrypt('should not encrypt', context: @ctx)
+  'encrypted-unexpectedly'
+rescue Familia::EncryptionError
+  'refused'
+end
+#=> 'refused'
+
+## Decryption stays permissive even with a blank current personalization: data
+## written under a now-historical value still decrypts (old data stays readable
+## even if the current config is broken), while new writes are refused above.
+Familia.config.encryption_personalization = 'WritePers'
+Familia.config.encryption_personalization_history = []
+@written = @mgr.encrypt('readable later', context: @ctx)
+Familia.config.encryption_personalization = nil
+Familia.config.encryption_personalization_history = ['WritePers']
+@mgr.decrypt(@written, context: @ctx)
+#=> 'readable later'
+
+# TEARDOWN
+Familia.config.encryption_personalization = @orig_personal
+Familia.config.encryption_personalization_history = @orig_history
+Familia.config.encryption_hkdf_salt = @orig_salt
+clear_test_encryption_keys
+# Restore the request-cache fiber-locals to their pristine (nil) state. The
+# cache tests above run with_request_cache, whose ensure leaves
+# `enabled=false`; in the shared full-suite process that would otherwise leak
+# into a later file asserting the untouched default is nil (request_cache_try).
+Fiber[:familia_request_cache] = nil
+Fiber[:familia_request_cache_enabled] = nil


### PR DESCRIPTION
## Summary

Closes #333. Makes the BLAKE2b personalization string rotatable, mirroring the 2.11.0 AES-GCM HKDF salt design (#311): writes pin to the single current `encryption_personalization`; decrypt walks a candidate list — current value, then `encryption_personalization_history`, then the legacy default `'FamilialMatters'`.

Before this, changing `encryption_personalization` made every existing XChaCha20-Poly1305 envelope permanently undecryptable — the hazard pinned by the upgrade proof (#330). With the legacy decrypt tail, deployments on the default (i.e. all current Onetimesecret v0.26 installs) can rotate with zero config; only rotation away from a non-default value requires a history entry.

## Changes

- **`Familia.config.encryption_personalization_history`** (default `[]`), analogous to `encryption_hkdf_salt_history`.
- **New shared `Blake2bPersonalization` module** included by both XChaCha providers (kills the #250/#356-style drift): `#personalizations` (filtered, deduped candidate list ending in `LEGACY_PERSONALIZATION`) and fail-closed `#current_personalization`.
- **Manager decrypt walk generalized** from salt-only to one rotation dimension per provider (`{salt:}` / `{personal:}` candidates; N×M explicitly forbidden). Key derivation moved inside the per-candidate rescue so an invalid candidate falls through instead of aborting the walk.
- **Request-cache key gained a personalization segment** — previously all XChaCha candidates collided on one cache entry, which would have made rotation silently inert inside `with_request_cache`.
- Behavior change: an explicit `personal:` over 16 bytes now raises `Familia::EncryptionError` instead of leaking `RbNaCl::LengthError`.
- Upgrade proof: the "personalization is unrotatable" check now proves rotation works (legacy tail + history), keeping a negative case for non-default values without history. Includes two pre-existing harness fixes needed for a green run (missing `base64` in proof gemfiles on Ruby 3.4; stale phase3 error-message regex).
- Docs: rotation guidance added alongside the salt-history docs; scriv changelog fragment included.

## Testing

- New `try/features/encryption/xchacha20_personalization_rotation_try.rb` (18 cases) mirroring the salt-rotation tryout case-for-case, including the request-cache candidate-key cases and the zero-config legacy-tail decrypt (mutant-checked: removing the legacy tail fails the test).
- Extended provider, config-persistence, and secure-memory tryouts (+12 cases).
- Full run: 880 tryout cases passing across encryption, encrypted_fields, and adjacent suites; rubocop clean on changed lib files.
- Upgrade proof phases 0–3 all green end-to-end.

_Implemented with AI assistance (multi-agent workflow: core, tests, proof, docs, verify)._