### PR TITLE
Stabilize test suite: scoped cleanup and deterministic flake fixes

### DIFF
--- a/try/features/dirty_write_warnings_try.rb
+++ b/try/features/dirty_write_warnings_try.rb
@@ -453,4 +453,5 @@ count_dirty_warnings(@no_out)
 Familia.strict_write_order = false
 Familia.dirty_write_warnings = :once
 Familia.raise_on_unsaved_parent_write = true
-Familia.dbclient.flushdb
+# Scoped delete of this file's DWW* model keys, never FLUSHDB (issue #283).
+delete_test_dbkeys('dww_*')

--- a/try/features/encrypted_fields/aad_nil_fields_try.rb
+++ b/try/features/encrypted_fields/aad_nil_fields_try.rb
@@ -33,7 +33,7 @@ class AADMultiFieldModel < Familia::Horreum
   encrypted_field :token, aad_fields: [:org, :role, :region]
 end
 
-Familia.dbclient.flushdb
+delete_test_dbkeys(AADNilFieldModel, AADMultiFieldModel) # scoped delete, not FLUSHDB (issue #283)
 
 ## Encrypt with nil AAD field and reveal without changing it succeeds
 record = AADNilFieldModel.new(id: 'nil-aad-1')
@@ -108,5 +108,5 @@ aad_one = @ft.send(:build_aad, rec_one_nil)
 aad_two != aad_one
 #=> true
 
-Familia.dbclient.flushdb
+delete_test_dbkeys(AADNilFieldModel, AADMultiFieldModel) # scoped delete, not FLUSHDB (issue #283)
 clear_test_encryption_keys

--- a/try/features/encrypted_fields/aad_protection_try.rb
+++ b/try/features/encrypted_fields/aad_protection_try.rb
@@ -23,7 +23,7 @@ class AADProtectedModel < Familia::Horreum
 end
 
 # Clean test environment
-Familia.dbclient.flushdb
+delete_test_dbkeys(AADProtectedModel) # scoped delete, not FLUSHDB (issue #283)
 
 ## AAD prevents field substitution attacks - proper cross-record test
 @victim = AADProtectedModel.new(id: 'victim-1', email: 'victim@example.com')
@@ -136,5 +136,5 @@ decrypted_legit
 #=> "legitimate-secret"
 
 # Cleanup
-Familia.dbclient.flushdb
+delete_test_dbkeys(AADProtectedModel) # scoped delete, not FLUSHDB (issue #283)
 clear_test_encryption_keys

--- a/try/features/encrypted_fields/aad_roundtrip_try.rb
+++ b/try/features/encrypted_fields/aad_roundtrip_try.rb
@@ -30,7 +30,7 @@ class AADRoundtripEnforcementModel < Familia::Horreum
   encrypted_field :api_key, aad_fields: [:email]
 end
 
-Familia.dbclient.flushdb
+delete_test_dbkeys(AADRoundtripModel, AADRoundtripEnforcementModel) # scoped delete, not FLUSHDB (issue #283)
 
 ## reveal succeeds on in-memory object after create! with aad_fields
 config = AADRoundtripModel.create!(domain_id: 'dom-001', api_key: 'secret-abc')
@@ -96,5 +96,5 @@ end
 result_enforced
 #=> "Familia::EncryptionError"
 
-Familia.dbclient.flushdb
+delete_test_dbkeys(AADRoundtripModel, AADRoundtripEnforcementModel) # scoped delete, not FLUSHDB (issue #283)
 clear_test_encryption_keys

--- a/try/features/encrypted_fields/aad_transient_fix_try.rb
+++ b/try/features/encrypted_fields/aad_transient_fix_try.rb
@@ -39,7 +39,7 @@ class MixedAADModel < Familia::Horreum
   encrypted_field :api_key, aad_fields: [:region, :session_token]
 end
 
-Familia.dbclient.flushdb
+delete_test_dbkeys(TransientAADModel, MixedAADModel) # scoped delete, not FLUSHDB (issue #283)
 
 @field_type = TransientAADModel.field_types[:secret]
 @mixed_ft = MixedAADModel.field_types[:api_key]
@@ -158,5 +158,5 @@ end
 @aad_build == @aad_from
 #=> true
 
-Familia.dbclient.flushdb
+delete_test_dbkeys(TransientAADModel, MixedAADModel) # scoped delete, not FLUSHDB (issue #283)
 clear_test_encryption_keys

--- a/try/features/encrypted_fields/aad_transient_proof_try.rb
+++ b/try/features/encrypted_fields/aad_transient_proof_try.rb
@@ -82,7 +82,7 @@ class SecretWithTransientAAD < Familia::Horreum
   transient_field :ciphertext_passphrase
 end
 
-Familia.dbclient.flushdb
+delete_test_dbkeys(SecretNoAAD, SecretWithFieldAAD, SecretTwoFieldAAD, SecretWithTransientAAD) # scoped delete, not FLUSHDB (issue #283)
 
 # ============================================================
 # PART 1: Current OTS behavior — no AAD, decrypt without passphrase
@@ -247,5 +247,5 @@ end
 #=> false
 
 # Cleanup
-Familia.dbclient.flushdb
+delete_test_dbkeys(SecretNoAAD, SecretWithFieldAAD, SecretTwoFieldAAD, SecretWithTransientAAD) # scoped delete, not FLUSHDB (issue #283)
 clear_test_encryption_keys

--- a/try/features/encrypted_fields/concealed_string_core_try.rb
+++ b/try/features/encrypted_fields/concealed_string_core_try.rb
@@ -27,7 +27,7 @@ end
 Object.const_set(:SecretDocument, TestSecretDocument)
 
 # Clean test environment
-Familia.dbclient.flushdb
+delete_test_dbkeys(TestSecretDocument) # scoped delete, not FLUSHDB (issue #283)
 
 # Create test document
 @doc = SecretDocument.new
@@ -224,7 +224,9 @@ debug_array.map(&:to_s)
 
 ## Debug what's actually in the database
 # Redis/Valkey do not guarantee KEYS ordering; sort for a deterministic check.
-@all_keys = Familia.dbclient.keys("*")
+# Scoped to this file's prefix (issue #283): the db is shared with other
+# tryout files, so asserting the whole keyspace is not valid.
+@all_keys = Familia.dbclient.keys("secret_document:*")
 @all_keys.sort
 #=> ["secret_document:instances", "secret_document:test123:object"]
 
@@ -264,5 +266,5 @@ end
 #=> "Public Title has concealed content"
 
 # Teardown
-Familia.dbclient.flushdb
+delete_test_dbkeys(TestSecretDocument) # scoped delete, not FLUSHDB (issue #283)
 clear_test_encryption_keys

--- a/try/features/encrypted_fields/envelope_version_branching_try.rb
+++ b/try/features/encrypted_fields/envelope_version_branching_try.rb
@@ -33,7 +33,7 @@ class VersionBranchKMModel < Familia::Horreum
   encrypted_field :vault, key_material: ->(r) { r.salt }
 end
 
-Familia.dbclient.flushdb
+delete_test_dbkeys(VersionBranchModel, VersionBranchKMModel) # scoped delete, not FLUSHDB (issue #283)
 
 ## v2 envelope decrypts normally
 @record = VersionBranchModel.new(id: 'vb-1', org_id: 'org-a')
@@ -100,5 +100,5 @@ end
 @loaded_env['envelope_version']
 #=> 2
 
-Familia.dbclient.flushdb
+delete_test_dbkeys(VersionBranchModel, VersionBranchKMModel) # scoped delete, not FLUSHDB (issue #283)
 clear_test_encryption_keys

--- a/try/features/encrypted_fields/envelope_version_try.rb
+++ b/try/features/encrypted_fields/envelope_version_try.rb
@@ -34,7 +34,7 @@ class EnvelopeNoAADModel < Familia::Horreum
   encrypted_field :token
 end
 
-Familia.dbclient.flushdb
+delete_test_dbkeys(EnvelopeVersionModel, EnvelopeNoAADModel, 'evolving_model:*', 'multi_aad_model:*', 'empty_aad_model:*') # scoped delete, not FLUSHDB (issue #283)
 
 ## New envelope has envelope_version: 2
 @record = EnvelopeVersionModel.new(id: 'env-v2-1', org_id: 'org-abc')
@@ -165,5 +165,5 @@ end
 @empty_env['aad_fields']
 #=> nil
 
-Familia.dbclient.flushdb
+delete_test_dbkeys(EnvelopeVersionModel, EnvelopeNoAADModel, 'evolving_model:*', 'multi_aad_model:*', 'empty_aad_model:*') # scoped delete, not FLUSHDB (issue #283)
 clear_test_encryption_keys

--- a/try/features/encrypted_fields/fast_writer_try.rb
+++ b/try/features/encrypted_fields/fast_writer_try.rb
@@ -20,7 +20,7 @@ class EncryptedFastWriterModel < Familia::Horreum
   encrypted_field :secret
 end
 
-Familia.dbclient.flushdb
+delete_test_dbkeys(EncryptedFastWriterModel) # scoped delete, not FLUSHDB (issue #283)
 
 ## Fast write persists and can be revealed after reload
 record = EncryptedFastWriterModel.new(id: 'fast-1')
@@ -63,5 +63,5 @@ loaded_normal.secret.reveal { |pt| decrypted_normal = pt }
 decrypted_fast == decrypted_normal && decrypted_fast == 'shared-value'
 #=> true
 
-Familia.dbclient.flushdb
+delete_test_dbkeys(EncryptedFastWriterModel) # scoped delete, not FLUSHDB (issue #283)
 clear_test_encryption_keys

--- a/try/features/encrypted_fields/key_material_try.rb
+++ b/try/features/encrypted_fields/key_material_try.rb
@@ -47,7 +47,7 @@ class NoKeyMaterialModel < Familia::Horreum
   encrypted_field :token
 end
 
-Familia.dbclient.flushdb
+delete_test_dbkeys(KeyMaterialModel, KeyMaterialTransientModel, NoKeyMaterialModel, 'nil_key_material_model:*', 'combined_model:*') # scoped delete, not FLUSHDB (issue #283)
 
 ## key_material present, correct value at decrypt succeeds
 record = KeyMaterialModel.new(id: 'km-1', user_salt: 'salt-abc')
@@ -199,5 +199,5 @@ end
 result_km
 #=> "Familia::EncryptionError"
 
-Familia.dbclient.flushdb
+delete_test_dbkeys(KeyMaterialModel, KeyMaterialTransientModel, NoKeyMaterialModel, 'nil_key_material_model:*', 'combined_model:*') # scoped delete, not FLUSHDB (issue #283)
 clear_test_encryption_keys

--- a/try/features/encrypted_fields/secure_by_default_behavior_try.rb
+++ b/try/features/encrypted_fields/secure_by_default_behavior_try.rb
@@ -26,7 +26,7 @@ class SecureUserAccount < Familia::Horreum
 end
 
 # Clean test environment
-Familia.dbclient.flushdb
+delete_test_dbkeys(SecureUserAccount) # scoped delete, not FLUSHDB (issue #283)
 
 # Create test user
 @user = SecureUserAccount.new
@@ -352,5 +352,5 @@ end
 #=> true
 
 # Teardown
-Familia.dbclient.flushdb
+delete_test_dbkeys(SecureUserAccount) # scoped delete, not FLUSHDB (issue #283)
 clear_test_encryption_keys

--- a/try/features/encrypted_fields/universal_serialization_safety_try.rb
+++ b/try/features/encrypted_fields/universal_serialization_safety_try.rb
@@ -26,7 +26,7 @@ class DataRecord < Familia::Horreum
 end
 
 # Clean environment
-Familia.dbclient.flushdb
+delete_test_dbkeys(DataRecord) # scoped delete, not FLUSHDB (issue #283)
 
 # Create test record with mixed data
 @record = DataRecord.new
@@ -191,5 +191,5 @@ end
 #=> true
 
 # Teardown
-Familia.dbclient.flushdb
+delete_test_dbkeys(DataRecord) # scoped delete, not FLUSHDB (issue #283)
 clear_test_encryption_keys

--- a/try/features/transient_fields/refresh_reset_try.rb
+++ b/try/features/transient_fields/refresh_reset_try.rb
@@ -8,7 +8,10 @@ require_relative '../../support/helpers/test_helpers'
 
 Familia.debug = false
 
-Familia.dbclient.flushdb
+# Scoped delete, never FLUSHDB (issue #283). SecretService is also defined
+# by transient_fields_core/integration tryouts with different identifiers,
+# so scope down to the exact identifiers this file writes.
+delete_test_dbkeys('secret_service:test-service:*', 'simple_service:no-transient-test:*')
 
 class SecretService < Familia::Horreum
   feature :transient_fields

--- a/try/integration/connection/isolated_dbclient_try.rb
+++ b/try/integration/connection/isolated_dbclient_try.rb
@@ -14,11 +14,16 @@ require_relative '../../support/helpers/test_helpers'
 # Clean up any existing test data left by previous runs of THIS file.
 # Scoped delete, never FLUSHDB (issue #283): these databases are shared
 # with other tryout files. The list below is exactly the keys this file
-# writes, removed from every db it exercises (0..8).
+# writes, removed from every db it exercises (0..8). Keys are namespaced
+# with this file's name so the cleanup can't collide with other files'
+# keys under --parallel.
 own_keys = %w[
-  test_key cached_key isolated_key before_error after_error
-  db_test uri_test default_test test_model:test:object
-] + (0..4).map { |i| "temp_key_#{i}" }
+  isolated_dbclient_try:test_key isolated_dbclient_try:cached_key
+  isolated_dbclient_try:isolated_key isolated_dbclient_try:before_error
+  isolated_dbclient_try:after_error isolated_dbclient_try:db_test
+  isolated_dbclient_try:uri_test isolated_dbclient_try:default_test
+  test_model:test:object
+] + (0..4).map { |i| "isolated_dbclient_try:temp_key_#{i}" }
 (0..8).each do |db|
   Familia.with_isolated_dbclient(db) do |client|
     client.del(*own_keys)
@@ -36,17 +41,17 @@ different_objects
 
 ## isolated_dbclient connects to the correct database
 Familia.with_isolated_dbclient(5) do |client|
-  client.set("test_key", "test_value")
+  client.set("isolated_dbclient_try:test_key", "test_value")
 end
 
 # Verify the key was set in database 5
 found_in_db5 = Familia.with_isolated_dbclient(5) do |client|
-  client.get("test_key") == "test_value"
+  client.get("isolated_dbclient_try:test_key") == "test_value"
 end
 
 # Verify the key is NOT in database 0
 not_found_in_db0 = Familia.with_isolated_dbclient(0) do |client|
-  client.get("test_key").nil?
+  client.get("isolated_dbclient_try:test_key").nil?
 end
 
 found_in_db5 && not_found_in_db0
@@ -55,17 +60,17 @@ found_in_db5 && not_found_in_db0
 ## isolated_dbclient doesn't affect cached connections
 # Set up a cached connection
 regular_client = Familia.dbclient(0)
-regular_client.set("cached_key", "cached_value")
+regular_client.set("isolated_dbclient_try:cached_key", "cached_value")
 
 # Use isolated connection on same database
 isolated_result = Familia.with_isolated_dbclient(0) do |client|
-  client.set("isolated_key", "isolated_value")
-  client.get("cached_key")
+  client.set("isolated_dbclient_try:isolated_key", "isolated_value")
+  client.get("isolated_dbclient_try:cached_key")
 end
 
 # Both keys should be accessible
-cached_accessible = regular_client.get("cached_key") == "cached_value"
-isolated_accessible = regular_client.get("isolated_key") == "isolated_value"
+cached_accessible = regular_client.get("isolated_dbclient_try:cached_key") == "cached_value"
+isolated_accessible = regular_client.get("isolated_dbclient_try:isolated_key") == "isolated_value"
 
 cached_accessible && isolated_accessible && isolated_result == "cached_value"
 #=> true
@@ -77,7 +82,7 @@ captured_clients = []
 5.times do |i|
   Familia.with_isolated_dbclient(i) do |client|
     captured_clients << client
-    client.set("temp_key_#{i}", "temp_value_#{i}")
+    client.set("isolated_dbclient_try:temp_key_#{i}", "temp_value_#{i}")
     # Verify connection works inside block
     client.ping
   end
@@ -86,7 +91,7 @@ end
 # Verify all connections worked and created distinct objects
 all_worked = captured_clients.size == 5
 all_distinct = captured_clients.map(&:object_id).uniq.size == 5
-keys_set = Familia.with_isolated_dbclient(0) { |c| c.exists?("temp_key_0") }
+keys_set = Familia.with_isolated_dbclient(0) { |c| c.exists?("isolated_dbclient_try:temp_key_0") }
 
 all_worked && all_distinct && keys_set
 #=> true
@@ -97,10 +102,10 @@ database_state_correct = false
 
 begin
   Familia.with_isolated_dbclient(0) do |client|
-    client.set("before_error", "value")
+    client.set("isolated_dbclient_try:before_error", "value")
     raise "Test exception"
     # This line should not be reached
-    client.set("after_error", "should_not_be_set")
+    client.set("isolated_dbclient_try:after_error", "should_not_be_set")
   end
 rescue => e
   exception_raised = (e.message == "Test exception")
@@ -109,7 +114,7 @@ end
 # Verify the database state after the exception was caught
 if exception_raised
   database_state_correct = Familia.with_isolated_dbclient(0) do |client|
-    client.get("before_error") == "value" && client.get("after_error").nil?
+    client.get("isolated_dbclient_try:before_error") == "value" && client.get("isolated_dbclient_try:after_error").nil?
   end
 end
 
@@ -147,16 +152,16 @@ Familia.unload_member(TestModel)
 
 ## isolated_dbclient with Integer argument
 client = Familia.isolated_dbclient(7)
-client.set("db_test", "seven")
-result = client.get("db_test")
+client.set("isolated_dbclient_try:db_test", "seven")
+result = client.get("isolated_dbclient_try:db_test")
 client.close
 result
 #=> "seven"
 
 ## isolated_dbclient with String URI argument
 client = Familia.isolated_dbclient("redis://localhost:2525/8")
-client.set("uri_test", "eight")
-result = client.get("uri_test")
+client.set("isolated_dbclient_try:uri_test", "eight")
+result = client.get("isolated_dbclient_try:uri_test")
 client.close
 result
 #=> "eight"
@@ -164,11 +169,11 @@ result
 ## isolated_dbclient with nil uses default
 default_db = Familia.uri.db || 0
 client = Familia.isolated_dbclient(nil)
-client.set("default_test", "default_value")
+client.set("isolated_dbclient_try:default_test", "default_value")
 
 # Verify it's in the expected database
 verification = Familia.with_isolated_dbclient(default_db) do |verify_client|
-  verify_client.get("default_test")
+  verify_client.get("isolated_dbclient_try:default_test")
 end
 
 client.close

--- a/try/integration/connection/isolated_dbclient_try.rb
+++ b/try/integration/connection/isolated_dbclient_try.rb
@@ -11,10 +11,17 @@
 
 require_relative '../../support/helpers/test_helpers'
 
-# Clean up any existing test data in all test databases
-(0..2).each do |db|
+# Clean up any existing test data left by previous runs of THIS file.
+# Scoped delete, never FLUSHDB (issue #283): these databases are shared
+# with other tryout files. The list below is exactly the keys this file
+# writes, removed from every db it exercises (0..8).
+own_keys = %w[
+  test_key cached_key isolated_key before_error after_error
+  db_test uri_test default_test test_model:test:object
+] + (0..4).map { |i| "temp_key_#{i}" }
+(0..8).each do |db|
   Familia.with_isolated_dbclient(db) do |client|
-    client.flushdb
+    client.del(*own_keys)
   end
 end
 

--- a/try/integration/connection/middleware_reconnect_try.rb
+++ b/try/integration/connection/middleware_reconnect_try.rb
@@ -40,9 +40,9 @@ chain_cleared
 
 
 
-## Setup: Clean database
-ReconnectTestUser.dbclient.flushdb
-#=> "OK"
+## Setup: Clean this file's keys (scoped delete, never FLUSHDB -- issue #283)
+delete_test_dbkeys(ReconnectTestUser).is_a?(Integer)
+#=> true
 
 ## Test 1: Basic reconnect functionality clears chain and increments version
 Familia.enable_database_logging = true

--- a/try/integration/connection/pools_try.rb
+++ b/try/integration/connection/pools_try.rb
@@ -84,9 +84,11 @@ class PoolTestAccountDB1 < Familia::Horreum
 end
 
 
-## Clean up before tests
-PoolTestAccount.dbclient.flushdb
-#=> "OK"
+## Clean up before tests (scoped delete, never FLUSHDB -- issue #283).
+## Model identifiers are random per run; this just prevents accumulation
+## of this file's own keys, including Test 13's test_key_<hex> strings.
+delete_test_dbkeys(PoolTestAccount, PoolTestSession, PoolTestAccountDB1, 'test_key_*').is_a?(Integer)
+#=> true
 
 ## Test 1: Connection provider configuration
 Familia.connection_provider.is_a?(Proc)

--- a/try/support/debugging/simple_refresh_test.rb
+++ b/try/support/debugging/simple_refresh_test.rb
@@ -1,8 +1,8 @@
-# try/features/transient_fields/simple_refresh_test.rb
+# try/support/debugging/simple_refresh_test.rb
 #
 # frozen_string_literal: true
 
-require_relative '../../helpers/test_helpers'
+require_relative '../helpers/test_helpers'
 
 Familia.debug = false
 Familia.dbclient.flushdb

--- a/try/support/helpers/test_helpers.rb
+++ b/try/support/helpers/test_helpers.rb
@@ -27,6 +27,52 @@ def generate_random_email
   "#{username}@#{domain}"
 end
 
+# Scoped cleanup for tryout files sharing the test server (issue #283).
+#
+# Every try file talks to the same Valkey/Redis instance (logical db 0
+# unless a model overrides it), and the runner may execute files in
+# parallel. A FLUSHDB in one file erases another file's live data
+# mid-run, so test files must never flush. Delete only the keys the
+# file itself creates instead:
+#
+#   delete_test_dbkeys(Widget241, DwModeModel)      # by model class
+#   delete_test_dbkeys('widget282*')                # by key pattern
+#   delete_test_dbkeys('test:*', client: source)    # explicit connection
+#
+# A Familia::Horreum subclass contributes the pattern "<prefix>:*" and
+# is cleaned through its own #dbclient, so logical_database is
+# respected. A String is used verbatim as a SCAN MATCH pattern against
+# +client+ (default Familia.dbclient). Keys are discovered with SCAN and
+# removed with DEL, so nothing outside the given patterns is touched.
+#
+# Keep patterns tight: a prefix shared with another try file (grep for
+# the class name first) means you must scope down to the exact
+# identifiers this file writes.
+#
+# @return [Integer] total number of keys deleted
+def delete_test_dbkeys(*targets, client: nil)
+  targets.sum do |target|
+    if target.is_a?(Class) && target <= Familia::Horreum
+      scan_and_delete_dbkeys("#{target.prefix}#{Familia.delim}*", target.dbclient)
+    else
+      scan_and_delete_dbkeys(target.to_s, client || Familia.dbclient)
+    end
+  end
+end
+
+# SCAN+DEL every key matching +pattern+ on +dbclient+. Building block
+# for #delete_test_dbkeys; prefer that entry point in test files.
+def scan_and_delete_dbkeys(pattern, dbclient)
+  deleted = 0
+  cursor = '0'
+  loop do
+    cursor, keys = dbclient.scan(cursor, match: pattern, count: 1000)
+    deleted += dbclient.del(*keys) unless keys.empty?
+    break if cursor == '0'
+  end
+  deleted
+end
+
 class Bone < Familia::Horreum
   using Familia::Refinements::TimeLiterals
 

--- a/try/unit/core/suite_hygiene_try.rb
+++ b/try/unit/core/suite_hygiene_try.rb
@@ -1,0 +1,25 @@
+# try/unit/core/suite_hygiene_try.rb
+#
+# frozen_string_literal: true
+
+# Suite hygiene guard (issue #283): no tryout file may call FLUSHDB or
+# FLUSHALL. The whole suite shares one Valkey/Redis server (logical db 0
+# unless a model overrides it), so a flush in one file erases another
+# file's live data mid-run -- the suite is order-fragile sequentially and
+# unsafe under --parallel. Use the scoped cleanup helper instead:
+# `delete_test_dbkeys` in try/support/helpers/test_helpers.rb.
+#
+# The forbidden-word regex is case-sensitive and this file spells the
+# commands in uppercase only, so the guard does not match itself. There
+# is no allowlist on purpose: the expected offender count is zero.
+
+require_relative '../../support/helpers/test_helpers'
+
+## No *_try.rb file under try/ contains a lowercase FLUSHDB/FLUSHALL call
+try_root = File.expand_path('../..', __dir__)
+forbidden = /\bflush(?:db|all)\b/
+offenders = Dir.glob(File.join(try_root, '**', '*_try.rb')).select do |path|
+  File.read(path).match?(forbidden)
+end
+offenders.map { |path| path.sub("#{try_root}/", '') }.sort
+#=> []

--- a/try/unit/core/suite_hygiene_try.rb
+++ b/try/unit/core/suite_hygiene_try.rb
@@ -10,15 +10,22 @@
 # `delete_test_dbkeys` in try/support/helpers/test_helpers.rb.
 #
 # The forbidden-word regex is case-sensitive and this file spells the
-# commands in uppercase only, so the guard does not match itself. There
-# is no allowlist on purpose: the expected offender count is zero.
+# commands in uppercase only, so the guard does not match itself.
+#
+# Scope is every .rb under try/ except try/support/: the suite runner only
+# executes *_try.rb, but non-tryout scripts sitting in suite directories
+# get required or copy-pasted from, so they must not flush either. Manual
+# debugging/prototype scripts live in try/support/ and are allowlisted.
 
 require_relative '../../support/helpers/test_helpers'
 
-## No *_try.rb file under try/ contains a lowercase FLUSHDB/FLUSHALL call
+## No .rb file under try/ (outside try/support/) contains a lowercase
+## FLUSHDB/FLUSHALL call
 try_root = File.expand_path('../..', __dir__)
 forbidden = /\bflush(?:db|all)\b/
-offenders = Dir.glob(File.join(try_root, '**', '*_try.rb')).select do |path|
+offenders = Dir.glob(File.join(try_root, '**', '*.rb')).reject do |path|
+  path.start_with?(File.join(try_root, 'support/'))
+end.select do |path|
   File.read(path).match?(forbidden)
 end
 offenders.map { |path| path.sub("#{try_root}/", '') }.sort

--- a/try/unit/core/tools_try.rb
+++ b/try/unit/core/tools_try.rb
@@ -19,8 +19,10 @@ begin
   dest_moved = dest_redis.get('test:key1') == 'value1'
   source_removed = !source_redis.exists?('test:key1')
 
-  source_redis.flushdb
-  dest_redis.flushdb
+  # Scoped cleanup (issue #283): dbs 1 and 2 are shared with other tryout
+  # files, so delete only the keys this test created -- never flush.
+  source_redis.del('test:key1', 'test:key2')
+  dest_redis.del('test:key1', 'test:key2')
 
   [moved, dest_moved, source_removed]
 rescue NameError

--- a/try/unit/data_types/enumerable_consistency/large_scale_consistency_try.rb
+++ b/try/unit/data_types/enumerable_consistency/large_scale_consistency_try.rb
@@ -295,9 +295,20 @@ bulk_add_to_set(@bone_1m.tags, 1_000_000)
 @bone_1m.tags.element_count
 #=> 1000000
 
-## UnsortedSet 1M: streaming count matches element_count
-@bone_1m.tags.each(batch_size: 50000).count
-#=> 1000000
+## UnsortedSet 1M: streaming covers every member (SSCAN is at-least-once)
+# SSCAN guarantees at-least-once delivery, not exactly-once: a member can be
+# yielded more than once while the hash table rehashes (likely right after a
+# 1M-member bulk load), so an exact `.count == 1_000_000` is inherently racy.
+# Assert the semantics SSCAN actually provides: raw yield count is at least
+# the cardinality, and the deduplicated count matches element_count exactly.
+raw_count = 0
+unique = Set.new
+@bone_1m.tags.each(batch_size: 50000) do |item|
+  raw_count += 1
+  unique << item
+end
+[raw_count >= @bone_1m.tags.element_count, unique.size]
+#=> [true, 1000000]
 
 ## UnsortedSet 1M: streaming XOR checksum is non-zero (sanity check)
 checksum = 0

--- a/try/unit/data_types/lock_try.rb
+++ b/try/unit/data_types/lock_try.rb
@@ -95,9 +95,15 @@ require_relative '../../support/helpers/test_helpers'
 @ttl_token
 #=> 'ttl-token'
 
-## Wait for TTL expiration and check if lock auto-expires
-# Note: This test might be flaky in fast test runs
-sleep 2
+## Lock acquired with TTL registers an expiration
+@lock.current_expiration.positive?
+#=> true
+
+## Lock auto-expires once its TTL elapses
+# Poll with a bounded deadline instead of a single fixed sleep: the key
+# expires ~1s after acquisition; allow up to 3s for slow/loaded runners.
+deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + 3
+sleep 0.05 while @lock.locked? && Process.clock_gettime(Process::CLOCK_MONOTONIC) < deadline
 @lock.locked?
 #=> false
 

--- a/try/unit/horreum/destroy_index_cleanup_try.rb
+++ b/try/unit/horreum/destroy_index_cleanup_try.rb
@@ -43,7 +43,9 @@ class ::Widget241 < Familia::Horreum
 end
 
 # Start from a clean slate for indexes so previous test runs don't leak.
-Familia.dbclient.flushdb
+# Scoped to this file's own key prefixes (issue #283): the db is shared
+# with every other tryout file, so flushing it would erase their data.
+delete_test_dbkeys('widget241*', 'widget282*', 'dw_mode_model:*')
 
 ## Class-level unique_index is populated by save
 @w1 = Widget241.create!(objid: 'w241-unique-001', name: 'alpha')
@@ -868,10 +870,11 @@ rescue ArgumentError => e
 end
 #=> true
 
-# Teardown: flush the database and remove throwaway constants so this
+# Teardown: delete this file's keys and remove throwaway constants so this
 # tryout doesn't pollute sibling suites (index keys in particular can
-# otherwise interfere with re-run iterations).
-Familia.dbclient.flushdb
+# otherwise interfere with re-run iterations). Scoped delete, not FLUSHDB,
+# because the db is shared (issue #283).
+delete_test_dbkeys('widget241*', 'widget282*', 'dw_mode_model:*')
 %i[
   Widget241
   Widget241ScopedEmployee

--- a/try/unit/thread_safety_monitor_try.rb
+++ b/try/unit/thread_safety_monitor_try.rb
@@ -115,8 +115,12 @@ lock_held.pop  # Rendezvous: t1 definitely holds the mutex now
 
 t2 = Thread.new { mutex.synchronize { 'got lock' } }
 # Wait until t2 is blocked on the mutex (its try_lock has already failed
-# and contention has been recorded by the time it sleeps in Mutex#lock)
-Thread.pass while t2.alive? && t2.status != 'sleep'
+# and contention has been recorded by the time it sleeps in Mutex#lock).
+# Bounded deadline so an unexpected t2 state fails the assertion below
+# instead of hanging the suite.
+deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + 5
+Thread.pass while t2.alive? && t2.status != 'sleep' &&
+                  Process.clock_gettime(Process::CLOCK_MONOTONIC) < deadline
 
 release_lock.push(:go)
 t1.join

--- a/try/unit/thread_safety_monitor_try.rb
+++ b/try/unit/thread_safety_monitor_try.rb
@@ -93,32 +93,36 @@ duration_μs >= 5000
 #=> true
 
 ## Wait time tracking uses microsecond precision
+Familia.start_monitoring!
 mutex = Familia::ThreadSafety::InstrumentedMutex.new('timing_mutex')
 Familia.thread_safety_monitor.reset_metrics
 
-# Create intentional contention with timing
-t1_ready = false
-t2_ready = false
+# Force contention deterministically: t1 holds the mutex until t2 is
+# provably blocked waiting on it. Contention is recorded as soon as the
+# non-blocking try_lock inside #synchronize fails, so t2 attempting
+# acquisition while t1 holds the lock guarantees contention_count > 0.
+lock_held = Queue.new
+release_lock = Queue.new
 
 t1 = Thread.new do
   mutex.synchronize do
-    t1_ready = true
-    sleep 0.01 while !t2_ready  # Wait for t2 to be waiting
-    sleep 0.005  # Hold lock for 5ms
+    lock_held.push(:held)
+    release_lock.pop  # Hold the lock until explicitly released
   end
 end
 
-t2 = Thread.new do
-  sleep 0.001 while !t1_ready  # Wait for t1 to acquire lock
-  t2_ready = true
-  mutex.synchronize { 'got lock' }
-end
+lock_held.pop  # Rendezvous: t1 definitely holds the mutex now
 
+t2 = Thread.new { mutex.synchronize { 'got lock' } }
+# Wait until t2 is blocked on the mutex (its try_lock has already failed
+# and contention has been recorded by the time it sleeps in Mutex#lock)
+Thread.pass while t2.alive? && t2.status != 'sleep'
+
+release_lock.push(:go)
 t1.join
 t2.join
 
 stats = mutex.stats
-# Should show contention occurred due to intentional delay
 stats[:contention_count] > 0
 #=> true
 


### PR DESCRIPTION
## Summary

Fixes the three test-infra flake issues for CI credibility:

- **#283** — Eliminated all cross-file `FLUSHDB`/`FLUSHALL` from the tryouts suite. New `delete_test_dbkeys` helper (SCAN+DEL, prefix-scoped, respects per-class `logical_database`) replaces flushes in 19 files. A `suite_hygiene_try.rb` guard fails if a flush reappears anywhere under `try/` (with `try/support/` allowlisted for manual debugging/prototype scripts). A dead debug script with a broken require was relocated to `try/support/debugging/` and repaired.
- **#360** — Timing-dependent tests made deterministic: the monitor-contention test now forces contention via a Queue rendezvous (blocking guaranteed by `InstrumentedMutex` semantics, not scheduler luck) and no longer depends on leftover monitoring state; the lock TTL test replaces a fixed `sleep 2` with a bounded monotonic-deadline poll (~1s typical, 3s cap).
- **#364** — The 1M streaming-count expectation is now SSCAN-duplicate-tolerant: asserts coverage (`raw_count >= 1M`) plus deduplicated cardinality (`== 1M`), since SCAN-family cursors guarantee only at-least-once delivery during rehash.

Test-only changes; `lib/` untouched.

## Verification

- Full sequential suite: **6356 passed / 0 failed**, twice — second run deliberately started from a dirty keyspace to prove scoped cleanup needs no whole-DB flush.
- The three previously-flaky files: 3x combined repeats, 83/0 every run.
- `grep` confirms zero lowercase `flushdb`/`flushall` in any suite-run file; guard enforces it going forward.
- Parallel (`-j`) baseline comparison: failures dropped ~130–150 → ~90–110, and 10 files that failed in both pre-fix baselines are now consistently clean. The remaining parallel failures are **non-flush** shared-global-state interference (middleware counters, encryption-key rotation, logger swap, transaction mode, key-name collisions) — tracked separately in #382.

Closes #283. Closes #360. Closes #364. Follow-up: #382.