### PR TITLE
[#307] Remove redundant post-save index re-run in Relationships#save

### DIFF
--- a/changelog.d/20260803_120000_claude_307_remove_post_save_index_rerun.rst
+++ b/changelog.d/20260803_120000_claude_307_remove_post_save_index_rerun.rst
@@ -1,0 +1,20 @@
+Fixed
+-----
+
+- Removed the redundant post-save ``update_all_indexes`` re-run from the
+  ``Relationships`` feature's ``save`` override (follow-up to #306). Class-level
+  index maintenance is fully handled inside the save transaction by
+  ``auto_update_class_indexes``, so the post-``EXEC`` re-run only re-claimed and
+  re-wrote the same values -- costing an extra ``EXISTS`` probe, a
+  ``claim_field`` ``EVAL``, and a second ``MULTI`` per unique index, and able to
+  raise ``RecordExistsError``/``PersistenceError`` *after* the save had already
+  committed. #307
+
+AI Assistance
+-------------
+
+- AI deleted the ``save`` override in
+  ``Familia::Features::Relationships::ModelInstanceMethods`` and added
+  regression coverage asserting that a class-level ``unique_index`` save queues
+  its ``HSET`` inside the save ``MULTI``/``EXEC`` and issues no index writes
+  after the transaction commits.

--- a/lib/familia/features/relationships.rb
+++ b/lib/familia/features/relationships.rb
@@ -122,7 +122,6 @@ module Familia
           identifier_field
         end
 
-
         # Validate relationship configurations
         def validate_relationships!
           errors = []
@@ -147,9 +146,7 @@ module Familia
 
           # Validate identifier field exists
           id_field = identifier
-          unless instance_methods.include?(id_field) || method_defined?(id_field)
-            errors << "Identifier field '#{id_field}' is not defined"
-          end
+          errors << "Identifier field '#{id_field}' is not defined" unless method_defined?(id_field)
 
           raise RelationshipError, "Relationship validation failed: #{errors.join('; ')}" if errors.any?
 
@@ -174,8 +171,6 @@ module Familia
 
         # Include core score encoding methods at class level
         include ScoreEncoding
-
-        private
       end
 
       module ModelInstanceMethods
@@ -251,8 +246,6 @@ module Familia
 
           temp_key
         end
-
-        private
       end
     end
   end

--- a/lib/familia/features/relationships.rb
+++ b/lib/familia/features/relationships.rb
@@ -182,17 +182,6 @@ module Familia
         # NOTE: identifier and identifier= methods are provided by Horreum base class
         # No need to override them here - use the existing infrastructure
 
-        # Override save to update relationships automatically
-        def save(update_expiration: true)
-          result = super
-
-          if result && respond_to?(:update_all_indexes)
-            update_all_indexes
-          end
-
-          result
-        end
-
         # Get comprehensive relationship status for this object
         def relationship_status
           status = {

--- a/lib/familia/features/relationships/indexing.rb
+++ b/lib/familia/features/relationships/indexing.rb
@@ -209,8 +209,8 @@ module Familia
           #
           # 1. Dirty tracking is still live -- clear_dirty! runs after the
           #    transaction -- so the previous value of a changed indexed field
-          #    is available to retract. The relationships save hook runs after
-          #    the commit, where changed_fields is already empty.
+          #    is available to retract. A post-commit hook would see empty
+          #    changed_fields and could never retract stale entries.
           # 2. The index mutation commits atomically with the object hash.
           #
           # @param tracked_entries [Hash<String, String>] tracker entries

--- a/lib/familia/features/relationships/indexing.rb
+++ b/lib/familia/features/relationships/indexing.rb
@@ -487,10 +487,10 @@ module Familia
             return if exists?
 
             location = if scope_instance
-                         "#{index_name} on #{scope_instance.class.name}"
-                       else
-                         "class-level #{index_name}"
-                       end
+              "#{index_name} on #{scope_instance.class.name}"
+            else
+              "class-level #{index_name}"
+            end
             raise Familia::PersistenceError,
                   "Cannot index unsaved #{self.class.name} in #{location}: " \
                   'the index entry would point to a record that does not ' \

--- a/try/features/relationships/indexing_commands_verification_try.rb
+++ b/try/features/relationships/indexing_commands_verification_try.rb
@@ -141,3 +141,19 @@ memberships = @user.current_indexings
 membership = memberships.find { |m| m[:type] == 'unique_index' }
 [membership[:index_name], membership[:field], membership[:field_value]]
 #=> [:email_index, :email, "test@example.com"]
+
+## Regression #307: save writes the class-level unique index inside the save
+## transaction (the HSET is queued in the MULTI/EXEC pipeline, not issued after)
+@txn_user = TestIndexedUser.new(user_id: 'txn_user_307', email: 'txn307@example.com')
+@save_commands = DatabaseLogger.capture_commands { @txn_user.save }.map(&:command)
+@txn_pos = @save_commands.index { |cmd| cmd.match?(/\Amulti\b/i) && cmd.match?(/\bexec\z/i) }
+@save_commands[@txn_pos].downcase.include?('email_index')
+#=> true
+
+## Regression #307: no post-commit index writes after the save transaction.
+## Before #307 the Relationships save override re-ran update_all_indexes after
+## super, issuing an EXISTS probe, a claim_field EVAL, and a second MULTI with
+## a redundant HSET -- all after the save had already committed.
+@post_commit = @save_commands[(@txn_pos + 1)..]
+@post_commit.grep(/email_index|\beval\b/i)
+#=> []

--- a/try/features/relationships/indexing_commands_verification_try.rb
+++ b/try/features/relationships/indexing_commands_verification_try.rb
@@ -143,7 +143,10 @@ membership = memberships.find { |m| m[:type] == 'unique_index' }
 #=> [:email_index, :email, "test@example.com"]
 
 ## Regression #307: save writes the class-level unique index inside the save
-## transaction (the HSET is queued in the MULTI/EXEC pipeline, not issued after)
+## transaction (the HSET is queued in the MULTI/EXEC pipeline, not issued after).
+## Relies on DatabaseLogger.capture_commands rendering a pipelined MULTI..EXEC as
+## a single joined command string; if that format changes, @txn_pos comes back
+## nil and the next line raises TypeError -- a loud failure, not a silent pass.
 @txn_user = TestIndexedUser.new(user_id: 'txn_user_307', email: 'txn307@example.com')
 @save_commands = DatabaseLogger.capture_commands { @txn_user.save }.map(&:command)
 @txn_pos = @save_commands.index { |cmd| cmd.match?(/\Amulti\b/i) && cmd.match?(/\bexec\z/i) }


### PR DESCRIPTION
Deletes the `save` override in `Relationships::ModelInstanceMethods` that re-ran `update_all_indexes` after `super` — outside the save `MULTI/EXEC`, with empty `old_values`. Since PR #306, `auto_update_class_indexes` fully maintains class-level indexes inside the save transaction, so the post-super re-run was pure redundancy: ~3 extra round trips per unique index (`EXISTS` probe + `claim_field` EVAL + its own MULTI) and a window where `RecordExistsError`/`PersistenceError` could surface *after* the save had already committed.

Adds two regression cases to `indexing_commands_verification_try.rb` asserting the unique-index HSET lands inside the save MULTI and no index writes or EVALs follow it (mutant-verified: reinstating the override fails the test). Also fixes a doc comment that cited the removed hook, plus rubocop autocorrections on the touched files.

989/989 relationships tryouts green, plus unique-index edge cases, automatic index validation, transaction safety, and both atomic-write suites.

Closes #307