### PR TITLE
[#309] Bound *_with_permission query, add ZSCAN streaming sibling

### DIFF
--- a/changelog.d/20260803_090000_claude_309_bounded_permission_query.rst
+++ b/changelog.d/20260803_090000_claude_309_bounded_permission_query.rst
@@ -1,0 +1,29 @@
+Fixed
+-----
+
+- Bounded the generated ``<collection>_with_permission`` participation query,
+  which previously materialized the entire sorted set per call. Permission bits
+  live in the fractional part of the score and are not a contiguous range, so
+  they can never be filtered server-side; the query now pages internally via
+  ``ZRANGEBYSCORE ... LIMIT`` in ``batch_size:`` chunks (default 500), keeping
+  peak memory at O(batch_size) instead of O(N). Results are identical for
+  collections not being concurrently modified; unlike the old single-command
+  fetch, the paged read is not an atomic snapshot. #309
+
+Added
+-----
+
+- ``limit:`` and ``offset:`` keyword arguments on
+  ``<collection>_with_permission`` count *matching* members (post-filter
+  semantics), enabling pagination in deterministic score order, and a new
+  ``each_<collection>_with_permission(min_permission = :read, batch_size: 100)``
+  sibling streams matches via ``ZSCAN`` with O(1) retained memory — unordered,
+  at-least-once delivery — returning an ``Enumerator`` when called without a
+  block. #309
+
+AI Assistance
+-------------
+
+- AI implemented the bounded/streaming query forms recommended by the memory
+  audit's #309 diagnosis and updated the relationships documentation
+  (``docs/overview.md``, the participation guide, and rdoc comments) to match.

--- a/docs/guides/feature-relationships-participation.md
+++ b/docs/guides/feature-relationships-participation.md
@@ -91,6 +91,20 @@ participates_in Customer, :domains, score: -> {
 customer.domains_with_permission(:read)  # Query by permission
 ```
 
+Permission bits live in the fractional part of the score and are not a
+contiguous range, so filtering is always client-side; the query pages
+internally (`batch_size:`, default 500). `limit:` and `offset:` count
+*matching* members (post-filter), enabling pagination in score order. For
+O(1)-memory streaming over large collections, the `each_` sibling walks the
+set with `ZSCAN` (unordered, at-least-once delivery) and returns an
+`Enumerator` when called without a block:
+
+```ruby
+customer.domains_with_permission(:write, limit: 50)              # first 50 matches
+customer.domains_with_permission(:write, limit: 50, offset: 50)  # next page
+customer.each_domains_with_permission(:read) { |id| ... }        # stream, O(1) memory
+```
+
 ## Class-Level Participation
 
 Track all instances automatically:

--- a/docs/investigation/memory-audit.md
+++ b/docs/investigation/memory-audit.md
@@ -281,6 +281,11 @@ expiring models and add a `*:rebuild:*` sweep + a TTL on temp keys.
 
 ## Issue #309 — focused diagnosis and fix design
 
+> **Status: fixed.** Shipped on branch `fix/309-collection-with-permission-perf`,
+> implementing the design below — additive `limit:`/`offset:`/`batch_size:`
+> kwargs on the Array-returning method (internal `ZRANGEBYSCORE … LIMIT` paging)
+> plus the ZSCAN-backed `each_<collection>_with_permission` enumerator.
+
 **What it is.** The generated `<collection>_with_permission(min_permission)`
 (`target_methods.rb:230-248`) issues one `ZRANGEBYSCORE key -inf +inf WITHSCORES`,
 materializing the **entire** sorted set as a Ruby array of `[member, score]` pairs

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -570,8 +570,29 @@ category — including `:content_editor` — yet its tier is `:administrator`, b
 > Permission bits are not a contiguous score range, so they cannot be filtered
 > server-side by `ZRANGEBYSCORE`. `<collection>_with_permission` fetches members
 > with scores and tests bits per member; there is deliberately no category-based
-> score range method. For large collections, fetch a time window with `score_range`
-> and post-filter with `filter_by_category`.
+> score range method. The fetch is paged internally in `batch_size:` chunks
+> (default 500), so peak memory is O(batch_size) rather than O(N).
+
+For large collections, bound the result or stream it:
+
+```ruby
+customer.documents_with_permission(:write, limit: 50)              # first 50 matches
+customer.documents_with_permission(:write, limit: 50, offset: 50)  # next page
+customer.each_documents_with_permission(:read) { |id| ... }        # stream, O(1) memory
+```
+
+`limit:` caps how many matching members are returned and `offset:` skips the
+first N *matching* members (post-filter semantics), so the two paginate cleanly
+in deterministic score order. Deep offsets cost server CPU — each page is a
+`ZRANGEBYSCORE ... LIMIT` scan, so the server re-walks skipped pages. Because
+the result is assembled across multiple paged reads rather than one command,
+the Array form is no longer an atomic snapshot: concurrent writes to the
+collection between pages can skip or duplicate a member.
+`each_<collection>_with_permission(min_permission = :read, batch_size: 100)`
+streams via `ZSCAN` instead: O(1) retained memory in a single pass, returning an
+`Enumerator` when called without a block. The trade is that iteration is
+unordered and at-least-once — a member can be yielded twice while the server
+rehashes — so collect into a `Set` when uniqueness matters.
 
 ## Advanced Patterns
 

--- a/lib/familia/features/relationships.rb
+++ b/lib/familia/features/relationships.rb
@@ -67,6 +67,9 @@ module Familia
     #
     #   # Query with permission filtering (atomic flags only, never role names)
     #   customer.domains_with_permission(:read)
+    #   customer.domains_with_permission(:read, limit: 50, offset: 50)  # bounded page (batch_size: kwarg too)
+    #   customer.each_domains_with_permission(:read) { |id| ... }       # ZSCAN stream, O(1) memory;
+    #                                                                   # Enumerator without a block
     #
     # @example Multi-collection operations
     #   # A participant carries a reverse index of every collection it is in,

--- a/lib/familia/features/relationships/participation.rb
+++ b/lib/familia/features/relationships/participation.rb
@@ -68,7 +68,9 @@ module Familia
       #       score: -> { permission_encode(created_at, permission_bits) }
       #   end
       #
-      #   customer.domains_with_permission(:read)  # → filtered by score
+      #   customer.domains_with_permission(:read)                    # → filtered by score
+      #   customer.domains_with_permission(:read, limit: 50)         # → bounded (offset:, batch_size: kwargs)
+      #   customer.each_domains_with_permission(:read) { |id| ... }  # → ZSCAN stream, O(1) memory
       #
       # Key Differences from Indexing:
       # - Participation: Bidirectional relationships with semantic scores

--- a/lib/familia/features/relationships/participation/target_methods.rb
+++ b/lib/familia/features/relationships/participation/target_methods.rb
@@ -249,7 +249,9 @@ collection_name: collection_name)
           # Creates: customer.domains_with_permission(min_level)
           #
           # min_permission takes an atomic PERMISSION_FLAG (:read, :write,
-          # :delete, ...). It is forwarded to ScoreEncoding.permission?, so a
+          # :delete, ...). It is validated eagerly (before the limit: 0
+          # shortcut and any scan, so it raises even on an empty collection)
+          # and forwarded per-member to ScoreEncoding.permission?, so a
           # PERMISSION_ROLE (:viewer, :editor, :moderator) raises ArgumentError
           # rather than being expanded to its bits -- deliberately, since
           # permission? tests bits individually and would answer "holds any of
@@ -273,6 +275,7 @@ collection_name: collection_name)
             method_name = "#{collection_name}_with_permission"
 
             target_class.define_method(method_name) do |min_permission = :read, limit: nil, offset: 0, batch_size: 500|
+              TargetMethods::Builder.validate_min_permission!(min_permission)
               TargetMethods::Builder.validate_permission_query_args!(
                 limit: limit, offset: offset, batch_size: batch_size,
               )
@@ -283,6 +286,17 @@ collection_name: collection_name)
                 limit: limit, offset: offset, batch_size: batch_size
               )
             end
+          end
+
+          # Validate min_permission eagerly, before any shortcut or scan loop,
+          # so an invalid flag raises even when limit: 0 or the collection is
+          # empty -- the lazy per-member permission? check never runs in those
+          # cases. Delegates to permission_level_value so the role-vs-flag
+          # ArgumentError message stays identical to the per-member path.
+          # @api private
+          def self.validate_min_permission!(min_permission)
+            ScoreEncoding.permission_level_value(min_permission)
+            nil
           end
 
           # Validate the pagination kwargs for *_with_permission (issue #309).
@@ -376,6 +390,7 @@ collection_name: collection_name)
             method_name = "each_#{collection_name}_with_permission"
 
             target_class.define_method(method_name) do |min_permission = :read, batch_size: 100, &block|
+              TargetMethods::Builder.validate_min_permission!(min_permission)
               unless batch_size.is_a?(Integer) && batch_size.positive?
                 raise ArgumentError, "batch_size must be a positive integer (got #{batch_size.inspect})"
               end

--- a/lib/familia/features/relationships/participation/target_methods.rb
+++ b/lib/familia/features/relationships/participation/target_methods.rb
@@ -27,7 +27,8 @@ module Familia
         # ├── add_domains_instance(domain, score)  # Add one domain to my collection
         # ├── remove_domains_instance(domain)      # Remove one domain from my collection
         # ├── add_domains([...])                   # Bulk add domains
-        # └── domains_with_permission(flag)        # Query by permission flag (sorted_set only)
+        # ├── domains_with_permission(flag)        # Query by permission flag (sorted_set only)
+        # └── each_domains_with_permission(flag)   # Stream by permission flag via ZSCAN (sorted_set only)
         module Builder
           extend CollectionOperations
 
@@ -80,6 +81,7 @@ module Familia
             return unless type == :sorted_set
 
             build_permission_query(target_class, collection_name)
+            build_permission_enumerator(target_class, collection_name)
           end
 
           # Build class-level collection methods (for class_participates_in)
@@ -255,23 +257,151 @@ collection_name: collection_name)
           # mean (:edit, not :editor). :admin names a flag as well as a role and
           # so resolves to bit 7 alone; see the "Flags versus roles" section in
           # ScoreEncoding for the full rationale.
+          # Pagination is additive and backward compatible: the default call
+          # (no kwargs) returns the same Array as before, but pages internally
+          # so peak intermediate memory is O(batch_size) instead of O(N)
+          # (issue #309).
+          #
+          # @param limit [Integer, nil] Max matching members to return
+          #   (nil = no cap; all pages are scanned but memory stays bounded).
+          # @param offset [Integer] Matching members to skip, applied
+          #   POST-FILTER (skips members that pass the permission test, not
+          #   raw sorted-set entries).
+          # @param batch_size [Integer] Page size for the internal
+          #   ZRANGEBYSCORE ... LIMIT loop.
           def self.build_permission_query(target_class, collection_name)
             method_name = "#{collection_name}_with_permission"
 
-            target_class.define_method(method_name) do |min_permission = :read|
-              collection = send(collection_name)
+            target_class.define_method(method_name) do |min_permission = :read, limit: nil, offset: 0, batch_size: 500|
+              TargetMethods::Builder.validate_permission_query_args!(
+                limit: limit, offset: offset, batch_size: batch_size,
+              )
+              return [] if limit&.zero?
 
-              # Permission bits are encoded in the FRACTIONAL part of each score
-              # (see ScoreEncoding) and do not form a contiguous range, so a
-              # score-range query (e.g. ZRANGEBYSCORE x +inf) cannot filter by
-              # permission -- it would match members regardless of their bits.
-              # Fetch every member with its score and test the bits per-member.
-              raw_pairs = collection.rangebyscoreraw('-inf', '+inf', with_scores: true)
-              raw_pairs.each_with_object([]) do |(raw_member, score), kept|
-                next unless ScoreEncoding.permission?(score, min_permission)
+              TargetMethods::Builder.filter_by_permission(
+                send(collection_name), min_permission,
+                limit: limit, offset: offset, batch_size: batch_size
+              )
+            end
+          end
 
-                kept << collection.deserialize_value(raw_member)
+          # Validate the pagination kwargs for *_with_permission (issue #309).
+          # Mirrors the validation style in CollectionBase#each_record.
+          # @api private
+          def self.validate_permission_query_args!(limit:, offset:, batch_size:)
+            unless batch_size.is_a?(Integer) && batch_size.positive?
+              raise ArgumentError, "batch_size must be a positive integer (got #{batch_size.inspect})"
+            end
+            unless offset.is_a?(Integer) && !offset.negative?
+              raise ArgumentError, "offset must be a non-negative integer (got #{offset.inspect})"
+            end
+            return if limit.nil? || (limit.is_a?(Integer) && !limit.negative?)
+
+            raise ArgumentError, "limit must be nil or a non-negative integer (got #{limit.inspect})"
+          end
+
+          # Collect members whose scores carry min_permission, in score order,
+          # applying offset (POST-FILTER: counts members that pass the
+          # permission test, not raw entries) and limit.
+          # @api private
+          def self.filter_by_permission(collection, min_permission, limit:, offset:, batch_size:)
+            matches = []
+            skipped = 0
+
+            each_permitted_pair(collection, min_permission, batch_size) do |raw_member, _score|
+              if skipped < offset
+                skipped += 1
+                next
               end
+
+              matches << collection.deserialize_value(raw_member)
+              return matches if limit && matches.size >= limit
+            end
+
+            matches
+          end
+
+          # Yield [raw_member, score] pairs holding min_permission, one
+          # ZRANGEBYSCORE page at a time so peak memory is O(batch_size).
+          #
+          # Permission bits are encoded in the FRACTIONAL part of each score
+          # (see ScoreEncoding) and do not form a contiguous range, so a
+          # score-range query (e.g. ZRANGEBYSCORE x +inf) cannot filter by
+          # permission -- it would match members regardless of their bits.
+          # Fetch members page by page and test the bits per-member.
+          #
+          # Pagination is offset-based (LIMIT page*batch_size, batch_size) on
+          # purpose. Do NOT switch to score-cursor pagination with an
+          # exclusive bound ("(#{score}"): encode_score truncates timestamps
+          # to integer seconds, so members added in the same second with the
+          # same permission bits share IDENTICAL scores, and an exclusive
+          # bound would silently drop members straddling a page boundary. The
+          # O(N²/batch) deep-offset CPU cost is the accepted trade for
+          # correctness and bounded memory.
+          # @api private
+          def self.each_permitted_pair(collection, min_permission, batch_size)
+            page = 0
+
+            loop do
+              raw_pairs = collection.rangebyscoreraw(
+                '-inf', '+inf',
+                limit: [page * batch_size, batch_size], with_scores: true
+              )
+              break if raw_pairs.empty?
+
+              raw_pairs.each do |raw_member, score|
+                yield raw_member, score if ScoreEncoding.permission?(score, min_permission)
+              end
+
+              break if raw_pairs.size < batch_size
+
+              page += 1
+            end
+          end
+
+          # Build streaming permission query for sorted sets (issue #309)
+          # Creates: customer.each_domains_with_permission(min_level) { |d| ... }
+          #
+          # Streams members via ZSCAN, so retained memory is O(1) regardless
+          # of collection size. ZSCAN trade-offs (vs the Array-returning
+          # <collection>_with_permission):
+          # - Iteration order is UNORDERED (not score order).
+          # - Delivery is at-least-once: a member may be yielded more than
+          #   once if the sorted set is rehashed mid-scan (duplicates
+          #   possible); members present for the whole scan are never missed.
+          #
+          # min_permission semantics match build_permission_query above:
+          # atomic PERMISSION_FLAGs only, roles raise ArgumentError.
+          def self.build_permission_enumerator(target_class, collection_name)
+            method_name = "each_#{collection_name}_with_permission"
+
+            target_class.define_method(method_name) do |min_permission = :read, batch_size: 100, &block|
+              unless batch_size.is_a?(Integer) && batch_size.positive?
+                raise ArgumentError, "batch_size must be a positive integer (got #{batch_size.inspect})"
+              end
+
+              unless block
+                return to_enum(:"each_#{collection_name}_with_permission", min_permission, batch_size: batch_size)
+              end
+
+              collection = send(collection_name)
+              cursor = 0
+              loop do
+                cursor, pairs = collection.scan(cursor, count: batch_size)
+                # ZSCAN yields an Array of [member, score] pairs (not a Hash);
+                # SortedSet#scan already deserializes members and coerces
+                # scores to Float, so yield the member directly. NB: if this
+                # loop ever stops using `score`, Style/HashEachMethods will
+                # want to autocorrect it to each_key, which raises
+                # NoMethodError on an Array — disable the cop, don't obey it
+                # (see the guard in SortedSet#each).
+                pairs.each do |member, score|
+                  block.call(member) if ScoreEncoding.permission?(score, min_permission)
+                end
+                break if cursor.zero?
+              end
+
+              self
             end
           end
 

--- a/try/bug_fixes/permission_query_try.rb
+++ b/try/bug_fixes/permission_query_try.rb
@@ -40,6 +40,25 @@ now = Familia.now
 @target.widgets.add("w_write", SE.encode_score(now, [:read, :write]))   # read + write
 @target.widgets.add("w_admin", SE.encode_score(now, [:read, :admin]))   # read + admin
 
+# Empty collection: min_permission must be validated eagerly, since the lazy
+# per-member permission? check never runs when there is nothing to scan.
+@empty_target = PermTarget.new(tid: "perm_target_empty", name: "E")
+@empty_target.save
+@empty_target.widgets.delete!
+
+# Multi-page dataset: 12 members with distinct integer-second timestamps so
+# ZRANGEBYSCORE order is deterministic. :write is set on m01-m04 and m09-m12;
+# m05-m08 are read-only, so with batch_size: 4 the middle page is entirely
+# non-matching for :write and must be skipped by the paging loop.
+@paged_target = PermTarget.new(tid: "perm_target_paged", name: "P")
+@paged_target.save
+@paged_target.widgets.delete!
+base = Familia.now.to_i
+(1..12).each do |i|
+  flags = (5..8).cover?(i) ? [:read] : [:read, :write]
+  @paged_target.widgets.add(format("m%02d", i), SE.encode_score(base + i, flags))
+end
+
 ## the sorted_set participation generates a *_with_permission method
 @target.respond_to?(:widgets_with_permission)
 #=> true
@@ -146,5 +165,51 @@ collected.sort
 @target.each_widgets_with_permission(:read, batch_size: 0)
 #=!> error.class == ArgumentError
 
+## min_permission is validated eagerly: a role raises even with limit: 0,
+## which would otherwise short-circuit to [] before any per-member check
+@target.widgets_with_permission(:editor, limit: 0)
+#=!> error.class == ArgumentError
+
+## eager validation also fires on an EMPTY collection (array form), where the
+## lazy per-member check would never run
+@empty_target.widgets_with_permission(:editor)
+#=!> error.class == ArgumentError
+
+## unknown permission symbols raise on an empty collection too
+@empty_target.widgets_with_permission(:bogus)
+#=!> error.class == ArgumentError
+
+## the streaming form validates min_permission eagerly on an empty collection
+@empty_target.each_widgets_with_permission(:editor) { |m| m }
+#=!> error.class == ArgumentError
+
+## and even without a block, before the Enumerator is built
+@empty_target.each_widgets_with_permission(:editor)
+#=!> error.class == ArgumentError
+
+## multi-page boundary: batch_size: 4 over 12 members pages through an
+## entirely non-matching middle page (m05-m08 lack :write) without dropping
+## the matches on either side
+@paged_target.widgets_with_permission(:write, batch_size: 4)
+#=> ["m01", "m02", "m03", "m04", "m09", "m10", "m11", "m12"]
+
+## the paged result equals the default (unpaged) result
+@paged_target.widgets_with_permission(:write, batch_size: 4) == @paged_target.widgets_with_permission(:write)
+#=> true
+
+## limit + offset + batch_size combined: offset is POST-FILTER, so it skips
+## the first 3 :write matches (m01-m03), then limit: 3 takes m04 plus the two
+## matches after the non-matching middle page
+@paged_target.widgets_with_permission(:write, limit: 3, offset: 3, batch_size: 4)
+#=> ["m04", "m09", "m10"]
+
+## same kwarg combination where every member matches (:read): the window is a
+## straight slice of score order across internal page boundaries
+@paged_target.widgets_with_permission(:read, limit: 5, offset: 4, batch_size: 4)
+#=> ["m05", "m06", "m07", "m08", "m09"]
+
 @target.widgets.delete!
 @target.destroy!
+@empty_target.destroy!
+@paged_target.widgets.delete!
+@paged_target.destroy!

--- a/try/bug_fixes/permission_query_try.rb
+++ b/try/bug_fixes/permission_query_try.rb
@@ -70,5 +70,81 @@ now = Familia.now
 @target.widgets_with_permission(:admin)
 #=> ["w_admin"]
 
+## Issue #309: limit: returns at most N matching members
+@target.widgets_with_permission(:read, limit: 2).size
+#=> 2
+
+## limit: 0 returns an empty array
+@target.widgets_with_permission(:read, limit: 0)
+#=> []
+
+## limit greater than the number of matches returns all matches
+@target.widgets_with_permission(:read, limit: 10).sort
+#=> ["w_admin", "w_read", "w_write"]
+
+## offset is applied POST-FILTER: limit+offset pages walk all matches
+## without gaps or overlap (union of the two pages == the unpaged result)
+page1 = @target.widgets_with_permission(:read, limit: 2, offset: 0)
+page2 = @target.widgets_with_permission(:read, limit: 2, offset: 2)
+(page1 + page2).sort
+#=> ["w_admin", "w_read", "w_write"]
+
+## offset beyond the number of matches returns an empty array
+@target.widgets_with_permission(:read, offset: 10)
+#=> []
+
+## small batch_size pages internally but returns the same results as the
+## default call (page boundary lands mid-matches: 3 members, pages of 2)
+@target.widgets_with_permission(:read, batch_size: 2).sort
+#=> ["w_admin", "w_read", "w_write"]
+
+## batch_size pagination with a sparser filter still finds the match
+@target.widgets_with_permission(:write, batch_size: 2)
+#=> ["w_write"]
+
+## batch_size must be a positive integer
+@target.widgets_with_permission(:read, batch_size: 0)
+#=!> error.class == ArgumentError
+
+## offset must be non-negative
+@target.widgets_with_permission(:read, offset: -1)
+#=!> error.class == ArgumentError
+
+## limit must be nil or non-negative
+@target.widgets_with_permission(:read, limit: -1)
+#=!> error.class == ArgumentError
+
+## Issue #309: the sorted_set participation also generates a ZSCAN-streaming
+## each_*_with_permission sibling
+@target.respond_to?(:each_widgets_with_permission)
+#=> true
+
+## without a block it returns an Enumerator
+@target.each_widgets_with_permission(:read).class
+#=> Enumerator
+
+## with a block it yields matching members (ZSCAN order is not guaranteed,
+## so compare sorted)
+collected = []
+@target.each_widgets_with_permission(:read) { |m| collected << m }
+collected.sort
+#=> ["w_admin", "w_read", "w_write"]
+
+## the enumerator filters by permission like the array form
+@target.each_widgets_with_permission(:write).to_a
+#=> ["w_write"]
+
+## the enumerator is lazy: first(1) yields a single matching member
+@target.each_widgets_with_permission(:read).first(1).size
+#=> 1
+
+## small batch_size still yields every match exactly (no rehash mid-scan here)
+@target.each_widgets_with_permission(:read, batch_size: 1).to_a.sort
+#=> ["w_admin", "w_read", "w_write"]
+
+## invalid batch_size raises even without a block
+@target.each_widgets_with_permission(:read, batch_size: 0)
+#=!> error.class == ArgumentError
+
 @target.widgets.delete!
 @target.destroy!


### PR DESCRIPTION
The generated `<collection>_with_permission` participation query fetched the entire sorted set in one `ZRANGEBYSCORE`. Permission bits live in the fractional part of the score and are not a contiguous range, so server-side filtering is impossible; the query now pages internally via `ZRANGEBYSCORE ... LIMIT` in `batch_size:` chunks (default 500), keeping peak memory at O(batch_size) instead of O(N).

Adds `limit:`/`offset:` kwargs with post-filter semantics (they count *matching* members, not raw entries) and a new `each_<collection>_with_permission` that streams via `ZSCAN` with O(1) retained memory — unordered, at-least-once delivery, returning an `Enumerator` without a block.

Offset-based paging is deliberate: `encode_score` truncates timestamps to integer seconds, so same-second members share identical scores and a score-cursor with an exclusive bound would silently drop members at page boundaries. Results are identical for collections not concurrently modified; unlike the old single-command fetch, the paged read is not an atomic snapshot.

24 tryouts in `try/bug_fixes/permission_query_try.rb` pass. Docs and rdoc updated to match.

Closes #309