### PR TITLE
*Resolve encrypt-path cache-key salt via fail-closed accessor

### DIFF
--- a/changelog.d/20260803_130000_claude_380_request_cache_fail_closed_salt.rst
+++ b/changelog.d/20260803_130000_claude_380_request_cache_fail_closed_salt.rst
@@ -1,0 +1,27 @@
+Security
+--------
+
+- The encrypt-path request-cache key now resolves the HKDF salt through the
+  fail-closed ``current_hkdf_salt`` accessor instead of the permissive
+  candidate list's head (``hkdf_salts.first``). Previously, with a blank
+  ``encryption_hkdf_salt``, a decrypt inside ``with_request_cache`` could
+  warm an entry keyed on a historical salt that a subsequent encrypt would
+  silently reuse -- because the cache lookup precedes derivation, the
+  blank-salt refusal in the provider never fired. Encrypts now refuse a
+  blank salt even against a warm cache. #380
+
+Changed
+-------
+
+- With a blank ``encryption_hkdf_salt``, ``Manager#encrypt`` now raises
+  ``EncryptionError`` when the request-cache key is built rather than at key
+  derivation. The raise happens earlier and now also fires on what would
+  previously have been a warm-cache hit; correctly configured deployments see
+  no change. #380
+
+AI Assistance
+-------------
+
+- Claude Code implemented the fail-closed cache-key resolution, added a
+  warm-cache regression tryout, and verified the encryption tryout files
+  pass (and that the new case fails without the fix).

--- a/lib/familia/encryption/manager.rb
+++ b/lib/familia/encryption/manager.rb
@@ -193,14 +193,18 @@ module Familia
       # explicitly. Keying on the raw argument would file those two
       # identical derivations under different keys (nil vs the resolved
       # value), so an encrypt followed by a decrypt of the same value in
-      # one request would derive twice instead of hitting the cache. The
-      # personalization resolves through current_personalization -- NOT
-      # personalizations.first -- so a blank config still raises here
-      # exactly as the provider's own derivation would, instead of quietly
-      # caching under a fallback. Providers without rotation have no
-      # effective candidate (nil:nil), so their cache key shape is stable.
+      # one request would derive twice instead of hitting the cache. Both
+      # dimensions resolve through their fail-closed accessors
+      # (current_hkdf_salt / current_personalization) -- NOT the candidate
+      # list's head -- so a blank config still raises here exactly as the
+      # provider's own derivation would. The cache lookup precedes
+      # derivation, so a permissive fallback would let a warm entry (e.g.
+      # from a decrypt keyed on a historical value) satisfy an encrypt that
+      # derive-time guards would refuse (#380). Providers without rotation
+      # have no effective candidate (nil:nil), so their cache key shape is
+      # stable.
       def rotation_cache_key(provider, version, context, salt:, personal:)
-        effective_salt = salt || (provider.respond_to?(:hkdf_salts) ? provider.hkdf_salts.first : nil)
+        effective_salt = salt || (provider.respond_to?(:current_hkdf_salt) ? provider.current_hkdf_salt : nil)
         effective_personal = personal ||
                              (provider.respond_to?(:current_personalization) ? provider.current_personalization : nil)
         "#{provider.algorithm}:#{version}:#{effective_salt}:#{effective_personal}:#{context}"

--- a/try/features/encryption/aes_gcm_salt_rotation_try.rb
+++ b/try/features/encryption/aes_gcm_salt_rotation_try.rb
@@ -154,7 +154,7 @@ end
 #=> ['beta', 'alpha']
 
 ## Issue 2 (#311): encrypt then decrypt the same value in one cache scope derives
-## once. The encrypt path (salt nil, resolved to hkdf_salts.first) and the decrypt
+## once. The encrypt path (salt nil, resolved via current_hkdf_salt) and the decrypt
 ## loop's first iteration (explicit hkdf_salts.first) now share a single cache
 ## entry, instead of filing the same derived key under nil and under the resolved
 ## salt. A single cached entry proves the redundant second derivation is gone.
@@ -190,6 +190,27 @@ begin
   'encrypted-unexpectedly'
 rescue Familia::EncryptionError
   'refused'
+end
+#=> 'refused'
+
+## Fail closed survives a warm request cache (#380): a decrypt inside the cache
+## scope populates an entry keyed on the historical salt; a subsequent encrypt
+## must still be refused rather than reusing that cached key. The cache lookup
+## precedes derivation, so the cache key itself must resolve through the
+## fail-closed accessor (current_hkdf_salt), never the candidate list's head.
+Familia.config.encryption_hkdf_salt = 'WarmCacheSalt'
+Familia.config.encryption_hkdf_salt_history = []
+@warm_blob = @mgr.encrypt('written under warm cache salt', context: @ctx)
+Familia.config.encryption_hkdf_salt = nil
+Familia.config.encryption_hkdf_salt_history = ['WarmCacheSalt']
+Familia::Encryption.with_request_cache do
+  @mgr.decrypt(@warm_blob, context: @ctx) # warms the cache under 'WarmCacheSalt'
+  begin
+    @mgr.encrypt('should not encrypt', context: @ctx)
+    'encrypted-unexpectedly'
+  rescue Familia::EncryptionError => e
+    e.message.include?('non-empty') ? 'refused' : 'wrong-error'
+  end
 end
 #=> 'refused'
 


### PR DESCRIPTION
Closes #380.

## Problem

`Manager#rotation_cache_key` resolved the salt segment permissively (`salt || hkdf_salts.first`) while the actual derivation is guarded by the fail-closed `current_hkdf_salt` accessor (#311). Because the request-cache lookup precedes derivation, with a blank `encryption_hkdf_salt` an encrypt inside `with_request_cache` could hit a key warmed by an earlier decrypt (keyed under a history entry or `LEGACY_HKDF_SALT`) and never trigger the blank-salt refusal. The personalization dimension three lines away already resolved fail-closed (#333), so the two rotation dimensions behaved asymmetrically. Flagged MEDIUM in the 2026-07-19 security audit.

## Fix

- `lib/familia/encryption/manager.rb` — resolve the cache-key salt via `current_hkdf_salt` when no explicit candidate is passed, mirroring `effective_personal` (the `respond_to?` predicate changes alongside). Doc comment generalized to state the fail-closed invariant for both dimensions.
- Decrypt is unaffected: `rotation_candidates` always passes explicit non-nil `salt:` values, so the fallback never runs on the candidate walk.

## Behavior change

With a blank salt, encrypt now raises `EncryptionError` at cache-key time instead of derive time, and also on what was previously a warm-cache hit. Correctly configured deployments see no change. Recorded in the changelog fragment (Security + Changed).

## Tests

- New warm-cache regression case in `try/features/encryption/aes_gcm_salt_rotation_try.rb`: decrypt warms the cache under a historical salt, subsequent encrypt must still refuse. Verified it fails without the fix (`expected refused, got encrypted-unexpectedly`) and passes with it.
- Re-ran the affected suites: `aes_gcm_salt_rotation_try.rb`, `request_cache_try.rb`, `xchacha20_personalization_rotation_try.rb`, `providers/aes_gcm_provider_try.rb` — 66 testcases, 0 failures; existing cache-size expectations unchanged.

_Drafted with AI assistance._