### PR TITLE
Add regression tests for TTL values above 30 days

### DIFF
--- a/try/features/expiration/long_ttl_try.rb
+++ b/try/features/expiration/long_ttl_try.rb
@@ -1,0 +1,196 @@
+# try/features/expiration/long_ttl_try.rb
+#
+# frozen_string_literal: true
+
+# Regression test for TTL values above 30 days (#4008).
+#
+# Verifies that Familia correctly sets, reads, cascades, and extends
+# expiration values larger than 2_592_000 seconds (30 days) on both
+# Horreum objects and their related DataType fields.
+
+require_relative '../../support/helpers/test_helpers'
+
+Familia.debug = false
+
+SECONDS_PER_DAY = 86_400
+
+# ------------------------------------------------------------------
+# Test class: Horreum with > 30-day TTL and multiple relation types
+# ------------------------------------------------------------------
+class LongTTLWidget < Familia::Horreum
+  feature :expiration
+
+  identifier_field :widget_id
+  field :widget_id
+  field :name
+
+  default_expiration 45 * SECONDS_PER_DAY
+
+  list       :events,           default_expiration: 60 * SECONDS_PER_DAY
+  set        :tags
+  hashkey    :permanent_config, no_expiration: true
+  sorted_set :metrics,          default_expiration: 90 * SECONDS_PER_DAY
+  string     :status_msg
+end
+
+LongTTLWidget.instances.clear
+LongTTLWidget.all.each(&:destroy!)
+
+# ------------------------------------------------------------------
+# Class-level configuration
+# ------------------------------------------------------------------
+
+## class default_expiration is 45 days in seconds
+LongTTLWidget.default_expiration
+#=> 3888000.0
+
+# ------------------------------------------------------------------
+# TTL on save: main hash key
+# ------------------------------------------------------------------
+
+## main hash TTL is greater than 30 days (2_592_000s)
+@w = LongTTLWidget.new(widget_id: 'long_ttl_w1', name: 'Widget A')
+@w.save
+@main_ttl = LongTTLWidget.dbclient.ttl(@w.dbkey)
+@main_ttl > 2_592_000
+#=> true
+
+## main hash TTL is within 5s of 45 days (3_888_000s)
+(@main_ttl - 3_888_000).abs <= 5
+#=> true
+
+# ------------------------------------------------------------------
+# Cascade to relations with explicit > 30-day TTL
+# ------------------------------------------------------------------
+
+## list with 60-day TTL gets correct value on write
+@w.events.push('created')
+@events_ttl = LongTTLWidget.dbclient.ttl(@w.events.dbkey)
+@events_ttl > 5_000_000 && @events_ttl <= 5_184_000
+#=> true
+
+## sorted_set with 90-day TTL gets correct value on write
+@w.metrics.add('cpu', 95.5)
+@metrics_ttl = LongTTLWidget.dbclient.ttl(@w.metrics.dbkey)
+@metrics_ttl > 7_700_000 && @metrics_ttl <= 7_776_000
+#=> true
+
+# ------------------------------------------------------------------
+# Cascade to relations inheriting parent > 30-day TTL
+# ------------------------------------------------------------------
+
+## set without own TTL inherits parent 45-day TTL
+@w.tags.add('test')
+@tags_ttl = LongTTLWidget.dbclient.ttl(@w.tags.dbkey)
+@tags_ttl > 3_800_000 && @tags_ttl <= 3_888_000
+#=> true
+
+## string without own TTL inherits parent 45-day TTL via cascade
+@w.status_msg.set('active')
+@w.update_expiration
+@status_ttl = LongTTLWidget.dbclient.ttl(@w.status_msg.dbkey)
+@status_ttl > 3_800_000 && @status_ttl <= 3_888_000
+#=> true
+
+## no_expiration relation is excluded from cascade
+@w.permanent_config['key1'] = 'value1'
+LongTTLWidget.dbclient.ttl(@w.permanent_config.dbkey)
+#=> -1
+
+# ------------------------------------------------------------------
+# Explicit update_expiration with values > 30 days
+# ------------------------------------------------------------------
+
+## explicit 31-day TTL sets correctly
+@w.update_expiration(expiration: 31 * SECONDS_PER_DAY)
+@ttl_31d = LongTTLWidget.dbclient.ttl(@w.dbkey)
+(@ttl_31d - 2_678_400).abs <= 2
+#=> true
+
+## explicit 60-day TTL sets correctly
+@w.update_expiration(expiration: 60 * SECONDS_PER_DAY)
+@ttl_60d = LongTTLWidget.dbclient.ttl(@w.dbkey)
+(@ttl_60d - 5_184_000).abs <= 2
+#=> true
+
+## explicit 90-day TTL sets correctly
+@w.update_expiration(expiration: 90 * SECONDS_PER_DAY)
+@ttl_90d = LongTTLWidget.dbclient.ttl(@w.dbkey)
+(@ttl_90d - 7_776_000).abs <= 2
+#=> true
+
+## explicit 180-day TTL sets correctly
+@w.update_expiration(expiration: 180 * SECONDS_PER_DAY)
+@ttl_180d = LongTTLWidget.dbclient.ttl(@w.dbkey)
+(@ttl_180d - 15_552_000).abs <= 2
+#=> true
+
+## explicit 365-day TTL sets correctly
+@w.update_expiration(expiration: 365 * SECONDS_PER_DAY)
+@ttl_365d = LongTTLWidget.dbclient.ttl(@w.dbkey)
+(@ttl_365d - 31_536_000).abs <= 2
+#=> true
+
+# ------------------------------------------------------------------
+# extend_expiration crossing the 30-day boundary
+# ------------------------------------------------------------------
+
+## extend_expiration from 15 days by 20 days results in > 30 days
+@w2 = LongTTLWidget.new(widget_id: 'long_ttl_w2', name: 'Widget B')
+@w2.save
+@w2.update_expiration(expiration: 15 * SECONDS_PER_DAY)
+@w2.extend_expiration(20 * SECONDS_PER_DAY)
+@extended_ttl = @w2.ttl
+@extended_ttl > 2_592_000
+#=> true
+
+## extended TTL is within 5s of 35 days (3_024_000s)
+(@extended_ttl - 3_024_000).abs <= 5
+#=> true
+
+# ------------------------------------------------------------------
+# ttl_report with > 30-day values
+# ------------------------------------------------------------------
+
+## ttl_report main key shows > 30 days
+@w.update_expiration(expiration: 45 * SECONDS_PER_DAY)
+@report = @w.ttl_report
+@report[:main][:ttl] > 2_592_000
+#=> true
+
+## ttl_report relations show correct TTL values
+@report[:relations][:events][:ttl] > 5_000_000
+#=> true
+
+## ttl_report no_expiration relation shows -1
+@report[:relations][:permanent_config][:ttl]
+#=> -1
+
+# ------------------------------------------------------------------
+# Instance-level override with > 30-day TTL
+# ------------------------------------------------------------------
+
+## instance-level default_expiration override with > 30 days
+@w3 = LongTTLWidget.new(widget_id: 'long_ttl_w3', name: 'Widget C')
+@w3.default_expiration = 60 * SECONDS_PER_DAY
+@w3.default_expiration
+#=> 5184000.0
+
+## save with instance override applies correct TTL
+@w3.save
+@w3_ttl = @w3.ttl
+(@w3_ttl - 5_184_000).abs <= 5
+#=> true
+
+# ------------------------------------------------------------------
+# persist! on > 30-day object removes TTL
+# ------------------------------------------------------------------
+
+## persist! removes TTL from object with > 30-day expiration
+@w3.persist!
+@w3.ttl
+#=> -1
+
+# Cleanup
+LongTTLWidget.instances.clear
+LongTTLWidget.all.each(&:destroy!)


### PR DESCRIPTION
## Summary

- Adds comprehensive tryouts regression test (`try/features/expiration/long_ttl_try.rb`) verifying that TTL values above 30 days (2,592,000 seconds) work correctly at the library level
- Covers class defaults (45 days), cascade to relations with explicit TTLs (60/90 days), inheritance for relations without own TTL, `no_expiration` exclusion, explicit `update_expiration` (31–365 days), `extend_expiration` crossing the 30-day boundary, `ttl_report`, instance-level overrides, and `persist!` removal
- All 21 assertions pass, confirming no code-level bug in Familia's TTL handling for large values

## Context

Reported as issue #4008: "TTL on self hosted (non-docker) above 30 days doesn't seem to work."

Investigation found no code-level defect — the full chain from time literals through validation to Redis EXPIRE handles large TTL values correctly. The issue is likely environmental (Redis `maxmemory-policy`, persistence/restart configuration, or similar) rather than a Familia bug. This test suite serves as both proof and a regression guard.

## Test plan

- [x] Run `tryouts try/features/expiration/long_ttl_try.rb` — 21/21 pass
- [x] Verify TTL values > 30 days set correctly on main hash keys
- [x] Verify cascade to relations with explicit and inherited TTLs
- [x] Verify `no_expiration` relations are excluded from cascade
- [x] Verify `extend_expiration` crossing the 30-day boundary
- [x] Verify `ttl_report` reflects correct values
- [x] Verify instance-level override and `persist!` removal

---
_Generated by [Claude Code](https://claude.ai/code/session_01DJ8igAA58o3ph8b48EEvnC)_