### PR TITLE
docs(security): add 2026-08-06 delta audit report

### DIFF
--- a/docs/security/2026-08-06-audit.md
+++ b/docs/security/2026-08-06-audit.md
@@ -1,0 +1,33 @@
+# Familia Code Audit — 2026-08-06 (delta since 2026-07-30)
+
+**Scope:** familia gem `main` @ `c7eb1a1` (post-merge of the 2026-07-30 audit's fix), the ~93 commits landed since then (`91480ec`..`c7eb1a1`).
+
+## Verification of 2026-07-30 finding
+
+The open MEDIUM finding from the prior audit — claim taken before the persisted-check in `update_in_<scope>_<index_name>` (`lib/familia/features/relationships/indexing/unique_index_generators.rb:369-399`) — is **fixed** on current `main`. Commit `fb4ef3c` ("[#370] Run the persisted guard before the index claim in update_in_*") reordered the calls. Current code at `unique_index_generators.rb:377-390`: `_ensure_persisted_before_index_write!` now runs on line 381, before `index_hash.claim_field(...)` on line 387, matching the sibling `add_to_*`/`update_in_class_*` methods. Closed.
+
+## New finding
+
+### MEDIUM — Residual TTL-set race in `Lock#acquire` when `ttl: nil` and a cascading `default_expiration` applies
+
+**File:** `lib/familia/data_type/types/lock.rb:47-51` (nil-TTL branch), delegating to `Familia::StringKey#setnx` at `lib/familia/data_type/types/stringkey.rb:82-86`
+
+`fix/347-ttl-race` (commit `5ec8819`) correctly closed the SETNX-then-EXPIRE race for the explicit positive-TTL path by switching to an atomic `SET NX EX` (`lock.rb:44`). The `ttl: nil` branch (line 49: `success = setnx(token)`) still goes through `StringKey#setnx`, which issues `SETNX` then a **separate** `update_expiration` command. Every `DataType` subclass — including `Lock` — has `feature :expiration` enabled, and `DataType#default_expiration` cascades from a parent Horreum's class-level `default_expiration` when the `Lock` has none of its own (a supported, documented pattern; `lock :name` is a registered relation type used in `try/support/helpers/test_helpers.rb:88`).
+
+**Failure scenario:** A Horreum class declares `feature :expiration; default_expiration 30; lock :my_lock`. A caller does `record.my_lock.acquire(token, ttl: nil)` (the documented way to defer to the feature default/cascade). `SETNX` succeeds server-side; before the follow-up `EXPIRE` (issued by `update_expiration`) reaches Redis, the process crashes or the connection drops. The lock key now exists with no TTL — a permanent lock that nothing will ever expire, requiring manual `force_unlock!`. This is exactly the failure class `fix/347-ttl-race` fixed for the explicit-ttl path, but the nil-ttl path was missed.
+
+**Recommendation:** Route the nil-ttl branch through the same atomic primitive — resolve the effective TTL (own/cascaded `default_expiration`) before the `SET`/`SETNX` call and use `SET NX` (no `EX`) only when the resolved TTL is truly zero/absent, otherwise `SET NX EX <resolved_ttl>`. Alternatively, document that `ttl: nil` combined with a nonzero cascading `default_expiration` is unsupported/discouraged for `Lock`.
+
+## Reviewed, no issue found
+
+- **`[#380]` fail-closed cache-key salt** (`e29caeb`, `lib/familia/encryption/manager.rb:193-216`). `rotation_cache_key` now resolves via `provider.current_hkdf_salt`/`provider.current_personalization` instead of the permissive candidate-list heads; both accessors raise `EncryptionError` on blank/nil config. Verified both the cached and uncached derive paths fail closed identically — an encrypt can never reuse a decrypt-warmed cache entry keyed on a historical/blank salt. Decrypt path is correctly unaffected (still walks the permissive candidate lists so old ciphertext stays readable).
+- **`[#347]` TTL race — explicit-ttl path.** Now correctly atomic (`SET NX EX`). Also reviewed the accompanying `OperationModeError` guard for transaction/pipeline contexts — correct, since the NX verdict only resolves at EXEC and a queued `Redis::Future` must not be reported as acquired.
+- **TTL values above 30 days** (`5d238bd`, test-only commit). Read the actual TTL-setting code (`expire`, `update_expiration`/`expire` in `features/expiration.rb`, `extend_expiration`) — no second/millisecond confusion, no 30-day ceiling or truncation anywhere. Looks like proactive regression coverage, not a fix for a real prior bug.
+- **`[#309]` eager `min_permission` validation.** `TargetMethods::Builder.validate_min_permission!` delegates to the same `ScoreEncoding.permission_level_value` function the per-member `permission?` check uses internally, so the eagerly-validated value is provably the value checked later — no symbol/string divergence reintroduced. Checked both array and enumerator forms. The new pagination is a bounded, correctly-reasoned offset-based `ZRANGEBYSCORE` loop, not a filtering weakening (permission bits still can't be range-filtered server-side, and aren't).
+- **General secret/CAS/race scan.** No hardcoded secrets or non-constant-time secret comparisons introduced in the delta. No `Marshal.load`/unsafe `YAML.load`. New `send(...)` calls all target private methods on trusted internal objects, never reachable from external input. New claim/index compensation logic (`[#308]`: `compensate_failed_indexed_fast_write`, `release_created_index_claims!`, `reconcile_index_claims_after_failed_write`) follows the established claim-before-MULTI + rollback-on-failure discipline. Capped-collection writes (`[#351]`, `max_length:`) correctly wrap write+trim in one MULTI, so a crash between write and trim cannot leave the collection over-cap.
+
+## Close calls ruled out (for next audit's benefit)
+
+- `claim_unique_<index_name>!` calls `claim_field` with no persisted-check — looks similar to the fixed 2026-07-30 bug at first glance, but is intentionally different: it's the class-level claim primitive used *during* `save`/`create!`, before the record's hash even exists (by design), not an update-existing-record path. Not a regression.
+- `Manager#decrypt`'s candidate walk always passes explicit salt/personalization candidates from the permissive lists — the `[#380]` fail-closed fix does not (and should not) touch this path; confirmed old ciphertext still decrypts correctly.
+- `extend_expiration`'s read-then-write TTL pattern is a read/compute/write sequence but not a CAS-relevant security race — worst case under concurrent extends is a lost update to the TTL value itself, pre-existing and unchanged in this delta.


### PR DESCRIPTION
## Summary

- Automated delta security audit against the 2026-07-30 report, covering the ~93 commits landed since (`91480ec`..`c7eb1a1`).
- Verified the prior open MEDIUM finding (claim taken before persisted-check in `update_in_<scope>_<index_name>`) is fixed on current `main` (commit `fb4ef3c`) — closed.
- New MEDIUM finding: `Lock#acquire` with `ttl: nil` still uses a non-atomic `SETNX`-then-`EXPIRE` path (`lib/familia/data_type/types/lock.rb:47-51` → `StringKey#setnx`). When a `Lock` cascades a nonzero `default_expiration` from its parent Horreum, a crash between the two Redis commands can leave a permanent, never-expiring lock. The explicit-TTL path was already fixed to use atomic `SET NX EX` by `fix/347-ttl-race`; the nil-TTL branch was missed.
- Everything else reviewed in the focus areas (fail-closed encryption cache-key salt resolution, TTL-above-30-days handling, eager `min_permission` validation, general secret/CAS/race sweep) checked out clean — details in the report.

## Test Plan

- N/A — documentation-only change (`docs/security/2026-08-06-audit.md`), no code touched. The Lock#acquire finding is a report of an issue to fix in a follow-up change, not something this PR fixes.

---
_Generated by [Claude Code](https://claude.ai/code/session_018ujuukGpnU86FvwMqogt91)_